### PR TITLE
bump oss-prow to v20190430-6a7dd776a

### DIFF
--- a/prow/cluster.yaml
+++ b/prow/cluster.yaml
@@ -83,7 +83,7 @@ spec:
       serviceAccountName: plank
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/plank:v20190430-6a7dd776a
         args:
         - --build-cluster=/etc/cluster/build-cluster.yaml
         - --dry-run=false
@@ -129,7 +129,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/sinker:v20190430-6a7dd776a
         args:
         - --build-cluster=/etc/cluster/build-cluster.yaml
         - --config-path=/etc/config/config.yaml
@@ -179,7 +179,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/deck:v20190430-6a7dd776a
         args:
         - --build-cluster=/etc/cluster/build-cluster.yaml
         - --config-path=/etc/config/config.yaml
@@ -239,7 +239,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/horologium:v20190430-6a7dd776a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
@@ -323,7 +323,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: gerrit
-        image: gcr.io/k8s-prow/gerrit:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/gerrit:v20190430-6a7dd776a
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
@@ -374,7 +374,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/crier:v20190430-6a7dd776a
         args:
         - --gerrit-workers=1
         - --github-workers=1
@@ -432,7 +432,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/hook:v20190430-6a7dd776a
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -775,7 +775,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190424-fc2ee9967
+        image: gcr.io/k8s-prow/tide:v20190430-6a7dd776a
         args:
         - --build-cluster=/etc/cluster/build-cluster.yaml
         - --config-path=/etc/config/config.yaml

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15,12 +15,11 @@
 tide:
   merge_method:
     GoogleCloudPlatform/osconfig: squash
-
   target_url: https://prow.gflocks.com/tide
-
   queries:
     - repos:
         - GoogleCloudPlatform/osconfig
+        - GoogleCloudPlatform/oss-test-infra
       labels:
         - lgtm
         - approved


### PR DESCRIPTION
To pick up https://github.com/kubernetes/test-infra/pull/12406 for kunit gerrit cannot trigger tests
Also see if tide would work.

/cc @cjwagner 