### PR TITLE
Use liam's gobuild container image

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -25,7 +25,9 @@ presubmits:
     context: prow/presubmit/gobuild
     spec:
       containers:
-      - image: gcr.io/compute-image-tools-test/gobuild:latest
+      - image: gcr.io/compute-image-tools-test/gobuild-liam:latest
+        args:
+        - "github.com/GoogleCloudPlatform/osconfig"  # TODO: substitution
         volumeMounts:
         - name: compute-image-tools-test-service-account
           mountPath: /etc/compute-image-tools-test-service-account


### PR DESCRIPTION
Move to the gobuild-liam image, which doesn't have hardcoded build targets but takes targets as input.