### PR TITLE
add explicit command/args to gcp-guest jobs

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -10,14 +10,17 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/compute-image-tools-test/gocheck:latest
+        command:
+        - "./wrapper"
+        - "./main.sh"
         volumeMounts:
-          - name: compute-image-tools-test-service-account
-            mountPath: /etc/compute-image-tools-test-service-account
-            readOnly: true
-      volumes:
         - name: compute-image-tools-test-service-account
-          secret:
-            secretName: compute-image-tools-test-service-account
+          mountPath: /etc/compute-image-tools-test-service-account
+          readOnly: true
+      volumes:
+      - name: compute-image-tools-test-service-account
+        secret:
+          secretName: compute-image-tools-test-service-account
   - name: osconfig-presubmit-gobuild
     cluster: gcp-guest
     run_if_changed: ".*\\.go$"
@@ -28,6 +31,9 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/compute-image-tools-test/gobuild-liam:latest
+        command:
+        - "./wrapper"
+        - "./main.sh"
         args:
         - "github.com/GoogleCloudPlatform/osconfig"  # TODO: substitution
         volumeMounts:


### PR DESCRIPTION
```
{"component":"plank","error":"invalid presubmit job osconfig-presubmit-gocheck: decorated job containers must specify command and/or args","jobConfig":"/etc/job-config","level":"error","msg":"Error loading config.","prowConfig":"/etc/config/config.yaml","time":"2019-05-03T00:58:45Z"}
```


/assign @hopkiw 