### PR TITLE
GCP-guest: use non-wrapper versions when decorated

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -9,9 +9,8 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/compute-image-tools-test/gocheck:latest
+      - image: gcr.io/compute-image-tools-test/gocheck-liam:latest
         command:
-        - "/go/wrapper"
         - "/go/main.sh"
         volumeMounts:
         - name: compute-image-tools-test-service-account
@@ -32,7 +31,6 @@ presubmits:
       containers:
       - image: gcr.io/compute-image-tools-test/gobuild-liam:latest
         command:
-        - "/go/wrapper"
         - "/go/main.sh"
         args:
         - "github.com/GoogleCloudPlatform/osconfig"  # TODO: substitution


### PR DESCRIPTION
`decorate:true` does seem to do the work our wrapper does, so testing with some non-wrapper versions of these images.