### PR TITLE
Add test post submit job to be triggered on osconfig repo

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -1,3 +1,24 @@
+postsubmits:
+  GoogleCloudPlatform/osconfig:
+  - name: osconfig-agent-build
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/compute-image-tools-test/osconfig-agent-build:latest
+          command:
+            - "./main.sh"
+          volumeMounts:
+            - name: compute-image-tools-test-service-account
+              mountPath: /etc/compute-image-tools-test-service-account
+              readOnly: true
+        volumes:
+          - name: compute-image-tools-test-service-account
+            secret:
+              secretName: compute-image-tools-test-service-account
+    max_concurrency: 10
+    branches:
+      - ^master$
+
 presubmits:
   GoogleCloudPlatform/osconfig:
   - name: osconfig-presubmit-gocheck


### PR DESCRIPTION
The container image currently is just a hello world shell script. Once the postsubmit job is tested, there will be a separate PR for the build and signing job