### PR TITLE
use checkconfig image for presubmit

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -5,25 +5,15 @@ presubmits:
     - master
     decorate: true
     always_run: true
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190329-811f7954b-master
+      - image: gcr.io/k8s-prow/checkconfig:latest
+        imagePullPolicy: Always
         command:
-        - runner.sh 
+        - /checkconfig
         args:
-        - bash
-        - -c
-        - >-
-          cd /home/prow/go/src/k8s.io/test-infra &&
-          bazel run prow/cmd/checkconfig
-          --
-          --config-path=/home/prow/go/src/github.com/GoogleCloudPlatform/oss-test-infra/prow/config.yaml
-          --job-config-path=/home/prow/go/src/github.com/GoogleCloudPlatform/oss-test-infra/prow/prowjobs
+        - --config-path=./prow/config.yaml
+        - --job-config-path=./prow/prowjobs
 
 periodics:
 # test jobs, remove later


### PR DESCRIPTION
ran with https://prow.gflocks.com/view/gcs/oss-prow/pr-logs/pull/GoogleCloudPlatform_oss-test-infra/32/pull-prow-config-validate/1125863189448232960 which looks ok, also tried docker run. (checkconfig doesn't provide any output upon success though..)

/assign @cjwagner 