### PR TITLE
Update image for cpp builds

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -234,7 +234,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: debian
+      - image: gcr.io/gcp-guest/build-essential:latest
         imagePullPolicy: Always
         command:
         - make
@@ -249,7 +249,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: debian
+      - image: gcr.io/gcp-guest/build-essential:latest
         imagePullPolicy: Always
         command:
         - make


### PR DESCRIPTION
`debian` doesn't have the necessary build tools and this is a make based repo, don't want to clutter it with shell scripts specific to prow or have a super customized container image for this either. compromised on debian+build-essential as an available image.