### PR TITLE
Preserve environment Kube context after "get-cluster-credentials"

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -19,6 +19,18 @@ ZONE          ?= us-west1-a
 CLUSTER       ?= prow
 JOB_NAMESPACE ?= test-pods
 
+export KUBECONFIG
+
+# This prevents the Kube current-context in the execution environment from being
+# overwritten unless the intention is made explicit w/ the `save` parameter.
+# e.g.
+#		make get-cluster-credentials save=true
+.PHONY: save-kubeconfig
+save-kubeconfig:
+ifndef save
+	$(eval KUBECONFIG=$(shell mktemp))
+endif
+
 .PHONY: update-config
 update-config: get-cluster-credentials
 	kubectl create configmap config --from-file=config.yaml=config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
@@ -34,5 +46,5 @@ update-cluster: get-cluster-credentials
 	kubectl apply -f cert-manager.yaml
 
 .PHONY: get-cluster-credentials
-get-cluster-credentials:
+get-cluster-credentials: save-kubeconfig
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"


### PR DESCRIPTION
It is *annoying* and *unsafe* to **change** the Kube `current-context` in the user's environment; instead, we should change it **only** for the execution of the make targets. 

Due to how `gcloud ... get-credentials` works, we can achieve this by exporting a temp `KUBECONFIG` where `gcloud` will set the cluster and user in this file for the life of the subprocess.