### PR TITLE
Use modern lens config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -66,11 +66,17 @@ deck:
     # TODO(krzyzacy): no testgrid support yet, consider use k8s.testgrid, or deploy a new testgrid instance
     # testgrid_config: gs://testgrid/config
     # testgrid_root: https://testgrid.corp.google.com/
-    viewers:
-      "started.json|finished.json":
-      - "metadata-viewer"
-      "build-log.txt":
-      - "build-log-viewer"
-      "artifacts/junit.*\\.xml":
-      - "junit-viewer"
+    lenses:
+      - lens:
+          name: metadata
+        required_files:
+          - started.json|finished.json
+      - lens:
+          name: buildlog
+        required_files:
+          - build-log.txt
+      - lens:
+          name: junit
+        required_files:
+          - artifacts/junit.*\.xml
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator-internal.googleplex.com/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to osp-engprod@google.com."


### PR DESCRIPTION
Spyglass is showing no lenses because it has no valid registered lenses.

This should fix #76.