### PR TITLE
Migrate Kubeflow jobs

### DIFF
--- a/prow/prowjobs/kubeflow/OWNERS
+++ b/prow/prowjobs/kubeflow/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- abhi-g
+- jlewi
+- kunmingg
+- lluunn
+- richardsliu

--- a/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
@@ -1,4 +1,26 @@
 periodics:
+- name: kubeflow-periodic-0-7
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      # TODO(https://github.com/kubeflow/testing/issues/498)
+      # This job needs to be moved over to kubeflow/kfctl v0.7-branch
+      # once it exists.
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-7 release
 - name: kubeflow-periodic-0-6-branch
   cluster: kubeflow
   interval: 8h
@@ -56,6 +78,47 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the latest master branch.
+    # TODO: use a public email group
+    testgrid-alert-email: kubeflow-engineering@google.com
+    testgrid-num-failures-to-alert: "3"
+- name: kubeflow-manifests-periodic-master
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: manifests
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow/manifests on the master branch.
+- name: kubeflow-manifests-periodic-0-6-branch
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: manifests
+      - name: BRANCH_NAME
+        value: v0.6-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow/manifests on the 0-6 release branch.
 - name: kubeflow-periodic-examples
   cluster: kubeflow
   interval: 8h
@@ -107,7 +170,7 @@ periodics:
     workdir: true
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         imagePullPolicy: Always
         command:
         - "./test/tools/project-cleaner/project_cleaner.sh"

--- a/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
@@ -1,5 +1,6 @@
 periodics:
 - name: kubeflow-periodic-0-6-branch
+  cluster: kubeflow
   interval: 8h
   labels:
     preset-service-account: "true"
@@ -18,6 +19,7 @@ periodics:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the 0-6 release branch.
 - name: kubeflow-periodic-0-5-branch
+  cluster: kubeflow
   interval: 8h
   labels:
     preset-service-account: "true"
@@ -35,43 +37,8 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the 0-5 release branch.
-- name: kubeflow-periodic-0-4-branch
-  interval: 8h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kubeflow
-      - name: BRANCH_NAME
-        value: v0.4-branch
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow on the 0-4 release branch.
-- name: kubeflow-periodic-0-3-branch
-  interval: 8h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kubeflow
-      - name: BRANCH_NAME
-        value: v0.3-branch
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow on the 0-3 release branch.
 - name: kubeflow-periodic-master
+  cluster: kubeflow
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -90,6 +57,7 @@ periodics:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the latest master branch.
 - name: kubeflow-periodic-examples
+  cluster: kubeflow
   interval: 8h
   labels:
     preset-service-account: "true"
@@ -108,6 +76,7 @@ periodics:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow examples
 - name: kubeflow-periodic-kfctl
+  cluster: kubeflow
   interval: 8h
   labels:
     preset-service-account: "true"
@@ -126,6 +95,7 @@ periodics:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow kfctl
 - name: kubeflow-periodic-project-cleanup
+  cluster: kubeflow
   interval: 1h
   decorate: true
   labels:

--- a/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
@@ -12,12 +12,12 @@ periodics:
       - name: REPO_OWNER
         value: kubeflow
       - name: REPO_NAME
-        value: kubeflow
+        value: kfctl
       # TODO(https://github.com/kubeflow/testing/issues/498)
       # This job needs to be moved over to kubeflow/kfctl v0.7-branch
       # once it exists.
       - name: BRANCH_NAME
-        value: master
+        value: v0.7-branch
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the 0-7 release

--- a/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
@@ -1,0 +1,153 @@
+periodics:
+- name: kubeflow-periodic-0-6-branch
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.6-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-6 release branch.
+- name: kubeflow-periodic-0-5-branch
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.5-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-5 release branch.
+- name: kubeflow-periodic-0-4-branch
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.4-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-4 release branch.
+- name: kubeflow-periodic-0-3-branch
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.3-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-3 release branch.
+- name: kubeflow-periodic-master
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the latest master branch.
+- name: kubeflow-periodic-examples
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: examples
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow examples
+- name: kubeflow-periodic-kfctl
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kfctl
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow kfctl
+- name: kubeflow-periodic-project-cleanup
+  interval: 1h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubeflow
+    repo: pipelines
+    base_ref: master
+    workdir: true
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+        imagePullPolicy: Always
+        command:
+        - "./test/tools/project-cleaner/project_cleaner.sh"
+        env:
+          - name: REPO_OWNER
+            value: kubeflow
+          - name: REPO_NAME
+            value: kubeflow
+          - name: BRANCH_NAME
+            value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic job to cleanup ml-pipeline-test GCP project

--- a/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
@@ -12,6 +12,19 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit kubeflow/examples.
+  kubeflow/internal-acls:
+  - name: kubeflow-internal-acls-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/internal-acls.
   kubeflow/kubeflow:
   - name: kubeflow-postsubmit
     cluster: kubeflow
@@ -25,6 +38,9 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit tests for Kubeflow.
+      # TODO: use a public email group
+      testgrid-alert-email: kubeflow-engineering@google.com
+      testgrid-num-failures-to-alert: "3"
   kubeflow/kfctl:
   - name: kubeflow-kfctl-postsubmit
     cluster: kubeflow
@@ -38,6 +54,19 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit tests for kubeflow/kfctl.
+  kubeflow/manifests:
+  - name: kubeflow-manifests-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/manifests.
   kubeflow/pytorch-operator:
   - name: kubeflow-pytorch-operator-postsubmit
     cluster: kubeflow
@@ -142,6 +171,19 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit kubeflow/experimental-seldon.
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-beagle.
   kubeflow/caffe2-operator:
   - name: kubeflow-caffe2-operator-postsubmit
     cluster: kubeflow
@@ -228,7 +270,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:
@@ -241,3 +283,16 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit tests for kubeflow/pipeline.
+  kubeflow/xgboost-operator:
+  - name: kubeflow-xgboost-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/xgboost-operator.

--- a/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
@@ -1,0 +1,237 @@
+postsubmits:
+  kubeflow/examples:
+  - name: kubeflow-examples-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/examples.
+  kubeflow/kubeflow:
+  - name: kubeflow-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for Kubeflow.
+  kubeflow/kfctl:
+  - name: kubeflow-kfctl-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/kfctl.
+  kubeflow/pytorch-operator:
+  - name: kubeflow-pytorch-operator-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/pytorch-operator.
+  kubeflow/reporting:
+  - name: kubeflow-reporting-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/reporting.
+  kubeflow/website:
+  - name: kubeflow-website-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/website.
+  kubeflow/testing:
+  - name: kubeflow-testing-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/testing.
+  kubeflow/tf-operator:
+  - name: kubeflow-tf-operator-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/tf-operator.
+  kubeflow/katib:
+  - name: kubeflow-katib-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/katib.
+  kubeflow/experimental-kvc:
+  - name: kubeflow-experimental-kvc-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-kvc.
+  kubeflow/experimental-seldon:
+  - name: kubeflow-experimental-seldon-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-seldon.
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-beagle.
+  kubeflow/caffe2-operator:
+  - name: kubeflow-caffe2-operator-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/caffe2-operator.
+  kubeflow/kubebench:
+  - name: kubeflow-kubebench-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/kubebench.
+  kubeflow/mpi-operator:
+  - name: kubeflow-mpi-operator-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/mpi-operator.
+  kubeflow/chainer-operator:
+  - name: kubeflow-chainer-operator-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/chainer-operator.
+  kubeflow/mxnet-operator:
+  - name: kubeflow-mxnet-operator-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/mxnet-operator.
+  kubeflow/arena:
+  - name: kubeflow-arena-postsubmit
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/arena.
+  kubeflow/pipelines:
+  - name: kubeflow-pipeline-postsubmit
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+        command:
+        - ./test/postsubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - component_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "7200"
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/pipeline.

--- a/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   kubeflow/examples:
   - name: kubeflow-examples-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -13,6 +14,7 @@ postsubmits:
       description: Postsubmit kubeflow/examples.
   kubeflow/kubeflow:
   - name: kubeflow-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -25,6 +27,7 @@ postsubmits:
       description: Postsubmit tests for Kubeflow.
   kubeflow/kfctl:
   - name: kubeflow-kfctl-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -37,6 +40,7 @@ postsubmits:
       description: Postsubmit tests for kubeflow/kfctl.
   kubeflow/pytorch-operator:
   - name: kubeflow-pytorch-operator-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -49,6 +53,7 @@ postsubmits:
       description: Postsubmit kubeflow/pytorch-operator.
   kubeflow/reporting:
   - name: kubeflow-reporting-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -61,6 +66,7 @@ postsubmits:
       description: Postsubmit kubeflow/reporting.
   kubeflow/website:
   - name: kubeflow-website-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -73,6 +79,7 @@ postsubmits:
       description: Postsubmit kubeflow/website.
   kubeflow/testing:
   - name: kubeflow-testing-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -85,6 +92,7 @@ postsubmits:
       description: Postsubmit kubeflow/testing.
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -97,6 +105,7 @@ postsubmits:
       description: Postsubmit kubeflow/tf-operator.
   kubeflow/katib:
   - name: kubeflow-katib-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -109,6 +118,7 @@ postsubmits:
       description: Postsubmit kubeflow/katib.
   kubeflow/experimental-kvc:
   - name: kubeflow-experimental-kvc-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -121,6 +131,7 @@ postsubmits:
       description: Postsubmit kubeflow/experimental-kvc.
   kubeflow/experimental-seldon:
   - name: kubeflow-experimental-seldon-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -131,20 +142,9 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit kubeflow/experimental-seldon.
-  kubeflow/experimental-beagle:
-  - name: kubeflow-experimental-beagle-postsubmit
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/experimental-beagle.
   kubeflow/caffe2-operator:
   - name: kubeflow-caffe2-operator-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -157,6 +157,7 @@ postsubmits:
       description: Postsubmit kubeflow/caffe2-operator.
   kubeflow/kubebench:
   - name: kubeflow-kubebench-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -169,6 +170,7 @@ postsubmits:
       description: Postsubmit tests for kubeflow/kubebench.
   kubeflow/mpi-operator:
   - name: kubeflow-mpi-operator-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -181,6 +183,7 @@ postsubmits:
       description: Postsubmit tests for kubeflow/mpi-operator.
   kubeflow/chainer-operator:
   - name: kubeflow-chainer-operator-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -193,6 +196,7 @@ postsubmits:
       description: Postsubmit tests for kubeflow/chainer-operator.
   kubeflow/mxnet-operator:
   - name: kubeflow-mxnet-operator-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -205,6 +209,7 @@ postsubmits:
       description: Postsubmit kubeflow/mxnet-operator.
   kubeflow/arena:
   - name: kubeflow-arena-postsubmit
+    cluster: kubeflow
     labels:
       preset-service-account: "true"
     spec:
@@ -217,6 +222,7 @@ postsubmits:
       description: Postsubmit tests for kubeflow/arena.
   kubeflow/pipelines:
   - name: kubeflow-pipeline-postsubmit
+    cluster: kubeflow
     decorate: true
     labels:
       preset-service-account: "true"

--- a/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
@@ -13,6 +13,20 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/examples.
       testgrid-num-columns-recent: '30'
+  kubeflow/internal-acls:
+  - name: kubeflow-internal-acls-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for Kubeflow/internal-acls.
+      testgrid-num-columns-recent: '30'
   kubeflow/kubeflow:
   - name: kubeflow-presubmit
     cluster: kubeflow
@@ -111,6 +125,20 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/katib.
       testgrid-num-columns-recent: '30'
+  kubeflow/experimental-kvc:
+  - name: kubeflow-experimental-kvc-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-kvc.
+      testgrid-num-columns-recent: '30'
   kubeflow/experimental-seldon:
   - name: kubeflow-experimental-seldon-presubmit
     cluster: kubeflow
@@ -124,6 +152,20 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/experimental-seldon.
+      testgrid-num-columns-recent: '30'
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-beagle.
       testgrid-num-columns-recent: '30'
   kubeflow/caffe2-operator:
   - name: kubeflow-caffe2-operator-presubmit
@@ -288,7 +330,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -304,7 +346,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -323,12 +365,26 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         command:
         - ./test/upgrade-tests.sh
         args:
         - --test_result_folder
         - upgrade_test
+  kubeflow/xgboost-operator:
+  - name: kubeflow-xgboost-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/xgboost-operator.
+      testgrid-num-columns-recent: '30'
 #   - name: kubeflow-pipeline-e2e-test-gce-minikube
 #     cluster: kubeflow
 #     always_run: true
@@ -338,7 +394,7 @@ presubmits:
 #       preset-service-account: "true"
 #     spec:
 #       containers:
-#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
 #         command:
 #         - ./test/presubmit-tests-gce-minikube.sh
 #         args:

--- a/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubeflow/examples:
   - name: kubeflow-examples-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -14,6 +15,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/kubeflow:
   - name: kubeflow-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -27,6 +29,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/pytorch-operator:
   - name: kubeflow-pytorch-operator-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -40,6 +43,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/reporting:
   - name: kubeflow-reporting-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -53,6 +57,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/website:
   - name: kubeflow-website-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -66,6 +71,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/testing:
   - name: kubeflow-testing-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -79,6 +85,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/tf-operator:
   - name: kubeflow-tf-operator-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -92,6 +99,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/katib:
   - name: kubeflow-katib-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -103,21 +111,9 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/katib.
       testgrid-num-columns-recent: '30'
-  kubeflow/experimental-kvc:
-  - name: kubeflow-experimental-kvc-presubmit
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/experimental-kvc.
-      testgrid-num-columns-recent: '30'
   kubeflow/experimental-seldon:
   - name: kubeflow-experimental-seldon-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -129,21 +125,9 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/experimental-seldon.
       testgrid-num-columns-recent: '30'
-  kubeflow/experimental-beagle:
-  - name: kubeflow-experimental-beagle-presubmit
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/experimental-beagle.
-      testgrid-num-columns-recent: '30'
   kubeflow/caffe2-operator:
   - name: kubeflow-caffe2-operator-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -157,6 +141,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/kubebench:
   - name: kubeflow-kubebench-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -170,6 +155,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/mpi-operator:
   - name: kubeflow-mpi-operator-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -183,6 +169,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/chainer-operator:
   - name: kubeflow-chainer-operator-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -196,6 +183,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/mxnet-operator:
   - name: kubeflow-mxnet-operator-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -209,6 +197,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/arena:
   - name: kubeflow-arena-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -222,6 +211,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/fairing:
   - name: kubeflow-fairing-presubmit
+    cluster: kubeflow
     always_run: true
     labels:
       preset-service-account: "true"
@@ -235,6 +225,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/metadata:
   - name: kubeflow-metadata-presubmit
+    cluster: kubeflow
     always_run: true
     labels:
       preset-service-account: "true"
@@ -248,6 +239,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/kfserving:
   - name: kubeflow-kfserving-presubmit
+    cluster: kubeflow
     always_run: true
     labels:
       preset-service-account: "true"
@@ -261,6 +253,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit
+    cluster: kubeflow
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -274,6 +267,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/kfctl:
   - name: kubeflow-kfctl-presubmit
+    cluster: kubeflow
     always_run: true
     labels:
       preset-service-account: "true"
@@ -287,6 +281,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
   - name: kubeflow-pipeline-e2e-test
+    cluster: kubeflow
     always_run: true
     decorate: true
     labels:
@@ -302,6 +297,7 @@ presubmits:
         - --test_result_folder
         - e2e_test
   - name: kubeflow-pipeline-sample-test
+    cluster: kubeflow
     always_run: true
     decorate: true
     labels:
@@ -319,6 +315,7 @@ presubmits:
         - --timeout
         - "3600"
   - name: kubeflow-pipeline-upgrade-test
+    cluster: kubeflow
     always_run: true
     decorate: true
     skip_report: true
@@ -333,6 +330,7 @@ presubmits:
         - --test_result_folder
         - upgrade_test
 #   - name: kubeflow-pipeline-e2e-test-gce-minikube
+#     cluster: kubeflow
 #     always_run: true
 #     decorate: true
 #     skip_report: true

--- a/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
@@ -1,0 +1,350 @@
+presubmits:
+  kubeflow/examples:
+  - name: kubeflow-examples-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/examples.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kubeflow:
+  - name: kubeflow-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for Kubeflow.
+      testgrid-num-columns-recent: '30'
+  kubeflow/pytorch-operator:
+  - name: kubeflow-pytorch-operator-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/pytorch-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/reporting:
+  - name: kubeflow-reporting-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/reporting.
+      testgrid-num-columns-recent: '30'
+  kubeflow/website:
+  - name: kubeflow-website-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/website.
+      testgrid-num-columns-recent: '30'
+  kubeflow/testing:
+  - name: kubeflow-testing-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/testing.
+      testgrid-num-columns-recent: '30'
+  kubeflow/tf-operator:
+  - name: kubeflow-tf-operator-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/tf-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/katib:
+  - name: kubeflow-katib-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/katib.
+      testgrid-num-columns-recent: '30'
+  kubeflow/experimental-kvc:
+  - name: kubeflow-experimental-kvc-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-kvc.
+      testgrid-num-columns-recent: '30'
+  kubeflow/experimental-seldon:
+  - name: kubeflow-experimental-seldon-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-seldon.
+      testgrid-num-columns-recent: '30'
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-beagle.
+      testgrid-num-columns-recent: '30'
+  kubeflow/caffe2-operator:
+  - name: kubeflow-caffe2-operator-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/caffe2-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kubebench:
+  - name: kubeflow-kubebench-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/kubebench.
+      testgrid-num-columns-recent: '30'
+  kubeflow/mpi-operator:
+  - name: kubeflow-mpi-operator-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/mpi-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/chainer-operator:
+  - name: kubeflow-chainer-operator-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/chainer-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/mxnet-operator:
+  - name: kubeflow-mxnet-operator-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/mxnet-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/arena:
+  - name: kubeflow-arena-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/arena.
+      testgrid-num-columns-recent: '30'
+  kubeflow/fairing:
+  - name: kubeflow-fairing-presubmit
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/fairing.
+      testgrid-num-columns-recent: '30'
+  kubeflow/metadata:
+  - name: kubeflow-metadata-presubmit
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/metadata.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kfserving:
+  - name: kubeflow-kfserving-presubmit
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/kfserving.
+      testgrid-num-columns-recent: '30'
+  kubeflow/manifests:
+  - name: kubeflow-manifests-presubmit
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/manifests.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kfctl:
+  - name: kubeflow-kfctl-presubmit
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/kfctl.
+      testgrid-num-columns-recent: '30'
+  kubeflow/pipelines:
+  - name: kubeflow-pipeline-e2e-test
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+        command:
+        - ./test/presubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - e2e_test_gke_v2.yaml
+        - --test_result_folder
+        - e2e_test
+  - name: kubeflow-pipeline-sample-test
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+        command:
+        - ./test/presubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - sample_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "3600"
+  - name: kubeflow-pipeline-upgrade-test
+    always_run: true
+    decorate: true
+    skip_report: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+        command:
+        - ./test/upgrade-tests.sh
+        args:
+        - --test_result_folder
+        - upgrade_test
+#   - name: kubeflow-pipeline-e2e-test-gce-minikube
+#     always_run: true
+#     decorate: true
+#     skip_report: true
+#     labels:
+#       preset-service-account: "true"
+#     spec:
+#       containers:
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20190911-069bf1f-master
+#         command:
+#         - ./test/presubmit-tests-gce-minikube.sh
+#         args:
+#         - --workflow_file
+#         - e2e_test_gke.yaml
+#         - --test_result_folder
+#         - e2e_test_gke


### PR DESCRIPTION
Moving Kubeflow configs from https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubeflow.

Fixes https://github.com/kubernetes/test-infra/issues/14343.