### PR TITLE
Setup a general build cluster for oss-prow

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,24 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include Makefile.gcloud.mk
+
 # These are the usual GKE variables.
 PROJECT       ?= oss-prow
-BUILD_PROJECT ?= oss-prow
+PROJECT_BUILD ?= oss-prow-builds
 ZONE          ?= us-west1-a
 CLUSTER       ?= prow
 JOB_NAMESPACE ?= test-pods
-
-export KUBECONFIG
-
-# This prevents the Kube current-context in the execution environment from being
-# overwritten unless the intention is made explicit w/ the `save` parameter.
-# e.g.
-#		make get-cluster-credentials save=true
-.PHONY: save-kubeconfig
-save-kubeconfig:
-ifndef save
-	$(eval KUBECONFIG=$(shell mktemp))
-endif
 
 .PHONY: update-config
 update-config: get-cluster-credentials
@@ -42,9 +32,10 @@ update-plugins: get-cluster-credentials
 .PHONY: deploy
 deploy: get-cluster-credentials
 	kubectl apply -f cluster.yaml
-	kubectl apply -f grandmatriarch.yaml
 	kubectl apply -f cert-manager.yaml
+	kubectl apply -f grandmatriarch_default.yaml
+	kubectl apply -f grandmatriarch_test-pods.yaml
 
-.PHONY: get-cluster-credentials
-get-cluster-credentials: save-kubeconfig
-	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+.PHONY: deploy-build
+deploy-build: get-build-cluster-credentials
+	kubectl apply -f grandmatriarch_test-pods.yaml

--- a/prow/Makefile.gcloud.mk
+++ b/prow/Makefile.gcloud.mk
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export KUBECONFIG
+
+# https://github.com/istio/test-infra/issues/1636
+# This prevents the Kube current-context in the execution environment from being
+# overwritten unless the intention is made explicit w/ the `save` parameter.
+# e.g.
+#		make get-cluster-credentials save=true
+
+.PHONY: save-kubeconfig
+save-kubeconfig:
+ifndef save
+	$(eval KUBECONFIG=$(shell mktemp))
+endif
+
+.PHONY: activate-serviceaccount
+activate-serviceaccount:
+ifdef GOOGLE_APPLICATION_CREDENTIALS
+	gcloud auth activate-service-account --key-file="$(GOOGLE_APPLICATION_CREDENTIALS)"
+endif
+
+.PHONY: get-cluster-credentials
+get-cluster-credentials: save-kubeconfig activate-serviceaccount
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+.PHONY: get-build-cluster-credentials
+get-build-cluster-credentials: save-kubeconfig activate-serviceaccount
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT_BUILD)" --zone="$(ZONE)"

--- a/prow/grandmatriarch_default.yaml
+++ b/prow/grandmatriarch_default.yaml
@@ -1,0 +1,82 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  grandmatriarch
+  namespace: default
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: grandmatriarch
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - update
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: grandmatriarch
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: grandmatriarch
+subjects:
+- kind: ServiceAccount
+  name: grandmatriarch
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grandmatriarch
+  namespace: default
+  labels:
+    app: grandmatriarch-default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grandmatriarch-default
+  template:
+    metadata:
+      labels:
+        app: grandmatriarch-default
+    spec:
+      serviceAccountName: grandmatriarch
+      containers:
+      - name: bakery
+        image: gcr.io/k8s-prow/grandmatriarch:v20190924-cb71f84e1
+        args:
+        - /etc/robot/service-account.json
+        - http-cookiefile
+        volumeMounts:
+        - mountPath: /etc/robot
+          name: robot
+          readOnly: true
+      volumes:
+      - name: robot
+        secret:
+          defaultMode: 420
+          secretName: service-account

--- a/prow/grandmatriarch_test-pods.yaml
+++ b/prow/grandmatriarch_test-pods.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name:  grandmatriarch
@@ -63,75 +68,6 @@ spec:
     metadata:
       labels:
         app: grandmatriarch-test
-    spec:
-      serviceAccountName: grandmatriarch
-      containers:
-      - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20190924-cb71f84e1
-        args:
-        - /etc/robot/service-account.json
-        - http-cookiefile
-        volumeMounts:
-        - mountPath: /etc/robot
-          name: robot
-          readOnly: true
-      volumes:
-      - name: robot
-        secret:
-          defaultMode: 420
-          secretName: service-account
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name:  grandmatriarch
-  namespace: default
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: grandmatriarch
-  namespace: default
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - get
-  - update
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: grandmatriarch
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: grandmatriarch
-subjects:
-- kind: ServiceAccount
-  name: grandmatriarch
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: grandmatriarch
-  namespace: default
-  labels:
-    app: grandmatriarch-default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: grandmatriarch-default
-  template:
-    metadata:
-      labels:
-        app: grandmatriarch-default
     spec:
       serviceAccountName: grandmatriarch
       containers:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -5,6 +5,7 @@ presubmits:
       branches:
         - master
       decorate: true
+      cluster: build
       always_run: true
       spec:
         containers:
@@ -20,6 +21,7 @@ presubmits:
       branches:
         - master
       decorate: true
+      cluster: build
       always_run: true
       spec:
         containers:


### PR DESCRIPTION
Summary of changes:
1. Pulled in the `Makefile.gcloud.mk` file, used internally and in Istio  which contains a bunch of helpers.
2. Separated out `grandmatriarch` *default* and *test-pods* deployments into separate files.
3. Added `deploy-build` command to `Makefile` for deploying build cluster.
4. Enabled `build` cluster on test-infra presubmits.

/assign @cjwagner @fejta 