### PR TITLE
Enable OSS rerun for all googlers

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -188,11 +188,23 @@ spec:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
         - --redirect-http-to=prow.gflocks.com
-        - --github-oauth-config-file=/etc/github/oauth
+        - --rerun-creates-job
+        - --oauth-url=/github-login
+        - --github-token-path=/etc/github/oauth
+        - --github-oauth-config-file=/etc/githuboauth/secret
         ports:
         - name: http
           containerPort: 8080
         volumeMounts:
+        - name: oauth-config
+          mountPath: /etc/githuboauth
+          readOnly: true
+        - name: cookie-secret
+          mountPath: /etc/cookie
+          readOnly: true
+        - name: oauth-token
+          mountPath: /etc/github
+          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
@@ -202,10 +214,16 @@ spec:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
           readOnly: true
-        - name: oauth
-          mountPath: /etc/github
-          readOnly: true
       volumes:
+      - name: oauth-config
+        secret:
+          secretName: github-oauth-config
+      - name: oauth-token
+        secret:
+          secretName: oauth-token
+      - name: cookie-secret
+        secret:
+          secretName: cookie
       - name: config
         configMap:
           name: config
@@ -216,9 +234,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
-      - name: oauth
-        secret:
-          secretName: oauth-token
 ---
 apiVersion: v1
 kind: Service

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -84,6 +84,10 @@ deck:
         required_files:
           - artifacts/junit.*\.xml
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator-internal.googleplex.com/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to osp-engprod@google.com."
+  rerun_auth_config:
+    github_team_slugs:
+    - org: GoogleCloudPlatform
+      slug: googlers
 
 presets:
 - labels:


### PR DESCRIPTION
Enable `deck` rerun for [Googlers](https://github.com/orgs/GoogleCloudPlatform/teams/googlers).
closes #68

> `github-oauth-config` and `cookie` secrets loaded to cluster.

/assign @cjwagner @krzyzacy  