### PR TITLE
Add missing rbac verbs for plank prowjobs resource

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -607,9 +607,11 @@ rules:
     resources:
       - prowjobs
     verbs:
+      - get
       - create
       - list
       - update
+      - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
> This will address the rbac issues regarding plank : #106

Same change reported: kubernetes/test-infra#14489 and  kubernetes/test-infra#14491.

/assign @krzyzacy @fejta 