### PR TITLE
Fix plugin config

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -38,7 +38,6 @@ plugins:
   - approve
   - assign
   - cat
-  - config-updater
   - dog
   - golint
   - hold
@@ -53,13 +52,13 @@ plugins:
 
   GoogleCloudPlatform/oss-test-infra:
   - blunderbuss
+  - config-updater
   - heart
   - override
   - wip
 
   GoogleCloudPlatform/testgrid:
   - blunderbuss
-  - golint
   - wip
 
   googleforgames/agones:


### PR DESCRIPTION
/assign @cjwagner @chases2 

```yaml
{
 insertId: "5tvffffjgwl78"  
 jsonPayload: {
  component: "hook"   
  error: "[plugins [golint] are duplicated for GoogleCloudPlatform/testgrid and GoogleCloudPlatform]"   
  file: "prow/plugins/plugins.go:276"   
  func: "k8s.io/test-infra/prow/plugins.(*ConfigAgent).Start.func1"   
  level: "error"   
  msg: "Error loading plugin config."   
  path: "/etc/plugins/plugins.yaml"   
 }
 labels: {…}  
 logName: "projects/oss-prow/logs/hook"  
 receiveTimestamp: "2019-10-10T23:53:30.809873253Z"  
 resource: {…}  
 severity: "ERROR"  
 timestamp: "2019-10-10T23:53:26Z"  
}
```