### PR TITLE
Set --cookie-secret for deck

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -192,6 +192,7 @@ spec:
         - --oauth-url=/github-login
         - --github-token-path=/etc/github/oauth
         - --github-oauth-config-file=/etc/githuboauth/secret
+        - --cookie-secret=/etc/cookie/secret
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
The current configuration is deprecated and should break this week. Fixes #146.