### PR TITLE
Add Prow Job to push TestGrid Configs to k8s-testgrid

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -53,6 +53,33 @@ postsubmits:
         - prow
         - deploy
         - deploy-build
+  - name: post-test-infra-upload-testgrid-config
+    cluster: test-infra-trusted
+    run_if_changed: '^(prow/prowjobs/.*\.yaml)|(testgrid/config\.yaml)$'
+    decorate: true
+    branches:
+    - master
+    annotations:
+      testgrid-create-test-group: "false"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/transfigure
+        command:
+        - /transfigure.sh
+        args:
+        - /etc/github-token/oauth
+        - prow/config.yaml
+        - prow/prowjobs
+        - testgrid/config.yaml
+        - GoogleCloudPlatform
+        volumeMounts:
+        - name: github
+          mountPath: /etc/github-token
+          readOnly: true
+      volumes:
+      - name: github
+        secret:
+          secretName: oauth-token
   GoogleCloudPlatform/testgrid:
   - name: push-testgrid-images
     cluster: test-infra-trusted

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1,0 +1,5 @@
+# Dashboards need to be specified here to be created on TestGrid
+# A prow annotation will be invalid if it references a dashboard that doesn't exist
+dashboards:
+
+dashboard_groups:


### PR DESCRIPTION
This should enable Prow annotations, and allow TestGrid to automatically update k8s/test-infra as other sources are.

/assign @fejta @michelle192837 
/cc @hopkiw 