### PR TITLE
apiproxy: add build and presubmit jobs to prow

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/api-proxy/api-proxy.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/api-proxy/api-proxy.yaml
@@ -1,0 +1,20 @@
+presubmits:
+  GoogleCloudPlatform/api-proxy:
+  - name: gcpproxy-build
+    always_run: true
+    decorate: true
+    path_alias: cloudesf.googlesource.com/gcpproxy
+    spec:
+      containers:
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20191114-v0.0.0-100-g901f883-master
+        command:
+        - ./prow/gcpproxy-build.sh
+  - name: gcpproxy-presubmit
+    always_run: true
+    decorate: true
+    path_alias: cloudesf.googlesource.com/gcpproxy
+    spec:
+      containers:
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20191114-v0.0.0-100-g901f883-master
+        command:
+        - ./prow/gcpproxy-presubmit.sh


### PR DESCRIPTION
They are two basic jobs which no external files or network required.