### PR TITLE
Import guest build tools for post-submit jobs

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -2,6 +2,11 @@ postsubmits:
   GoogleCloudPlatform/osconfig:
   - name: osconfig-build
     cluster: gcp-guest
+    extra_refs:
+    - org: GoogleCloudPlatform
+      repo: guest-test-infra
+      base_ref: master
+      workdir: true
     decorate: true
     annotations:
       testgrid-dashboards: google-gcp-guest
@@ -37,6 +42,11 @@ postsubmits:
   - name: oslogin-build
     cluster: gcp-guest
     decorate: true
+    extra_refs:
+    - org: GoogleCloudPlatform
+      repo: guest-test-infra
+      base_ref: master
+      workdir: true
     annotations:
       testgrid-dashboards: google-gcp-guest
     spec:
@@ -70,6 +80,11 @@ postsubmits:
   GoogleCloudPlatform/guest-configs:
   - name: guest-config-build
     cluster: gcp-guest
+    extra_refs:
+    - org: GoogleCloudPlatform
+      repo: guest-test-infra
+      base_ref: master
+      workdir: true
     decorate: true
     annotations:
       testgrid-dashboards: google-gcp-guest
@@ -104,6 +119,11 @@ postsubmits:
   GoogleCloudPlatform/guest-agent:
   - name: guest-agent-build
     cluster: gcp-guest
+    extra_refs:
+    - org: GoogleCloudPlatform
+      repo: guest-test-infra
+      base_ref: master
+      workdir: true
     decorate: true
     annotations:
       testgrid-dashboards: google-gcp-guest


### PR DESCRIPTION
without this this wf files are not available for builds

sample failure
https://storage.googleapis.com/oss-prow/logs/osconfig-build/1195399548411842560/build-log.txt