### PR TITLE
Migrate Kubeflow from k8s-prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14,6 +14,7 @@
 
 tide:
   merge_method:
+    kubeflow: squash
     GoogleCloudPlatform/osconfig: squash
     GoogleCloudPlatform/guest-logging-go: squash
     GoogleCloudPlatform/guest-agent: squash
@@ -22,6 +23,17 @@ tide:
     GoogleCloudPlatform/compute-image-tools: squash
   target_url: https://oss-prow.knative.dev/tide
   queries:
+    - orgs:
+      - kubeflow
+      labels:
+      - lgtm
+      - approved
+      missingLabels:
+      - do-not-merge
+      - do-not-merge/hold
+      - do-not-merge/invalid-owners-file
+      - do-not-merge/work-in-progress
+      - needs-rebase
     - repos:
         - GoogleCloudPlatform/osconfig
         - GoogleCloudPlatform/oss-test-infra

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -21,6 +21,30 @@ config_updater:
     prow/prowjobs/**/*.yaml:
       name: job-config
 
+triggers:
+- repos:
+  - kubeflow
+  join_org_url: "https://github.com/kubeflow/kubeflow/blob/master/CONTRIBUTING.md"
+
+label:
+  additional_labels:
+  # These labels are used by Kubeflow
+  - community/discussion
+  - community/maintenance
+  - community/question
+  - cuj/build-train-deploy
+  - cuj/multi-user
+  - platform/aws
+  - platform/azure
+  - platform/gcp
+  - platform/minikube
+  - platform/other
+
+project_config:
+  project_org_configs:
+    kubeflow:
+      org_maintainers_team_id: 3198542 # kubeflow-project-maintainers
+
 approve:
 - repos:
   - GoogleCloudPlatform
@@ -98,4 +122,22 @@ plugins:
   # jobs to enable the trigger plugin if a plugins.yaml is specified.
   # https://github.com/kubernetes/test-infra/issues/14743
   https://kunit-review.googlesource.com/linux:
+  - trigger
+
+  kubeflow:
+  - approve   # Enable /approve and /assign commands.
+  - assign
+  - blunderbuss
+  - golint
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle   # Lets PRs & issues be flagged as stale
+  - override
+  - project # Lets issues be tagged into projects
+  - size
+  - skip  # Allows cleaning up stale commit statuses
+  - verify-owners   # Validates OWNERS file changes in PRs.
+  - wip   # Applies a label to PRs with wip in the title to block merge
   - trigger

--- a/prow/prowjobs/kubeflow/OWNERS
+++ b/prow/prowjobs/kubeflow/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- abhi-g
+- jlewi
+- kunmingg
+- lluunn
+- richardsliu

--- a/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
@@ -1,0 +1,186 @@
+periodics:
+- name: kubeflow-periodic-0-7
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kfctl
+      # TODO(https://github.com/kubeflow/testing/issues/498)
+      # This job needs to be moved over to kubeflow/kfctl v0.7-branch
+      # once it exists.
+      - name: BRANCH_NAME
+        value: v0.7-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-7 release
+- name: kubeflow-periodic-0-6-branch
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.6-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-6 release branch.
+- name: kubeflow-periodic-0-5-branch
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.5-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-5 release branch.
+- name: kubeflow-periodic-master
+  cluster: kubeflow
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the latest master branch.
+    # TODO: use a public email group
+    testgrid-alert-email: kubeflow-engineering@google.com
+    testgrid-num-failures-to-alert: "3"
+- name: kubeflow-manifests-periodic-master
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: manifests
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow/manifests on the master branch.
+- name: kubeflow-manifests-periodic-0-6-branch
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: manifests
+      - name: BRANCH_NAME
+        value: v0.6-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow/manifests on the 0-6 release branch.
+- name: kubeflow-periodic-examples
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: examples
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow examples
+- name: kubeflow-periodic-kfctl
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kfctl
+      - name: BRANCH_NAME
+        value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow kfctl
+- name: kubeflow-periodic-project-cleanup
+  cluster: kubeflow
+  interval: 1h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubeflow
+    repo: pipelines
+    base_ref: master
+    workdir: true
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        imagePullPolicy: Always
+        command:
+        - "./test/tools/project-cleaner/project_cleaner.sh"
+        env:
+          - name: REPO_OWNER
+            value: kubeflow
+          - name: REPO_NAME
+            value: kubeflow
+          - name: BRANCH_NAME
+            value: master
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic job to cleanup ml-pipeline-test GCP project

--- a/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
-- name: kubeflow-periodic-0-7
+- name: kubeflow-periodic-1-0
   cluster: kubeflow
-  interval: 8h
+  interval: 4h
   labels:
     preset-service-account: "true"
   spec:
@@ -13,9 +13,27 @@ periodics:
         value: kubeflow
       - name: REPO_NAME
         value: kfctl
-      # TODO(https://github.com/kubeflow/testing/issues/498)
-      # This job needs to be moved over to kubeflow/kfctl v0.7-branch
-      # once it exists.
+      - name: BRANCH_NAME
+        value: v1.0-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 1-0 release
+- name: kubeflow-periodic-0-7
+  cluster: kubeflow
+  # Might want to increase this after the 0.7 release is done.
+  # Other periodics run at 8h.
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kfctl
       - name: BRANCH_NAME
         value: v0.7-branch
   annotations:
@@ -59,6 +77,44 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the 0-5 release branch.
+- name: kubeflow-periodic-0-4-branch
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.4-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-4 release branch.
+- name: kubeflow-periodic-0-3-branch
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: v0.3-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 0-3 release branch.
 - name: kubeflow-periodic-master
   cluster: kubeflow
   interval: 4h
@@ -121,7 +177,7 @@ periodics:
     description: Periodic testing of Kubeflow/manifests on the 0-6 release branch.
 - name: kubeflow-periodic-examples
   cluster: kubeflow
-  interval: 8h
+  interval: 1h
   labels:
     preset-service-account: "true"
   spec:
@@ -170,17 +226,17 @@ periodics:
     workdir: true
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
-        imagePullPolicy: Always
-        command:
-        - "./test/tools/project-cleaner/project_cleaner.sh"
-        env:
-          - name: REPO_OWNER
-            value: kubeflow
-          - name: REPO_NAME
-            value: kubeflow
-          - name: BRANCH_NAME
-            value: master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
+      imagePullPolicy: Always
+      command:
+      - "./test/tools/project-cleaner/project_cleaner.sh"
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kubeflow
+      - name: BRANCH_NAME
+        value: master
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic job to cleanup ml-pipeline-test GCP project

--- a/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
@@ -263,14 +263,31 @@ postsubmits:
       testgrid-dashboards: sig-big-data
       description: Postsubmit tests for kubeflow/arena.
   kubeflow/pipelines:
-  - name: kubeflow-pipeline-postsubmit
+  - name: kubeflow-pipeline-postsubmit-standalone-component-test
     cluster: kubeflow
+    branches:
+    - ^master$
     decorate: true
     labels:
       preset-service-account: "true"
+    env:
+    - name: DOCKER_IN_DOCKER_ENABLED
+      value: "true"
+    volumes:
+    # kubekins-e2e legacy path
+    - name: docker-graph
+      emptyDir: {}
+    # krte (normal) path
+    - name: docker-root
+      emptyDir: {}
+    volumeMounts:
+    - name: docker-graph
+      mountPath: /docker-graph
+    - name: docker-root
+      mountPath: /var/lib/docker
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:
@@ -280,6 +297,78 @@ postsubmits:
         - sample_test
         - --timeout
         - "7200"
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/pipeline.
+  - name: kubeflow-pipeline-postsubmit-mkp-component-test
+    cluster: kubeflow
+    branches:
+    - ^master$
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/ml-pipeline/test-worker:latest
+        command:
+        - ./test/postsubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --kfp_deployment
+        - mkp
+        - --workflow_file
+        - component_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "7200"
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/pipeline.
+  - name: kubeflow-pipeline-postsubmit-mkp-e2e-test
+    cluster: kubeflow
+    branches:
+    - ^master$
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
+        command:
+        - ./test/postsubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --kfp_deployment
+        - mkp
+        - --workflow_file
+        - e2e_test_gke_v2.yaml
+        - --test_result_folder
+        - e2e_test
+        - --timeout
+        - "7200"
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/pipeline.
+  - name: kubeflow-pipeline-postsubmit-mkp-sample-test
+    cluster: kubeflow
+    branches:
+    - ^master$
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
+        command:
+        - ./test/postsubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --kfp_deployment
+        - mkp
+        - --workflow_file
+        - sample_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "3600"
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit tests for kubeflow/pipeline.

--- a/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-postsubmits.yaml
@@ -1,0 +1,298 @@
+postsubmits:
+  kubeflow/examples:
+  - name: kubeflow-examples-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/examples.
+  kubeflow/internal-acls:
+  - name: kubeflow-internal-acls-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/internal-acls.
+  kubeflow/kubeflow:
+  - name: kubeflow-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for Kubeflow.
+      # TODO: use a public email group
+      testgrid-alert-email: kubeflow-engineering@google.com
+      testgrid-num-failures-to-alert: "3"
+  kubeflow/kfctl:
+  - name: kubeflow-kfctl-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/kfctl.
+  kubeflow/manifests:
+  - name: kubeflow-manifests-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/manifests.
+  kubeflow/pytorch-operator:
+  - name: kubeflow-pytorch-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/pytorch-operator.
+  kubeflow/reporting:
+  - name: kubeflow-reporting-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/reporting.
+  kubeflow/website:
+  - name: kubeflow-website-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/website.
+  kubeflow/testing:
+  - name: kubeflow-testing-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/testing.
+  kubeflow/tf-operator:
+  - name: kubeflow-tf-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/tf-operator.
+  kubeflow/katib:
+  - name: kubeflow-katib-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/katib.
+  kubeflow/experimental-kvc:
+  - name: kubeflow-experimental-kvc-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-kvc.
+  kubeflow/experimental-seldon:
+  - name: kubeflow-experimental-seldon-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-seldon.
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/experimental-beagle.
+  kubeflow/caffe2-operator:
+  - name: kubeflow-caffe2-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/caffe2-operator.
+  kubeflow/kubebench:
+  - name: kubeflow-kubebench-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/kubebench.
+  kubeflow/mpi-operator:
+  - name: kubeflow-mpi-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/mpi-operator.
+  kubeflow/chainer-operator:
+  - name: kubeflow-chainer-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/chainer-operator.
+  kubeflow/mxnet-operator:
+  - name: kubeflow-mxnet-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit kubeflow/mxnet-operator.
+  kubeflow/arena:
+  - name: kubeflow-arena-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/arena.
+  kubeflow/pipelines:
+  - name: kubeflow-pipeline-postsubmit
+    cluster: kubeflow
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        command:
+        - ./test/postsubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - component_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "7200"
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/pipeline.
+  kubeflow/xgboost-operator:
+  - name: kubeflow-xgboost-operator-postsubmit
+    cluster: kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/xgboost-operator.

--- a/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
@@ -1,0 +1,404 @@
+presubmits:
+  kubeflow/examples:
+  - name: kubeflow-examples-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/examples.
+      testgrid-num-columns-recent: '30'
+  kubeflow/internal-acls:
+  - name: kubeflow-internal-acls-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for Kubeflow/internal-acls.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kubeflow:
+  - name: kubeflow-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for Kubeflow.
+      testgrid-num-columns-recent: '30'
+  kubeflow/pytorch-operator:
+  - name: kubeflow-pytorch-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/pytorch-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/reporting:
+  - name: kubeflow-reporting-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/reporting.
+      testgrid-num-columns-recent: '30'
+  kubeflow/website:
+  - name: kubeflow-website-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/website.
+      testgrid-num-columns-recent: '30'
+  kubeflow/testing:
+  - name: kubeflow-testing-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/testing.
+      testgrid-num-columns-recent: '30'
+  kubeflow/tf-operator:
+  - name: kubeflow-tf-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/tf-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/katib:
+  - name: kubeflow-katib-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/katib.
+      testgrid-num-columns-recent: '30'
+  kubeflow/experimental-kvc:
+  - name: kubeflow-experimental-kvc-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-kvc.
+      testgrid-num-columns-recent: '30'
+  kubeflow/experimental-seldon:
+  - name: kubeflow-experimental-seldon-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-seldon.
+      testgrid-num-columns-recent: '30'
+  kubeflow/experimental-beagle:
+  - name: kubeflow-experimental-beagle-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/experimental-beagle.
+      testgrid-num-columns-recent: '30'
+  kubeflow/caffe2-operator:
+  - name: kubeflow-caffe2-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/caffe2-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kubebench:
+  - name: kubeflow-kubebench-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/kubebench.
+      testgrid-num-columns-recent: '30'
+  kubeflow/mpi-operator:
+  - name: kubeflow-mpi-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/mpi-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/chainer-operator:
+  - name: kubeflow-chainer-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/chainer-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/mxnet-operator:
+  - name: kubeflow-mxnet-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/mxnet-operator.
+      testgrid-num-columns-recent: '30'
+  kubeflow/arena:
+  - name: kubeflow-arena-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/arena.
+      testgrid-num-columns-recent: '30'
+  kubeflow/fairing:
+  - name: kubeflow-fairing-presubmit
+    cluster: kubeflow
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/fairing.
+      testgrid-num-columns-recent: '30'
+  kubeflow/metadata:
+  - name: kubeflow-metadata-presubmit
+    cluster: kubeflow
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/metadata.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kfserving:
+  - name: kubeflow-kfserving-presubmit
+    cluster: kubeflow
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/kfserving.
+      testgrid-num-columns-recent: '30'
+  kubeflow/manifests:
+  - name: kubeflow-manifests-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/manifests.
+      testgrid-num-columns-recent: '30'
+  kubeflow/kfctl:
+  - name: kubeflow-kfctl-presubmit
+    cluster: kubeflow
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmits for kubeflow/kfctl.
+      testgrid-num-columns-recent: '30'
+  kubeflow/pipelines:
+  - name: kubeflow-pipeline-e2e-test
+    cluster: kubeflow
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        command:
+        - ./test/presubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - e2e_test_gke_v2.yaml
+        - --test_result_folder
+        - e2e_test
+  - name: kubeflow-pipeline-sample-test
+    cluster: kubeflow
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        command:
+        - ./test/presubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - sample_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "3600"
+  - name: kubeflow-pipeline-upgrade-test
+    cluster: kubeflow
+    always_run: true
+    decorate: true
+    skip_report: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        command:
+        - ./test/upgrade-tests.sh
+        args:
+        - --test_result_folder
+        - upgrade_test
+  kubeflow/xgboost-operator:
+  - name: kubeflow-xgboost-operator-presubmit
+    cluster: kubeflow
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Presubmit tests for kubeflow/xgboost-operator.
+      testgrid-num-columns-recent: '30'
+#   - name: kubeflow-pipeline-e2e-test-gce-minikube
+#     cluster: kubeflow
+#     always_run: true
+#     decorate: true
+#     skip_report: true
+#     labels:
+#       preset-service-account: "true"
+#     spec:
+#       containers:
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+#         command:
+#         - ./test/presubmit-tests-gce-minikube.sh
+#         args:
+#         - --workflow_file
+#         - e2e_test_gke.yaml
+#         - --test_result_folder
+#         - e2e_test_gke

--- a/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/kubeflow-presubmits.yaml
@@ -322,6 +322,38 @@ presubmits:
       description: Presubmits for kubeflow/kfctl.
       testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
+  - name: kubeflow-pipeline-frontend-test
+    cluster: kubeflow
+    always_run: true
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: node:12
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - cd ./frontend && npm run test:ci:prow
+  - name: kubeflow-pipeline-backend-test
+    always_run: false
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: l.gcr.io/google/bazel:0.24.0
+        command:
+        - "bazel"
+        args:
+        - "--host_jvm_args=-Xmx500m"
+        - "--host_jvm_args=-Xms500m"
+        - "test"
+        - "--noshow_progress"
+        - "--noshow_loading_progress"
+        - "--define=grpc_no_ares=true"
+        - "//backend/..."
   - name: kubeflow-pipeline-e2e-test
     cluster: kubeflow
     always_run: true
@@ -330,7 +362,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -346,7 +378,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -365,7 +397,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
         command:
         - ./test/upgrade-tests.sh
         args:
@@ -394,7 +426,7 @@ presubmits:
 #       preset-service-account: "true"
 #     spec:
 #       containers:
-#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
 #         command:
 #         - ./test/presubmit-tests-gce-minikube.sh
 #         args:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3,10 +3,10 @@
 dashboards:
 - name: googleoss-gcp-guest
 - name: googleoss-test-infra
+- name: sig-big-data
 
 dashboard_groups:
   - name: googleoss
     dashboard_names:
     - googleoss-gcp-guest
     - googleoss-test-infra
-


### PR DESCRIPTION
Copied `kubeflow` configuration from [config](https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml) and [plugins](https://github.com/kubernetes/test-infra/blob/master/config/prow/plugins.yaml) and add [**tide**](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/192) and [**jobs**](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/93).