### PR TITLE
Bind the gerrit service account to a GCP one

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -709,6 +709,8 @@ subjects:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    "iam.gke.io/gcp-service-account": "oss-prow@oss-prow.iam.gserviceaccount.com"
   name: "gerrit"
 ---
 kind: Role


### PR DESCRIPTION
ref https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202

/assign @Katharine @chases2 


```console
test-infra$ experiment/workload-identity/enable-workload-identity.sh oss-prow us-west1-a prow
++ gcloud beta container clusters describe prow '--format=value(workloadIdentityConfig.identityNamespace)' --project=oss-prow --zone=us-west1-a
++ gcloud beta container node-pools list --cluster=prow '--format=value(name,config.workloadMetadataConfig.nodeMetadata)' --project=oss-prow --zone=us-west1-a
Nothing to do
```

After merging I can run:

```console
test-infra$ experiment/workload-identity/bind-service-accounts.sh oss-prow us-west1-a prow default gerrit oss-prow@oss-prow.iam.gserviceaccount.com
Service account has wrong/missing annotation, please declare the following to default/gerrit in gke_oss-prow_us-west1-a_prow:
{"metadata": {"annotations": "iam.gke.io/gcp-service-account": "$gcp_service_account"}}
```