### PR TITLE
Update gcloud-in-go to latest image.

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -65,7 +65,7 @@ postsubmits:
       preset-prow-deployer-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20200109-87b811d
         command:
         - make
         args:


### PR DESCRIPTION
This should be compatible with 1.14 clusters

ref https://github.com/kubernetes/test-infra/issues/15842