### PR TITLE
Push testgrid images using workload identity

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -52,7 +52,7 @@ plank:
       gcs_configuration:
         bucket: "oss-prow"
         path_strategy: "explicit"
-      gcs_credentials_secret: "service-account"
+      gcs_credentials_secret: "service-account" # TODO(fejta): remove https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202
 
 sinker:
   resync_period: 1m
@@ -87,33 +87,3 @@ deck:
   rerun_auth_config:
     github_orgs:
     - GoogleCloudPlatform
-
-presets:
-- labels:
-    preset-service-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/service-account/service-account.json
-  - name: E2E_GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/service-account/service-account.json
-  volumes:
-  - name: service
-    secret:
-      secretName: service-account
-  volumeMounts:
-  - name: service
-    mountPath: /etc/service-account
-    readOnly: true
-- labels:
-    preset-prow-deployer-service-account: "true"
-  env:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /creds/service-account.json
-  volumeMounts:
-  - name: creds
-    mountPath: /creds
-    readOnly: true
-  volumes:
-  - name: creds
-    secret:
-      secretName: prow-deployer-service-account

--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -51,10 +51,6 @@ presubmits:
   - name: ESPv2-gke-e2e-tight-http-bookstore-managed
     always_run: true
     decorate: true
-    labels:
-      preset-k8s-ssh: "true"
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
     spec:
       containers:
       - args:
@@ -81,6 +77,19 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         image: gcr.io/k8s-testimages/kubekins-e2e:v20190509-e418529-master
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: E2E_GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+      volumes:
+      - name: service # TODO(fejta): remove https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202
+        secret:
+          secretName: service-account
   - name: ESPv2-cloud-run-e2e-cloud-run-http-bookstore
     always_run: true
     decorate: true

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -73,6 +73,17 @@ postsubmits:
         - prow
         - deploy
         - deploy-build
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
+        - name: creds
+          mountPath: /creds
+          readOnly: true
+      volumes:
+      - name: creds
+        secret:
+          secretName: prow-deployer-service-account
   - name: post-oss-test-infra-upload-testgrid-config
     cluster: test-infra-trusted
     run_if_changed: '^(prow/prowjobs/.*\.yaml)|(testgrid/config\.yaml)$'
@@ -123,7 +134,7 @@ postsubmits:
       volumes:
       - name: testgrid-service-account
         secret:
-          secretName: testgrid-service-account
+          secretName: testgrid-service-account # TODO(fejta): remove https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202
 
 periodics:
 - cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -121,20 +121,11 @@ postsubmits:
       testgrid-dashboards: googleoss-test-infra
       testgrid-alert-email: slchase@google.com
     spec:
+      serviceAccountName: testgrid-pusher
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /creds/service-account.json
         command:
         - ./images/push.sh
-        volumeMounts:
-        - name: testgrid-service-account
-          mountPath: /creds
-      volumes:
-      - name: testgrid-service-account
-        secret:
-          secretName: testgrid-service-account # TODO(fejta): remove https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202
 
 periodics:
 - cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri

--- a/prow/serviceaccounts/GoogleCloudPlatform_testgrid_serviceaccounts.yaml
+++ b/prow/serviceaccounts/GoogleCloudPlatform_testgrid_serviceaccounts.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: image-updater@k8s-testgrid.iam.gserviceaccount.com
+  name: testgrid-pusher
+  namespace: test-pods


### PR DESCRIPTION
Also get rid of presets (only used in one location)

Need https://github.com/GoogleCloudPlatform/testgrid/pull/82 to merge first
ref https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202