### PR TITLE
Use workload-identity for grandmatriarch

### DIFF
--- a/prow/cluster/grandmatriarch_default.yaml
+++ b/prow/cluster/grandmatriarch_default.yaml
@@ -71,14 +71,4 @@ spec:
       - name: bakery
         image: gcr.io/k8s-prow/grandmatriarch:v20200110-25a30e033
         args:
-        - /etc/robot/service-account.json
         - http-cookiefile
-        volumeMounts:
-        - mountPath: /etc/robot
-          name: robot
-          readOnly: true
-      volumes:
-      - name: robot
-        secret:
-          defaultMode: 420
-          secretName: service-account # TODO(fejta): workload-identity https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202

--- a/prow/cluster/grandmatriarch_test-pods.yaml
+++ b/prow/cluster/grandmatriarch_test-pods.yaml
@@ -76,14 +76,4 @@ spec:
       - name: bakery
         image: gcr.io/k8s-prow/grandmatriarch:v20200110-25a30e033
         args:
-        - /etc/robot/service-account.json
         - http-cookiefile
-        volumeMounts:
-        - mountPath: /etc/robot
-          name: robot
-          readOnly: true
-      volumes:
-      - name: robot
-        secret:
-          defaultMode: 420
-          secretName: service-account # TODO(fejta): workload-identity https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202


### PR DESCRIPTION
ref #202 

https://github.com/GoogleCloudPlatform/oss-test-infra/pull/224#issuecomment-573816169 validates that all three service accounts can access the GCP service account
