### PR TITLE
Use serviceAccount for bookstore-managed job

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -52,6 +52,7 @@ presubmits:
     always_run: true
     decorate: true
     spec:
+      serviceAccountName: gcp-esp-v2-default
       containers:
       - args:
         - --cluster=

--- a/prow/serviceaccounts/build/GoogleCloudPlatform_esp-v2_serviceaccounts.yaml
+++ b/prow/serviceaccounts/build/GoogleCloudPlatform_esp-v2_serviceaccounts.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: # TODO(fejta): https://github.com/GoogleCloudPlatform/oss-test-infra/issues/222 use a diff account
+    iam.gke.io/gcp-service-account: oss-prow@oss-prow.iam.gserviceaccount.com
+  name: gcp-esp-v2-default
+  namespace: test-pods


### PR DESCRIPTION
ref #202 #222 

Merging this will create the k8s SA, which will allow me to bind it to the gcp SA and then update the job to remove the secret (and then delete the secret)

/assign @michelle192837 @chases2 