### PR TITLE
update to latest e2e image

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -76,7 +76,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20190509-e418529-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json


### PR DESCRIPTION
The old image has error to pull k8s-release
Err msg:
error during gsutil cat gs://kubernetes-release-dev/ci/latest-1.13.txt: exit status 1