### PR TITLE
Mandate TestGrid Validation

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -34,7 +34,6 @@ presubmits:
   - name: pull-oss-test-infra-check-testgrid-config
     run_if_changed: '^(prow/prowjobs/.*\.yaml)|(testgrid/config\.yaml)$'
     decorate: true
-    optional: true
     branches:
     - master
     annotations:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -3,12 +3,10 @@
 dashboards:
 - name: googleoss-gcp-guest
 - name: googleoss-test-infra
-- name: googleoss-esp-v2
 
 dashboard_groups:
   - name: googleoss
     dashboard_names:
     - googleoss-gcp-guest
     - googleoss-test-infra
-    - googleoss-esp-v2
 


### PR DESCRIPTION
Also makes changes to ensure that this presubmit passes:
- Dashboard 'googleoss-esp-v2' removed; no postsumits/periodics are run by that team