### PR TITLE
Bump bazelbuild image to 2.1.0

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -110,7 +110,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20190916-ec59af8-0.29.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200212-b304d89-2.1.0
         command:
         - ./images/push.sh
   - name: post-testgrid-deploy


### PR DESCRIPTION
Fixes [failing job](https://prow.k8s.io/view/gcs/oss-prow/logs/push-testgrid-images/1227668576593252352) caused by Bazel bump

/assign @fejta
/assign @michelle192837 