### PR TITLE
move e2e test using kubekins on github-prow temporarily

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -85,7 +85,6 @@ presubmits:
         secret:
           secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-gke-e2e-tight-http-bookstore-managed
-    cluster: espv2
     always_run: true
     decorate: true
     spec:
@@ -141,7 +140,6 @@ presubmits:
         secret:
           secretName: cloudesf-ssh-key-secret
   - name: ESPv2-gke-e2e-tight-grpc-echo-managed
-    cluster: espv2
     always_run: true
     decorate: true
     spec:
@@ -196,8 +194,64 @@ presubmits:
       - name: cloudesf-ssh-key-secret
         secret:
           secretName: cloudesf-ssh-key-secret
-  - name: ESPv2-gke-e2e-tight-grpc-interop-managed
+  - name: ESPv2-gke-e2e-tight-grpc-echo-managed-experiment
     cluster: espv2
+    optional: true
+    always_run: true
+    decorate: true
+    spec:
+      serviceAccountName: gcp-esp-v2-default
+      containers:
+        - args:
+            - --cluster=
+            - --deployment=gke
+            - --extract=release/stable-1.14
+            - --gcp-project=cloudesf-testing
+            - --gcp-zone=us-west1-b
+            - --gcp-network=default
+            - --gcp-node-image=gci
+            - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
+            - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+            - --gke-environment=prod
+            - --provider=gke
+            - --env=TEST_CASE=tight-grpc-echo-managed
+            - --test=false
+            - --test-cmd=../prow/gcpproxy-e2e.sh
+            - --test-cmd-name=gcpproxy_e2e
+            - --timeout=80m
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          command:
+            - runner.sh
+            - /workspace/scenarios/kubernetes_e2e.py
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/service-account/service-account.json
+            - name: E2E_GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/service-account/service-account.json
+            - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+              value: /etc/cloudesf-ssh-key-secret/ssh-private
+            - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+              value: /etc/cloudesf-ssh-key-secret/ssh-public
+            - name: USER
+              value: prow
+          volumeMounts:
+            - name: service
+              mountPath: /etc/service-account
+              readOnly: true
+            - name: cloudesf-ssh-key-secret
+              mountPath: /etc/cloudesf-ssh-key-secret
+              readOnly: true
+      volumes:
+        - name: service # TODO(fejta): remove https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202
+          secret:
+            secretName: service-account
+        - name: cloudesf-ssh-key-secret
+          secret:
+            secretName: cloudesf-ssh-key-secret
+  - name: ESPv2-gke-e2e-tight-grpc-interop-managed
     always_run: true
     decorate: true
     spec:


### PR DESCRIPTION
- Move those jobs using kubekins back to github-prow clusters
- Add one experimental job to test if our own cluster works
