### PR TITLE
Delete gcp-esp-v2-default serviceaccount from shared cluster

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -37,4 +37,3 @@ deploy: get-cluster-credentials
 .PHONY: deploy-build
 deploy-build: get-build-cluster-credentials
 	kubectl apply -f ./cluster/build/
-	kubectl apply -f ./serviceaccounts/build/

--- a/prow/serviceaccounts/build/GoogleCloudPlatform_esp-v2_serviceaccounts.yaml
+++ b/prow/serviceaccounts/build/GoogleCloudPlatform_esp-v2_serviceaccounts.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: github-prow-jobs@cloudesf-testing.iam.gserviceaccount.com
-  name: gcp-esp-v2-default
-  namespace: test-pods


### PR DESCRIPTION
The espv2 jobs no longer run in the shared cluster, so we no longer need this service account

/assign @TAOXUY 