### PR TITLE
Migrate espv2 e2e jobs from default cluster to espv2 cluster

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -85,7 +85,6 @@ presubmits:
         secret:
           secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-gke-e2e-tight-http-bookstore-managed
-    cluster: espv2
     always_run: true
     decorate: true
     spec:
@@ -141,7 +140,6 @@ presubmits:
         secret:
           secretName: cloudesf-ssh-key-secret
   - name: ESPv2-gke-e2e-tight-grpc-echo-managed
-    cluster: espv2
     always_run: true
     decorate: true
     spec:
@@ -197,7 +195,6 @@ presubmits:
         secret:
           secretName: cloudesf-ssh-key-secret
   - name: ESPv2-gke-e2e-tight-grpc-interop-managed
-    cluster: espv2
     always_run: true
     decorate: true
     spec:


### PR DESCRIPTION
Previously, the espv2 cluster doesn't have the corresponding service account so e2e jobs failed. Now thoes SA are created so migrate e2e jobs. 