### PR TITLE
Enable reporting of pod info to GCS.

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -414,6 +414,9 @@ spec:
         - --gerrit-projects=https://kunit-review.googlesource.com=linux
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --gcs-workers=1 
+        - --kubernetes-gcs-workers=1 
+        - --kubeconfig=/etc/kubeconfig/oss-config-20200214
         volumeMounts:
         - name: cookies
           mountPath: /etc/cookies
@@ -423,6 +426,9 @@ spec:
           readOnly: true
         - name: job-config
           mountPath: /etc/job-config
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
           readOnly: true
         - name: oauth
           mountPath: /etc/github
@@ -438,6 +444,10 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
       - name: oauth
         secret:
           secretName: oauth-token

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -42,7 +42,8 @@ tide:
 plank:
   job_url_prefix_config:
     '*': https://prow.gflocks.com/view/gcs/
-  pod_pending_timeout: 60m
+  pod_pending_timeout: 15m
+  pod_unscheduled_timeout: 1m
   default_decoration_configs:
     '*':
       timeout: 7200000000000 # 2h
@@ -60,7 +61,8 @@ plank:
 sinker:
   resync_period: 1m
   max_prowjob_age: 48h
-  max_pod_age: 24h
+  max_pod_age: 48h
+  terminated_pod_ttl: 30m
 
 prowjob_namespace: default
 pod_namespace: test-pods
@@ -78,6 +80,8 @@ deck:
           name: metadata
         required_files:
           - started.json|finished.json
+        optional_files:
+          - podinfo.json
       - lens:
           name: buildlog
         required_files:
@@ -86,6 +90,10 @@ deck:
           name: junit
         required_files:
           - artifacts/junit.*\.xml
+      - lens:
+          name: podinfo
+        required_files:
+          - podinfo.json
     announcement: "The old job viewer, Gubernator, has been deprecated in favour of this page, Spyglass.{{if .ArtifactPath}} For now, the old page is <a href='https://gubernator-internal.googleplex.com/build/{{.ArtifactPath}}'>still available</a>.{{end}} Please send feedback to osp-engprod@google.com."
   rerun_auth_config:
     github_orgs:


### PR DESCRIPTION
Also tweaks things like pod timeout to match kubernetes/test-infra for
more useful debugging.

Lens will be enabled in follow-up PR if this works.