### PR TITLE
Disable http redirection.

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -200,7 +200,7 @@ spec:
         - --spyglass=true
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
-        - --redirect-http-to=prow.gflocks.com
+        # --redirect-http-to=oss-prow.knative.dev
         - --rerun-creates-job
         - --oauth-url=/github-login
         - --github-token-path=/etc/github/oauth


### PR DESCRIPTION
The gflocks domain is retired, prepare to migrate to oss-prow.knative.dev

/assign @michelle192837 @clarketm 