### PR TITLE
move continuous e2e jobs into us-west1-c

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -488,7 +488,7 @@ periodics:
             - --deployment=gke
             - --extract=release/stable-1.14
             - --gcp-project=cloudesf-testing
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-west1-c
             - --gcp-network=default
             - --gcp-node-image=gci
             - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
@@ -546,7 +546,7 @@ periodics:
             - --deployment=gke
             - --extract=release/stable-1.14
             - --gcp-project=cloudesf-testing
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-west1-c
             - --gcp-network=default
             - --gcp-node-image=gci
             - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
@@ -604,7 +604,7 @@ periodics:
             - --deployment=gke
             - --extract=release/stable-1.14
             - --gcp-project=cloudesf-testing
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-west1-c
             - --gcp-network=default
             - --gcp-node-image=gci
             - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
@@ -661,7 +661,7 @@ periodics:
             - --cluster=
             - --deployment=gke
             - --gcp-project=cloudesf-testing
-            - --gcp-zone=us-west1-b
+            - --gcp-zone=us-west1-c
             - --gcp-network=default
             - --gcp-node-image=gci
             - --gke-environment=prod


### PR DESCRIPTION
Like our gob-prow, move our e2e jobs in to us-west1-c so that they can be clean with `periodic-ESPv2-continuous-job-janitor`, which cleanup the e2e jobs in us-west1-c and older than 5hrs.