### PR TITLE
Rename ResultStore ProwJob

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -197,7 +197,7 @@ periodics:
       secret:
         secretName: oauth-token
 - interval: 5m
-  name: ci-test-infra-resultstore-upload
+  name: ci-google-oss-test-infra-resultstore-upload
   annotations:
     testgrid-dashboards: googleoss-test-infra
     testgrid-tab-name: resultstore


### PR DESCRIPTION
Prevents redundancy with k8s/test-infra, which is required for TestGrid utilities (ex. Transfigure) to function

Fixes #318 