### PR TITLE
Domain is now oss-prow.knative.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ limitations under the License.
 
 Here lives the OSS [prow](https://github.com/kubernetes/test-infra/tree/master/prow) config for google-owned OSS projects.
 
-Prow deck: https://prow.gflocks.com/
+Prow deck: https://oss-prow.knative.dev/
 
 Please follow https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#how-to-configure-new-jobs for how to configure prowjobs in [config.yaml](./prow/config.yaml).

--- a/prow/README.md
+++ b/prow/README.md
@@ -9,7 +9,7 @@ prow/bump.sh --auto
 # commit change and merge PR
 make -C prow deploy
 # kubectl get pods and watch for problems
-# prow.gflocks.com and watch for problems
+# https://oss-prow.knative.dev and watch for problems
 # Look at stack driver logs (go/oss-prow-debug or whatever) and look for problems)
 ```
 
@@ -78,7 +78,7 @@ my-repo: # ADD THIS BLOCK
 ### Manually Trigger a Prow Job
 
 ```bash
-# Assuming you cannot click the rerun button on prow.gflocks.com,
+# Assuming you cannot click the rerun button on deck
 # and if you are oncall, do the following:
 go get -u k8s.io/test-infra/prow/cmd/mkpj
 

--- a/prow/tests/README.md
+++ b/prow/tests/README.md
@@ -1,9 +1,7 @@
 # prow/tests
 
-This directory contains tests for the jobs deployed on [prow.gflocks.com]
+This directory contains tests for the jobs deployed on [oss-prow.knative.dev](https://oss-prow.knative.dev/)
 
 These tests enforce a number of project-specific conventions.
 
 To run via go: `go test .`
-
-[prow.gflocks.com]: https://prow.gflocks.com


### PR DESCRIPTION
Changes domain name in all documentation

Does not cover domain name in [prow/cluster/cluster.yaml](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/a9beebb04e4e85a178c994226a1408ef8680401c/prow/cluster/cluster.yaml#L306-L313); I'm not sure if that managed certificate is being used currently. 