### PR TITLE
Removed deprecated ManagedCertificate

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -306,15 +306,6 @@ spec:
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  name: prow-gflocks-com
-  namespace: default
-spec:
-  domains:
-  - prow.gflocks.com
----
-apiVersion: networking.gke.io/v1beta1
-kind: ManagedCertificate
-metadata:
   name: oss-prow-knative-dev
   namespace: default
 spec:


### PR DESCRIPTION
I'm about 80% sure this certificate isn't being used, but would like some confirmation, if possible.