### PR TITLE
Fix hook RBAC and CRD validation.

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -64,7 +64,6 @@ spec:
                   - "success"
                   - "failure"
                   - "error"
-                  - "aborted"
           - required:
             - completionTime
 ---
@@ -843,6 +842,8 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - update
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
This is needed to allow aborting jobs for closed PRs and will resolve a few types of errors in the logs.
/assign @fejta 