### PR TITLE
Fix ghproxy deployment selector.

### DIFF
--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -21,6 +21,9 @@ metadata:
     app: ghproxy
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ghproxy
   template:
     metadata:
       labels:


### PR DESCRIPTION
/assign @fejta 
I'm done boosting my GH activity stats. This time I checked that the deployment is valid with kind.