### PR TITLE
Revert "Bump prow from v20200417-a6017ee5b to v20200422-8c8546d74"

### DIFF
--- a/prow/cluster/cluster.yaml
+++ b/prow/cluster/cluster.yaml
@@ -87,7 +87,7 @@ spec:
       serviceAccountName: plank
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/plank:v20200417-a6017ee5b
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200214
         - --dry-run=false
@@ -137,7 +137,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/sinker:v20200417-a6017ee5b
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200214
         - --config-path=/etc/config/config.yaml
@@ -191,7 +191,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/deck:v20200417-a6017ee5b
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200214
         - --config-path=/etc/config/config.yaml
@@ -284,7 +284,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/horologium:v20200417-a6017ee5b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
@@ -357,7 +357,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: gerrit
-        image: gcr.io/k8s-prow/gerrit:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/gerrit:v20200417-a6017ee5b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
@@ -407,7 +407,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/crier:v20200417-a6017ee5b
         args:
         - --gerrit-workers=1
         - --github-workers=1
@@ -481,7 +481,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/hook:v20200417-a6017ee5b
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml
@@ -892,7 +892,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/tide:v20200417-a6017ee5b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/ghproxy:v20200417-a6017ee5b
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=49

--- a/prow/cluster/grandmatriarch_default.yaml
+++ b/prow/cluster/grandmatriarch_default.yaml
@@ -69,6 +69,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/grandmatriarch:v20200417-a6017ee5b
         args:
         - http-cookiefile

--- a/prow/cluster/grandmatriarch_test-pods.yaml
+++ b/prow/cluster/grandmatriarch_test-pods.yaml
@@ -74,6 +74,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20200422-8c8546d74
+        image: gcr.io/k8s-prow/grandmatriarch:v20200417-a6017ee5b
         args:
         - http-cookiefile

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -51,10 +51,10 @@ plank:
       timeout: 7200000000000 # 2h
       grace_period: 15000000000 # 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200422-8c8546d74"
-        initupload: "gcr.io/k8s-prow/initupload:v20200422-8c8546d74"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200422-8c8546d74"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20200422-8c8546d74"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200417-a6017ee5b"
+        initupload: "gcr.io/k8s-prow/initupload:v20200417-a6017ee5b"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200417-a6017ee5b"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20200417-a6017ee5b"
       gcs_configuration:
         bucket: "oss-prow"
         path_strategy: "explicit"

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20200422-8c8546d74
+        - image: gcr.io/k8s-prow/checkconfig:v20200417-a6017ee5b
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -168,7 +168,7 @@ periodics:
     testgrid-tab-name: autobump-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200422-8c8546d74
+    - image: gcr.io/k8s-prow/autobump:v20200417-a6017ee5b
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/oss-test-infra#343

Currently preventing some jobs from starting at all.