### PR TITLE
[ESPv2] Revert back serverless e2e images

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -369,7 +369,7 @@ presubmits:
       description: "Runs e2e tests for Cloud Run."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200527-v2.10.0-7-g332387c-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200309-v2.6.0-15-gd62fe00-master
         command:
         - ./prow/gcpproxy-e2e.sh
         env:
@@ -396,7 +396,7 @@ presubmits:
       description: "Runs e2e tests for Cloud Functions."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200527-v2.10.0-7-g332387c-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200309-v2.6.0-15-gd62fe00-master
         command:
         - ./prow/gcpproxy-e2e.sh
         env:
@@ -423,7 +423,7 @@ presubmits:
       description: "Runs e2e tests for Cloud Run."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200527-v2.10.0-7-g332387c-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200309-v2.6.0-15-gd62fe00-master
         command:
         - ./prow/gcpproxy-e2e.sh
         env:
@@ -857,7 +857,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200527-v2.10.0-7-g332387c-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200309-v2.6.0-15-gd62fe00-master
           command:
             - ./prow/e2e-cloud-run-cloud-run-http-bookstore.sh
           env:
@@ -888,7 +888,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200527-v2.10.0-7-g332387c-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200309-v2.6.0-15-gd62fe00-master
           command:
             - ./prow/e2e-cloud-run-cloud-function-http-bookstore.sh
           env:
@@ -919,7 +919,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200527-v2.10.0-7-g332387c-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20200309-v2.6.0-15-gd62fe00-master
           command:
             - ./prow/e2e-cloud-run-cloud-run-grpc-echo.sh
           env:


### PR DESCRIPTION
These keep failing on `gcloud auth print-access-token`. I imagine it is a problem with GKE workload identity in the latest `gcloud`, as I cannot reproduce locally.

Reverting the image should be safe. E2E tests do not build envoy, so they don't need the latest changes.

Test failures: https://testgrid.k8s.io/googleoss-esp-v2-periodic#e2e-cloud-run-http-bookstore

Signed-off-by: Teju Nareddy <nareddyt@google.com>