### PR TITLE
Switch en-server from internal Prow to OSS Prow.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14,34 +14,37 @@
 
 tide:
   merge_method:
-    GoogleCloudPlatform/osconfig: squash
-    GoogleCloudPlatform/guest-logging-go: squash
+    GoogleCloudPlatform/compute-image-tools: squash
     GoogleCloudPlatform/guest-agent: squash
     GoogleCloudPlatform/guest-configs: squash
     GoogleCloudPlatform/guest-diskexpand: squash
-    GoogleCloudPlatform/guest-test-infra: squash
+    GoogleCloudPlatform/guest-logging-go: squash
     GoogleCloudPlatform/guest-oslogin: squash
-    GoogleCloudPlatform/compute-image-tools: squash
+    GoogleCloudPlatform/guest-test-infra: squash
+    GoogleCloudPlatform/osconfig: squash
+    google/exposure-notifications-server: squash
   target_url: https://oss-prow.knative.dev/tide
   queries:
-    - repos:
-        - GoogleCloudPlatform/osconfig
-        - GoogleCloudPlatform/oss-test-infra
-        - GoogleCloudPlatform/guest-logging-go
-        - GoogleCloudPlatform/guest-agent
-        - GoogleCloudPlatform/guest-configs
-        - GoogleCloudPlatform/guest-diskexpand
-        - GoogleCloudPlatform/guest-oslogin
-        - GoogleCloudPlatform/testgrid
-        - GoogleCloudPlatform/guest-test-infra
-        - GoogleCloudPlatform/compute-image-tools
-      labels:
-        - lgtm
-        - approved
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
+  - repos:
+    - GoogleCloudPlatform/compute-image-tools
+    - GoogleCloudPlatform/guest-agent
+    - GoogleCloudPlatform/guest-configs
+    - GoogleCloudPlatform/guest-diskexpand
+    - GoogleCloudPlatform/guest-logging-go
+    - GoogleCloudPlatform/guest-oslogin
+    - GoogleCloudPlatform/guest-test-infra
+    - GoogleCloudPlatform/osconfig
+    - GoogleCloudPlatform/oss-test-infra
+    - GoogleCloudPlatform/testgrid
+    - google/exposure-notifications-server
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
 
 plank:
   job_url_prefix_config:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -24,12 +24,14 @@ config_updater:
 approve:
 - repos:
   - GoogleCloudPlatform
+  - google
   - googleforgames
   require_self_approval: false
 
 lgtm:
 - repos:
   - GoogleCloudPlatform
+  - google
   - googleforgames
   review_acts_as_lgtm: true
 
@@ -96,7 +98,26 @@ plugins:
   - yuks # /joke
 
   google:
+  - approve
+  - assign
+  - cat
+  - dog
+  - golint
+  - hold
+  - label
+  - lgtm
+  - owners-label
+  - pony
+  - shrug
+  - size
   - trigger
+  - verify-owners
+  - wip
+  - yuks
+
+  google/exposure-notifications-server:
+  - blunderbuss
+  - lifecycle
 
   # This is a gerrit repo so this config doesn't do anything. It is included
   # to satisfy the checkconfig tool which expects all repos that configure


### PR DESCRIPTION
Depends on https://github.com/GoogleCloudPlatform/oss-test-infra/pull/375

Hold for validation of dependent PR and synchronized merge with internal PR to disable automation on internal Prow.
/hold

/assign @crwilcox @sethvargo @fejta 