### PR TITLE
exposure-notification jobs use build cluster

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -1,6 +1,7 @@
 presubmits:
   google/exposure-notifications-server:
   - name: pull-en-server-release-unit
+    cluster: build-apollo-server
     always_run: true
     decorate: true
     labels:


### PR DESCRIPTION
/hold
Would be nice if we can manually test this job before pushing it

/assign @cjwagner @michelle192837 