### PR TITLE
Apollo Server test: add a canary job for testing GCS access token

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -23,4 +23,37 @@ presubmits:
           requests:
             cpu: 7
             memory: '16Gi'
-
+  - name: pull-en-server-release-unit-canary
+    cluster: build-apollo-server
+    always_run: false
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/cloud-devrel-public-resources/exposure-notifications/presubmit-test
+        command:
+        - /bin/runner.sh
+        args:
+        - ./scripts/presubmit.sh
+        env:
+        - name: GO111MODULE
+          value: "on"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/gcs-access-service-account/service-account.json
+        - name: GOOGLE_CLOUD_BUCKET
+          value: apollo-server-prow-test-bucket
+        volumeMounts:
+        - name: gcs-access-service-account
+          mountPath: /etc/gcs-access-service-account
+        securityContext:
+          # We run docker-in-docker which requires privileged mode
+          privileged: true
+        resources:
+          requests:
+            cpu: 7
+            memory: '16Gi'
+      volumes:
+      - name: gcs-access-service-account
+        secret:
+          secretName: gcs-access-service-account


### PR DESCRIPTION
The service account json key `gcs-access-service-account` was already mounted on build cluster, and GCS bucket `apollo-server-prow-test-bucket` was created as well. They are ready for a test now

