### PR TITLE
Apollo server: move canary to prod

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -23,37 +23,3 @@ presubmits:
           requests:
             cpu: 7
             memory: '16Gi'
-  - name: pull-en-server-release-unit-canary
-    cluster: build-apollo-server
-    always_run: false
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/cloud-devrel-public-resources/exposure-notifications/presubmit-test
-        command:
-        - /bin/runner.sh
-        args:
-        - ./scripts/presubmit.sh
-        env:
-        - name: GO111MODULE
-          value: "on"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs-access-service-account/service-account.json
-        - name: GOOGLE_CLOUD_BUCKET
-          value: apollo-server-prow-test-bucket
-        volumeMounts:
-        - name: gcs-access-service-account
-          mountPath: /etc/gcs-access-service-account
-        securityContext:
-          # We run docker-in-docker which requires privileged mode
-          privileged: true
-        resources:
-          requests:
-            cpu: 7
-            memory: '16Gi'
-      volumes:
-      - name: gcs-access-service-account
-        secret:
-          secretName: gcs-access-service-account

--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -16,6 +16,13 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/gcs-access-service-account/service-account.json
+        - name: GOOGLE_CLOUD_BUCKET
+          value: apollo-server-prow-test-bucket
+        volumeMounts:
+        - name: gcs-access-service-account
+          mountPath: /etc/gcs-access-service-account
         securityContext:
           # We run docker-in-docker which requires privileged mode
           privileged: true
@@ -23,3 +30,7 @@ presubmits:
           requests:
             cpu: 7
             memory: '16Gi'
+      volumes:
+      - name: gcs-access-service-account
+        secret:
+          secretName: gcs-access-service-account


### PR DESCRIPTION
The canary job for using service account auth GCS succeeded, move it to prod
Succeeded run: https://oss-prow.knative.dev/view/gcs/oss-prow/pr-logs/pull/google_exposure-notifications-server/497/pull-en-server-release-unit-canary/1275876003427651584

There are two commits for easier code review:
 
1. Delete canary job
1. Update prod job