### PR TITLE
Add auto bump job for knative prow configs

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -188,7 +188,7 @@ periodics:
     testgrid-tab-name: autobump-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200622-168a90f1b0
+    - image: gcr.io/k8s-prow/autobump:v20200630-ba12d68fe6
       command:
       - /autobump.sh
       args:
@@ -231,7 +231,7 @@ periodics:
     testgrid-tab-name: autobump-knative-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200629-32917fc1b6
+    - image: gcr.io/k8s-prow/autobump:v20200630-ba12d68fe6
       command:
       - /autobump.sh
       args:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -216,6 +216,49 @@ periodics:
     - name: github
       secret:
         secretName: oauth-token
+- cron: "15 15-23 * * 1-5"  # Run at 7:15-15:15 PST (15:15 UTC) Mon-Fri
+  name: ci-oss-test-infra-autobump-knative-prow
+  cluster: test-infra-trusted
+  decorate: true
+  extra_refs:
+  - org: GoogleCloudPlatform
+    repo: oss-test-infra
+    base_ref: master
+  annotations:
+    testgrid-dashboards: googleoss-test-infra
+    testgrid-tab-name: autobump-knative-prow
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/autobump:v20200622-168a90f1b0
+      command:
+      - /autobump.sh
+      args:
+      - /etc/github-token/oauth
+      - "Google OSS Prow Robot"
+      - google-oss-robot@google.com
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+      env:
+      - name: GH_ORG
+        value: GoogleCloudPlatform
+      - name: GH_REPO
+        value: oss-test-infra
+      - name: PLANK_DEPLOYMENT_FILE
+        value: prow/knative/cluster/400-plank.yaml
+      - name: COMPONENT_FILE_DIR
+        value: prow/knative/cluster
+      - name: CONFIG_PATH
+        value: prow/knative/cluster/400-plank.yaml # Trick autobump as this is required
+      - name: JOB_CONFIG_PATH
+        value: prow/knative/cluster/400-plank.yaml # Ditto trick
+      - name: PROW_INSTANCE_NAME
+        value: knative-prow
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token
 - interval: 5m
   name: ci-google-oss-test-infra-resultstore-upload
   annotations:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -212,6 +212,8 @@ periodics:
         value: prow/oss/config.yaml
       - name: JOB_CONFIG_PATH
         value: prow/prowjobs
+      - name: PROW_INSTANCE_NAME
+        value: oss-prow
     volumes:
     - name: github
       secret:
@@ -250,9 +252,7 @@ periodics:
       - name: COMPONENT_FILE_DIR
         value: prow/knative/cluster
       - name: CONFIG_PATH
-        value: prow/knative/cluster/400-plank.yaml # Trick autobump as this is required
-      - name: JOB_CONFIG_PATH
-        value: prow/knative/cluster/400-plank.yaml # Ditto trick
+        value: prow/knative/config.yaml
       - name: PROW_INSTANCE_NAME
         value: knative-prow
     volumes:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -231,7 +231,7 @@ periodics:
     testgrid-tab-name: autobump-knative-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200622-168a90f1b0
+    - image: gcr.io/k8s-prow/autobump:v20200629-32917fc1b6
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
Basically copy/paste from auto bump job above. Other than job name and testgrid tab name, the only changes are env vars

/assign cjwagner