### PR TITLE
Protect knative prow cluster from being used by any job

### DIFF
--- a/prow/knative/OWNERS
+++ b/prow/knative/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- chaodaiG
+- chizhg


### PR DESCRIPTION
This is step 2 as described in #407 . Kubeconfig of knative prow cluster will be added onto oss-test-infra prow for managing knative prow core and plugin configs. Adding this guard to ensure knative prow cluster isn't accidentally used by any job to run workload

/assign cjwagner chizhg
/cc albertomilan