### PR TITLE
Updateconfig plugin updates knative prow configs from oss-test-infra prow

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -20,6 +20,16 @@ config_updater:
       name: plugins
     prow/prowjobs/**/*.yaml:
       name: job-config
+    prow/knaitve/config.yaml: # For knative prow
+      name: config
+      clusters: 
+        knative-prow-trusted:
+        - default
+    prow/knative/plugins.yaml: # For knative prow
+      name: plugins
+      clusters: 
+        knative-prow-trusted:
+        - default
 
 approve:
 - repos:

--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -20,14 +20,14 @@ config_updater:
       name: plugins
     prow/prowjobs/**/*.yaml:
       name: job-config
-    prow/knaitve/config.yaml: # For knative prow
+    prow/knative/config.yaml: # For knative prow
       name: config
-      clusters: 
+      clusters:
         knative-prow-trusted:
         - default
     prow/knative/plugins.yaml: # For knative prow
       name: plugins
-      clusters: 
+      clusters:
         knative-prow-trusted:
         - default
 


### PR DESCRIPTION
This is step 4 as described in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/407

Shouldn't merge until steps 1-3 are done
/hold