### PR TITLE
Knative prow stop updating core and plugins. Mirror from https://github.com/knative/test-infra/pull/2255

### DIFF
--- a/prow/knative/plugins.yaml
+++ b/prow/knative/plugins.yaml
@@ -76,10 +76,6 @@ config_updater:
     config/prod/prow/jobs/**/*.yaml:
       name: job-config
       gzip: true
-    config/prod/prow/core/config.yaml:
-      name: config
-    config/prod/prow/core/plugins.yaml:
-      name: plugins
 # Plugins enabled for each repo.
 plugins:
   knative:


### PR DESCRIPTION
This is a side effect of step 3 from https://github.com/GoogleCloudPlatform/oss-test-infra/pull/407

/cc chizhg cjwagner