### PR TITLE
Add performance test job for exposure notification server

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -43,6 +43,9 @@ periodics:
     - org: google
       repo: exposure-notifications-server
       base_ref: master
+    annotations:
+      testgrid-dashboards: googleoss-en-server
+      testgrid-tab-name: performance
     labels:
       preset-dind-enabled: "true"
     spec:

--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -34,3 +34,32 @@ presubmits:
       - name: gcs-access-service-account
         secret:
           secretName: gcs-access-service-account
+periodics:
+  - cron: "0 8 * * *"  # Run at 00:00 PST
+    name: ci-en-server-performance
+    cluster: build-apollo-server
+    decorate: true
+    extra_refs:
+    - org: google
+      repo: exposure-notifications-server
+      base_ref: master
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/cloud-devrel-public-resources/exposure-notifications/presubmit-test
+        command:
+        - /bin/runner.sh
+        args:
+        - ./scripts/performance.sh
+        env:
+        - name: GO111MODULE
+          value: "on"
+        volumeMounts:
+        securityContext:
+          # We run docker-in-docker which requires privileged mode
+          privileged: true
+        resources:
+          requests:
+            cpu: 7
+            memory: '16Gi'

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -5,6 +5,7 @@ dashboards:
 - name: googleoss-test-infra
 - name: googleoss-esp-v2-presubmit
 - name: googleoss-esp-v2-periodic
+- name: googleoss-en-server
 
 dashboard_groups:
   - name: googleoss
@@ -13,3 +14,4 @@ dashboard_groups:
     - googleoss-test-infra
     - googleoss-esp-v2-presubmit
     - googleoss-esp-v2-periodic
+    - googleoss-en-server


### PR DESCRIPTION
This job is set to run once per day initially

Success of this job is contingent on the creation of entrypoint script in exposure-notification-server repo. 

/cc @stati0n