### PR TITLE
Mount kubeconfig secret for hook

### DIFF
--- a/prow/oss/cluster/cluster.yaml
+++ b/prow/oss/cluster/cluster.yaml
@@ -485,6 +485,7 @@ spec:
         image: gcr.io/k8s-prow/hook:v20200622-168a90f1b0
         imagePullPolicy: Always
         args:
+        - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
@@ -510,6 +511,9 @@ spec:
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
       volumes:
       - name: hmac
         secret:
@@ -526,6 +530,10 @@ spec:
       - name: plugins
         configMap:
           name: plugins
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Passing `kubeconfig`  as a parameter for hook deployment