### PR TITLE
Noop update on knative core config

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 plank:
   job_url_template: 'https://prow.knative.dev/view/gcs/knative-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_templates:


### PR DESCRIPTION
The previous attempt for testing updateconfig plugin failed due to hook deployment doesn't have kubeconfig mounted, which is fixed in #416. Create this PR for testing the 2nd time

/cc @chizhg 

/hold
Wait until #416 merged