### PR TITLE
Spyglass highlights a handful of compile errors.

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -79,6 +79,16 @@ deck:
           - 'Please run .*hack/update-codegen.sh'
           # Metrics are logged only for Pods in a failed test.
           - 'Metrics logs'
+          # Compile error - unused import.
+          - "imported and not used:"
+          # Compile error - unused variable.
+          - "declared but not used"
+          # Compile error - undefined variable.
+          - "undefined:"
+          # Compile error - not enough arguments.
+          - "not enough arguments in call to "
+          # Compile error - incorrect argument type.
+          - "cannot use .* \\(type .*\\) as type .* in argument to"
       required_files:
       - build-log.txt
     - lens:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**What this PR does, why we need it**:

This PR makes Spyglass highlight a handful of compile errors.

I created this after trying to diagnose why a [dependency update PR failed](https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/google_knative-gcp/1371/pull-google-knative-gcp-build-tests/1278361112407969793). 

Spyglass showed:

```
---- Checking for forbidden licenses ----
-----------------------------------------
---- Wed Jul  1 09:31:42 PDT 2020
-----------------------------------------
2020/07/01 16:32:41 Getting artifacts dir from prow
Step failed: default_build_test_runner
============================
==== BUILD TESTS FAILED ====
============================
==== Wed Jul  1 09:32:41 PDT 2020
============================
Step failed: run_build_tests
+ EXIT_VALUE=1
+ set +o xtrace
```

Which was not very helpful. I had to search through the logs to find:

```
test/e2e/e2e_test.go:107:52: not enough arguments in call to "knative.dev/eventing/test/e2e/helpers".EventTransformationForTriggerTestHelper
	have (*"testing".T, string, "knative.dev/eventing/test/lib".ComponentsTestRunner, func(*"knative.dev/eventing/test/lib".Client))
	want (*"testing".T, string, string, string, "knative.dev/eventing/test/lib".ComponentsTestRunner, ..."knative.dev/eventing/test/lib".SetupClientOption)
test/e2e/e2e_test.go:117:48: not enough arguments in call to "knative.dev/eventing/test/e2e/helpers".BrokerChannelFlowWithTransformation
	have (*"testing".T, string, "knative.dev/eventing/test/lib".ComponentsTestRunner, func(*"knative.dev/eventing/test/lib".Client))
	want (*"testing".T, string, string, string, "knative.dev/eventing/test/lib".ComponentsTestRunner, ..."knative.dev/eventing/test/lib".SetupClientOption)
```

While adding this regex, I tried to think of a few other common problems and add them too (e.g. unused import or variable).
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Special notes to reviewers**:
None.

**User-visible changes in this PR**:
Spyglass will highlight additional lines.
