### PR TITLE
Remove unused secret for EN verification server

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
@@ -16,13 +16,6 @@ presubmits:
         env:
         - name: GO111MODULE
           value: "on"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs-access-service-account/service-account.json
-        - name: GOOGLE_CLOUD_BUCKET
-          value: apollo-server-prow-test-bucket
-        volumeMounts:
-        - name: gcs-access-service-account
-          mountPath: /etc/gcs-access-service-account
         securityContext:
           # We run docker-in-docker which requires privileged mode
           privileged: true
@@ -30,7 +23,3 @@ presubmits:
           requests:
             cpu: 7
             memory: '16Gi'
-      volumes:
-      - name: gcs-access-service-account
-        secret:
-          secretName: gcs-access-service-account


### PR DESCRIPTION
This secret was taken form exposure-notifications-server, but is causing a build failure

https://oss-prow.knative.dev/view/gcs/oss-prow/pr-logs/pull/google_exposure-notifications-verification-server/85/pull-en-server-release-unit/1280340453987717120