### PR TITLE
Update baseref of exposure notification server from master to main

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -42,7 +42,7 @@ periodics:
     extra_refs:
     - org: google
       repo: exposure-notifications-server
-      base_ref: master
+      base_ref: main
     annotations:
       testgrid-dashboards: googleoss-en-server
       testgrid-tab-name: performance


### PR DESCRIPTION
Just noticed the repo had switched from `master` to `main`: https://github.com/google/exposure-notifications-server. Update the job so that it doesn't fail fetching `master`