### PR TITLE
Update testgrid bazel image to 2.1.0->2.2.0 variant

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-images.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-images.yaml
@@ -7,10 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:2.1.0
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real # Ignore .bazelversion in CI
+      - image: gcr.io/k8s-prow/launcher.gcr.io/google/bazel:v20200707-f1683e2-testgrid
         command:
         - bazel
         args:


### PR DESCRIPTION
Image built from https://github.com/kubernetes/test-infra/pull/18202