### PR TITLE
Update testgrid bazel image to 2.1.0->3.0.0 variant

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-images.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-images.yaml
@@ -7,10 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:2.1.0
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real # Ignore .bazelversion in CI
+      - image: gcr.io/k8s-prow/launcher.gcr.io/google/bazel:v20200708-6aff115-testgrid
         command:
         - bazel
         args:


### PR DESCRIPTION
Supercedes https://github.com/GoogleCloudPlatform/oss-test-infra/pull/426

Image built from https://github.com/kubernetes/test-infra/pull/18204

To support https://github.com/GoogleCloudPlatform/testgrid/pull/141