### PR TITLE
Fix typo in bazel image repo

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-images.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-images.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-prow/launcher.gcr.io/google/bazel:v20200708-6aff115-testgrid
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20200708-6aff115-testgrid
         command:
         - bazel
         args:


### PR DESCRIPTION
Fix typo introduced in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/427

I'm slightly confused because I copied the image name from https://storage.googleapis.com/kubernetes-jenkins/logs/post-test-infra-push-bazel/1280659794998333441/build-log.txt

So not sure how I should have known this ends up in the k8s-testimages repo instead