### PR TITLE
Fix prow config validate job by using relative path

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -67,7 +67,7 @@ presubmits:
             - /checkconfig
           args:
             - --config-path=./prow/knative/config.yaml
-            - --job-config-path=${GOPATH}/src/github.com/knative/test-infra/config/prod/prow/jobs
+            - --job-config-path=../../knative/test-infra/config/prod/prow/jobs
             - --plugin-config=prow/knative/plugins.yaml
             - --strict
             # This warning can forbid valid (and convenient) config. Exclude it.


### PR DESCRIPTION
The current job failed https://github.com/GoogleCloudPlatform/oss-test-infra/pull/432

```
{"component":"unset","error":"stat ${GOPATH}/src/github.com/knative/test-infra/config/prod/prow/jobs: no such file or directory","file":"prow/config/agent.go:314","func":"k8s.io/test-infra/prow/config.lastConfigModTime","jobConfig":"${GOPATH}/src/github.com/knative/test-infra/config/prod/prow/jobs","level":"error","msg":"Error loading job configs.","severity":"error","time":"2020-07-10T15:16:36Z"}
```

Use relative path should solve this problem.

Link for failed run: https://oss-prow.knative.dev/view/gcs/oss-prow/pr-logs/pull/GoogleCloudPlatform_oss-test-infra/432/pull-knative-prow-config-validate/1281608234565636096

/cc @fejta @chizhg 
