### PR TITLE
Ignore long job name in knative prow config check

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -74,6 +74,7 @@ presubmits:
             # Details: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/131#discussion_r334208082
             - --exclude-warning=mismatched-tide
             - --exclude-warning=non-decorated-jobs
+            - --exclude-warning=long-job-names
 
 postsubmits:
   GoogleCloudPlatform/oss-test-infra:


### PR DESCRIPTION
Config check still failed, this time it's due to long job name. Updated the checkconfig job to also exclude long job name. Verified with checkconfig job in knative and there should be no more flag missing

Failed run: https://oss-prow.knative.dev/view/gcs/oss-prow/pr-logs/pull/GoogleCloudPlatform_oss-test-infra/432/pull-knative-prow-config-validate/1281675679175282688

/cc @fejta @chizhg 