### PR TITLE
Knative prow deployment define namespaces

### DIFF
--- a/prow/knative/cluster/400-crier.yaml
+++ b/prow/knative/cluster/400-crier.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: crier
+  namespace: default
   labels:
     app: crier
 spec:

--- a/prow/knative/cluster/400-deck.yaml
+++ b/prow/knative/cluster/400-deck.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: deck
+  namespace: default
   labels:
     app: deck
 spec:

--- a/prow/knative/cluster/400-hook.yaml
+++ b/prow/knative/cluster/400-hook.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: hook
+  namespace: default
   labels:
     app: hook
 spec:

--- a/prow/knative/cluster/400-horologium.yaml
+++ b/prow/knative/cluster/400-horologium.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: horologium
+  namespace: default
   labels:
     app: horologium
 spec:

--- a/prow/knative/cluster/400-ingress.yaml
+++ b/prow/knative/cluster/400-ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: deck-ing
+  namespace: default
   annotations:
     kubernetes.io/ingress.class: "gce"
     kubernetes.io/ingress.global-static-ip-name: prow-ingress

--- a/prow/knative/cluster/400-plank.yaml
+++ b/prow/knative/cluster/400-plank.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: plank
+  namespace: default
   labels:
     app: plank
 spec:

--- a/prow/knative/cluster/400-sinker.yaml
+++ b/prow/knative/cluster/400-sinker.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: sinker
+  namespace: default
   labels:
     app: sinker
 spec:

--- a/prow/knative/cluster/400-tide.yaml
+++ b/prow/knative/cluster/400-tide.yaml
@@ -17,6 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tide
+  namespace: default
 spec:
   selector:
     app: tide


### PR DESCRIPTION
Knative prow deployment definition has never had namespace defined. Not sure how `kubectl apply -f` magically figured out deploying prow components in default namespace. After migrating here they were deployed to test-pods namespace instead. 

Explicitly setting namespace to fix this problem

/cc @chizhg @BenTheElder 