### PR TITLE
Enable slack reporter for crier

### DIFF
--- a/prow/knative/cluster/400-crier.yaml
+++ b/prow/knative/cluster/400-crier.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200710-f1d386e7c4
+        image: gcr.io/k8s-prow/crier:v20200717-96f632166e
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
         - --blob-storage-workers=1
@@ -43,6 +43,8 @@ spec:
         - --github-workers=5
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --slack-workers=1
+        - --slack-token-file=/etc/slack/token
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
@@ -58,6 +60,9 @@ spec:
           readOnly: true
         - name: service-account
           mountPath: /etc/service-account
+          readOnly: true
+        - name: slack
+          mountPath: /etc/slack
           readOnly: true
       volumes:
       - name: config
@@ -76,3 +81,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: slack
+        secret:
+          secretName: slack-token

--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 plank:
   job_url_template: 'https://prow.knative.dev/view/gcs/knative-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_templates:
@@ -37,6 +38,17 @@ plank:
           requests:
             cpu: 100m
             memory: 20Mi
+
+slack_reporter_configs:
+  "*":
+    # Do not report any job types by default.
+    job_types_to_report:
+    # Do not report any job states by default.
+    job_states_to_report:
+    # By default reporting to the test channel, it is required so it has to be set here.
+    channel: test
+    report_template: "Job `{{.Spec.Job}}` ended with state *{{.Status.State}}*: <{{.Status.URL}}|View logs>"
+
 deck:
   spyglass:
     size_limit: 500000000 # 500MB
@@ -104,9 +116,11 @@ deck:
     '*':
       github_team_ids:
         - 3012514 # Knative Milestone Maintainers
+
 prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug
+
 branch-protection:
   orgs:
     knative:
@@ -121,6 +135,7 @@ branch-protection:
     google:
       protect: true
       enforce_admins: false
+
 tide:
   queries:
   - orgs:


### PR DESCRIPTION
1. Enable slack reporter for crier, based on the doc in https://github.com/kubernetes/test-infra/tree/master/prow/crier#slack-reporter. Please note I have created the `slack-token` on the Prow cluster, so it is now safe to update crier deployment.

2. Add `slack_reporter_configs` in the Prow core config file. Please note the job types to report is now empty, so this config will be a no-op and won't report any jobs. I will create followup PRs in knative/test-infra repo to enable this reporter for the specific jobs that we want.

/cc @chaodaiG 