### PR TITLE
Remove legacy gcs/ suffix from job_url_prefix_config for both Knative and OSS Prow.

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -17,7 +17,7 @@ plank:
   report_templates:
     '*': '[Full PR test history](https://gubernator.knative.dev/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.knative.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
   job_url_prefix_config:
-    '*': https://prow.knative.dev/view/gcs/
+    '*': https://prow.knative.dev/view/
   pod_pending_timeout: 60m
   default_decoration_configs:
     '*':

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -48,7 +48,7 @@ tide:
 
 plank:
   job_url_prefix_config:
-    '*': https://oss-prow.knative.dev/view/gcs/
+    '*': https://oss-prow.knative.dev/view/
   pod_pending_timeout: 15m
   pod_unscheduled_timeout: 1m
   default_decoration_configs:


### PR DESCRIPTION
> configuring the 'gcs/' storage provider suffix in the job url prefix is now deprecated, please configure the job url prefix without the suffix as it's now appended automatically. Handling of the old configuration will be removed in September 2020

/assign @chaodaiG @e-blackwelder