### PR TITLE
Add a regex in spyglass to highlight go build OOM error

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -86,21 +86,25 @@ deck:
           - 'timeout waiting for pods to come up'
           # Prow job killed
           - 'Entrypoint received interrupt: terminated'
+          # Go build failure due to OOM
+          - '"go build": signal: killed'
           # Code is outdated
           # TODO(chizhg): this error message should be defined by the common test infrastructure
           - 'Please run .*hack/update-codegen.sh'
           # Metrics are logged only for Pods in a failed test.
           - 'Metrics logs'
           # Compile error - unused import.
-          - "imported and not used:"
+          - 'imported and not used:'
           # Compile error - unused variable.
-          - "declared but not used"
+          - 'declared but not used'
           # Compile error - undefined variable.
-          - "undefined:"
+          - 'undefined:'
           # Compile error - not enough arguments.
-          - "not enough arguments in call to "
+          - 'not enough arguments in call to '
+          # Compile error - too many arguments.
+          - 'too many arguments in call to '
           # Compile error - incorrect argument type.
-          - "cannot use .* \\(type .*\\) as type .* in argument to"
+          - 'cannot use .* \\(type .*\\) as type .* in argument to'
       required_files:
       - build-log.txt
     - lens:


### PR DESCRIPTION
When this error happens, the log file is usually very large, so it would be helpful to highlight the error line in Spyglass.

/cc @chaodaiG 