### PR TITLE
Add prow job for disk-inspection-pytest.

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -13,7 +13,20 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/main.sh"
-        
+  - name: boot-inspect-pytest
+    cluster: gcp-guest
+    run_if_changed: 'daisy_workflows/image_import/inspection/.*'
+    trigger: "(?m)^/pytest-boot-inspect$"
+    rerun_command: "/pytest-boot-inspect"
+    context: prow/presubmit/pytest/boot-inspect
+    decorate: true
+    spec:
+      containers:
+        - image: gcr.io/gcp-guest/pytest:latest
+          imagePullPolicy: Always
+          command:
+            - "/main.py"
+          args: ["daisy_workflows/image_import/inspection"]
   - name: cli-tools-presubmit-gocheck
     cluster: gcp-guest
     run_if_changed: 'cli_tools/.*'


### PR DESCRIPTION
This adds a presubmit for https://github.com/GoogleCloudPlatform/compute-image-tools.




[local-results.zip](https://github.com/GoogleCloudPlatform/oss-test-infra/files/5100408/local-results.zip) contains the output from running the job locally. Ideally I'd like to verify the results on `spyglass`; I tried setting up a local prow instance with [runlocal](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/deck/runlocal), but that resulted in *many* build failures.

So: Any ideas on how to view this on a spyglass instance?

Testing:
 * `bash pj-on-kind.sh boot-inspect-pytest`
 * PR: https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1326

Output structure:
```
tree /mnt/disks/prowjob-out/boot-inspect-pytest/1296276119707717632
/mnt/disks/prowjob-out/boot-inspect-pytest/1296276119707717632
├── artifacts
│   ├── junit_py35.xml
│   ├── junit_py36.xml
│   ├── junit_py37.xml
│   ├── junit_py38.xml
│   └── tox
│       ├── py35
│       │   ├── py35-0.log
│       │   ├── py35-1.log
│       │   ├── py35-2.log
│       │   └── py35-3.log
│       ├── py36
│       │   ├── py36-0.log
│       │   ├── py36-1.log
│       │   ├── py36-2.log
│       │   └── py36-3.log
│       ├── py37
│       │   ├── py37-0.log
│       │   ├── py37-1.log
│       │   ├── py37-2.log
│       │   └── py37-3.log
│       ├── py38
│       │   ├── py38-0.log
│       │   ├── py38-1.log
│       │   ├── py38-2.log
│       │   └── py38-3.log
│       ├── pyproject.toml
│       └── tox.ini
├── build-log.txt
├── clone-log.txt
├── clone-records.json
├── finished.json
└── started.json
```