### PR TITLE
Add a canary e2e test job for en server

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -34,6 +34,38 @@ presubmits:
       - name: gcs-access-service-account
         secret:
           secretName: gcs-access-service-account
+  - name: pull-en-server-release-e2e-canary
+    cluster: build-apollo-server
+    always_run: false
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/cloud-devrel-public-resources/exposure-notifications/presubmit-test
+        command:
+        - /bin/runner.sh
+        args:
+        - ./scripts/e2e-test.sh
+        env:
+        - name: GO111MODULE
+          value: "on"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/e2e-test-service-account/service-account.json
+        volumeMounts:
+        - name: e2e-test-service-account
+          mountPath: /etc/e2e-test-service-account
+        securityContext:
+          # We run docker-in-docker which requires privileged mode
+          privileged: true
+        resources:
+          requests:
+            cpu: 7
+            memory: '16Gi'
+      volumes:
+      - name: e2e-test-service-account
+        secret:
+          secretName: e2e-test-service-account
 periodics:
   - cron: "0 */3 * * *"  # Run every 3 hours
     name: ci-en-server-performance


### PR DESCRIPTION
Setting up this canary job for quickly figuring out what's required for running smoke test based on terraform deployment.

Note: this canary job will not be triggered automatically, so will not block PRs.