### PR TITLE
Revert "[ESPv2] Temporarily increase continuous test frequency"

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -555,7 +555,7 @@ presubmits:
 periodics:
   - name: ESPv2-continuous-build
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic
@@ -584,7 +584,7 @@ periodics:
             secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-presubmit
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic
@@ -613,7 +613,7 @@ periodics:
             secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-presubmit-asan
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic
@@ -642,7 +642,7 @@ periodics:
             secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-presubmit-tsan
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic
@@ -671,7 +671,7 @@ periodics:
             secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-coverage
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic
@@ -700,7 +700,7 @@ periodics:
           secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-gke-e2e-http-bookstore-managed
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
         timeout: 5h
@@ -764,7 +764,7 @@ periodics:
             secretName: cloudesf-ssh-key-secret
   - name: ESPv2-continuous-gke-e2e-http-bookstore-managed-using-sa-cred
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -828,7 +828,7 @@ periodics:
           secretName: cloudesf-ssh-key-secret
   - name: ESPv2-continuous-gke-e2e-grpc-echo-managed
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -892,7 +892,7 @@ periodics:
             secretName: cloudesf-ssh-key-secret
   - name: ESPv2-continuous-gke-e2e-grpc-interop-managed
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -956,7 +956,7 @@ periodics:
             secretName: cloudesf-ssh-key-secret
   - name: ESPv2-continuous-anthos-cloud-run-e2e-cloud-run-http-bookstore
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -1018,7 +1018,7 @@ periodics:
             secretName: cloudesf-ssh-key-secret
   - name: ESPv2-continuous-cloud-run-e2e-cloud-run-http-bookstore
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -1049,7 +1049,7 @@ periodics:
             secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-cloud-run-e2e-cloud-function-http-bookstore
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -1080,7 +1080,7 @@ periodics:
             secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-cloud-run-e2e-app-engine-http-bookstore
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -1111,7 +1111,7 @@ periodics:
           secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-cloud-run-e2e-cloud-run-grpc-echo
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     decoration_config:
       timeout: 5h
@@ -1142,7 +1142,7 @@ periodics:
             secretName: cloudesf-testing-github-prow-service-account
   - name: ESPv2-continuous-e2e-gcloud-build-image
     cluster: espv2
-    cron: '10 * * * *' # Run every hour at minute 10.
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic


### PR DESCRIPTION
This reverts commit f810c97b. The release is done, we will setup a way to manually trigger these jobs in the future.

Prefer to revert this soon, as the periodic jobs keep overwriting the endpoints service, making it hard to test https://github.com/GoogleCloudPlatform/esp-v2/pull/287.

Signed-off-by: Teju Nareddy <nareddyt@google.com>