### PR TITLE
Add hmac Prow postsubmit job

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -75,6 +75,14 @@ prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug
 
+managed_webhooks:
+  # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.
+  respect_legacy_global_token: true
+  # Config for orgs and repos that have been onboarded to this Prow instance.
+  org_repo_config:
+#    [org_name]/[repo_name]:
+#      token_created_after: 2020-08-18T00:10:00Z
+
 deck:
   spyglass:
     size_limit: 500000000 # 500MB

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -146,6 +146,47 @@ postsubmits:
       - name: github
         secret:
           secretName: oauth-token
+  - name: post-oss-test-infra-reconcile-hmacs
+    cluster: test-infra-trusted
+    run_if_changed: 'prow/oss/config.yaml'
+    decorate: true
+    annotations:
+      testgrid-dashboards: googleoss-test-infra
+      testgrid-tab-name: hmacs-reconcilation
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/hmac:v20200808-0caff2cd1b
+        command:
+        - /hmac
+        args:
+        - --config-path=prow/oss/config.yaml
+        - --hook-url=https://oss-prow.knative.dev/hook
+        - --hmac-token-secret-name=hmac-token
+        - --hmac-token-key=hmac
+        - --kubeconfig=/etc/kubeconfig/config
+        - --kubeconfig-context=prow-services
+        - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy.default.svc.cluster.local
+        - --github-endpoint=https://api.github.com
+        - --dry-run=false
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-services
+      - name: oauth
+        secret:
+          defaultMode: 420
+          secretName: oauth-token
   GoogleCloudPlatform/testgrid:
   - name: push-testgrid-images
     cluster: test-infra-trusted


### PR DESCRIPTION
Add hmac Prow postsubmit job for reconciling hmacs token secret when we use the config.yaml file to onboard new orgs/repos.

Note merging this PR will only add this Prow job, and the job will only be triggered in the next time config.yaml is updated.

/cc @cjwagner 