### PR TITLE
Revert "Update knative boskos to use new image path, as well as update it to …"

### DIFF
--- a/prow/knative/cluster/build/400-boskos-deployment.yaml
+++ b/prow/knative/cluster/build/400-boskos-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-staging-boskos/boskos:v20200717-7299d53
+        image: gcr.io/k8s-prow/boskos/boskos:v20200406-3d3428b91
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/prow/knative/cluster/build/400-boskos-janitor.yaml
+++ b/prow/knative/cluster/build/400-boskos-janitor.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-staging-boskos/janitor:v20200717-7299d53
+        image: gcr.io/k8s-prow/boskos/janitor:v20200406-3d3428b91
         args:
         - --resource-type=gke-project
         - --

--- a/prow/knative/cluster/build/400-boskos-metrics.yaml
+++ b/prow/knative/cluster/build/400-boskos-metrics.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-staging-boskos/metrics:v20200717-7299d53
+        image: gcr.io/k8s-prow/boskos/metrics:v20200327-4e1ed20bb
         args:
         - --resource-type=gke-project
         ports:

--- a/prow/knative/cluster/build/400-boskos-reaper.yaml
+++ b/prow/knative/cluster/build/400-boskos-reaper.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-staging-boskos/reaper:v20200717-7299d53
+        image: gcr.io/k8s-prow/boskos/reaper:v20200406-3d3428b91
         args:
         - --resource-type=gke-project
         resources:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/oss-test-infra#473

Knative Boskos is broken, too many projects are in cleaning state and there are a lot of Janitor error logs.

/cc @chaodaiG 