### PR TITLE
Allow Knative PJs to be aborted without completion time.

### DIFF
--- a/prow/knative/cluster/300-crds.yaml
+++ b/prow/knative/cluster/300-crds.yaml
@@ -59,6 +59,5 @@ spec:
                   - "success"
                   - "failure"
                   - "error"
-                  - "aborted"
           - required:
             - completionTime


### PR DESCRIPTION
This is causing errors when hook tries to abort presubmits for PRs that are closed.
/assign @chaodaiG 