### PR TITLE
[ESPv2] Use any stable gke release, don't pin to 1.14

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -138,7 +138,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable-1.14
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -197,7 +197,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable-1.14
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -256,7 +256,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable-1.14
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -315,7 +315,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable-1.14
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -385,7 +385,7 @@ presubmits:
         - --test-cmd=../prow/gcpproxy-e2e.sh
         - --test-cmd-name=gcpproxy_e2e
         - --timeout=80m
-        - --extract=release/stable-1.14
+        - --extract=release/stable
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -717,7 +717,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=release/stable-1.14
+            - --extract=release/stable
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -781,7 +781,7 @@ periodics:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable-1.14
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-c
         - --gcp-network=default
@@ -845,7 +845,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=release/stable-1.14
+            - --extract=release/stable
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -909,7 +909,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=release/stable-1.14
+            - --extract=release/stable
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -983,7 +983,7 @@ periodics:
             - --test-cmd=../prow/e2e-anthos-cloud-run-anthos-cloud-run-http-bookstore.sh
             - --test-cmd-name=gcpproxy_e2e
             - --timeout=300m
-            - --extract=release/stable-1.14
+            - --extract=release/stable
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Just `release/stable` should work:

https://github.com/kubernetes/test-infra/blob/fd124b768d9e95177125c6f3d19b3af8b5e71a03/kubetest/extract_k8s.go#L49

Fixes all the test failures currently due to GKE not supporting 1.14:

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=No valid versions with the prefix "1.14.10" found.
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>