### PR TITLE
[ESPv2] Pin to a specific release version

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -138,7 +138,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable
+        - --extract=v1.16.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -197,7 +197,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable
+        - --extract=v1.16.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -256,7 +256,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable
+        - --extract=v1.16.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -315,7 +315,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable
+        - --extract=v1.16.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -385,7 +385,7 @@ presubmits:
         - --test-cmd=../prow/gcpproxy-e2e.sh
         - --test-cmd-name=gcpproxy_e2e
         - --timeout=80m
-        - --extract=release/stable
+        - --extract=v1.16.13
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -717,7 +717,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=release/stable
+            - --extract=v1.16.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -781,7 +781,7 @@ periodics:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=release/stable
+        - --extract=v1.16.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-c
         - --gcp-network=default
@@ -845,7 +845,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=release/stable
+            - --extract=v1.16.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -909,7 +909,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=release/stable
+            - --extract=v1.16.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -983,7 +983,7 @@ periodics:
             - --test-cmd=../prow/e2e-anthos-cloud-run-anthos-cloud-run-http-bookstore.sh
             - --test-cmd-name=gcpproxy_e2e
             - --timeout=300m
-            - --extract=release/stable
+            - --extract=v1.16.13
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
- `release/stable` using 1.18, which is not supported in GKE yet.
- `release/stable-1.16` would use 1.16.14, which is also not supported on GKE yet.
- So just provide a valid patch version that is supported.

Signed-off-by: Teju Nareddy <nareddyt@google.com>