### PR TITLE
Exclude archived repos to get rid of the Tide warnings

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -145,6 +145,12 @@ tide:
   - orgs:
     - "knative"
     - "knative-sandbox"
+    excludedRepos:
+    - knative/build
+    - knative/build-templates
+    - knative/eventing-operator
+    - knative/serving-operator
+    - knative/observability
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
Exclude archived repos to get rid of the Tide warnings

/cc @cjwagner @chaodaiG 