### PR TITLE
Removing deprecated `github-token-path` plank arg

### DIFF
--- a/prow/oss/cluster/cluster.yaml
+++ b/prow/oss/cluster/cluster.yaml
@@ -91,7 +91,6 @@ spec:
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --dry-run=false
-        - --github-token-path=
         - --skip-report=true
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config


### PR DESCRIPTION
Which was removed in https://github.com/kubernetes/test-infra/commit/2408556a40ad1b0f117c41ac3f90a170aa842a4f