### PR TITLE
Remove deprecated plank arg

### DIFF
--- a/prow/oss/cluster/cluster.yaml
+++ b/prow/oss/cluster/cluster.yaml
@@ -91,7 +91,6 @@ spec:
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --dry-run=false
-        - --skip-report=true
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         volumeMounts:


### PR DESCRIPTION
Removing `skip-report` flag since it's going to be deprecated real soon: https://github.com/kubernetes/test-infra/blob/a4333b6022cbc19d82eaf6058d4ae4086619e5d5/prow/cmd/plank/main.go#L59

/assign @e-blackwelder 