### PR TITLE
En server: email notify if prow jobs failed

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -78,6 +78,8 @@ periodics:
     annotations:
       testgrid-dashboards: googleoss-en-server
       testgrid-tab-name: terrafrom-smoke
+      testgrid-alert-email: en-server-prow-test-alert@google.com
+      testgrid-num-failures-to-alert: '1'
     labels:
       preset-dind-enabled: "true"
     spec:
@@ -117,6 +119,8 @@ periodics:
     annotations:
       testgrid-dashboards: googleoss-en-server
       testgrid-tab-name: performance
+      testgrid-alert-email: en-server-prow-test-alert@google.com
+      testgrid-num-failures-to-alert: '1'
     labels:
       preset-dind-enabled: "true"
     spec:

--- a/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
@@ -75,6 +75,8 @@ periodics:
     annotations:
       testgrid-dashboards: googleoss-en-server
       testgrid-tab-name: verification-terrafrom-smoke
+      testgrid-alert-email: en-server-prow-test-alert@google.com
+      testgrid-num-failures-to-alert: '1'
     labels:
       preset-dind-enabled: "true"
     spec:


### PR DESCRIPTION
The alerts will be sent to a google group, so far I'm the only one in the group

/cc @sethvargo @icco 