### PR TITLE
compute-image-tools: periodic for boot inspection

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -1,3 +1,32 @@
+periodics:
+  - name: disk-inspect
+    interval: 4h
+    cluster: gcp-guest
+    decorate: true
+    extra_refs:
+      - org: GoogleCloudPlatform
+        repo: compute-image-tools
+        base_ref: master
+        workdir: true
+    labels:
+      preset-daisy: "true"
+    annotations:
+      testgrid-dashboards: googleoss-compute-image-tools
+      testgrid-tab-name: disk-inspect
+    spec:
+      containers:
+        - image: gcr.io/gcp-guest/gotest:latest
+          imagePullPolicy: Always
+          command:
+            - "/go/main.sh"
+          args: ["cli_tools_e2e_test/diskinspect"]
+          env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: compute-image-tools-test
+            - name: GOOGLE_CLOUD_ZONE
+              value: us-west1-b
+
+
 presubmits:
   GoogleCloudPlatform/compute-image-tools:
   - name: compute-image-tools-flake8

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1,6 +1,7 @@
 # Dashboards need to be specified here to be created on TestGrid
 # A prow annotation will be invalid if it references a dashboard that doesn't exist
 dashboards:
+- name: googleoss-compute-image-tools
 - name: googleoss-gcp-guest
 - name: googleoss-test-infra
 - name: googleoss-esp-v2-presubmit
@@ -10,6 +11,7 @@ dashboards:
 dashboard_groups:
   - name: googleoss
     dashboard_names:
+    - googleoss-compute-image-tools
     - googleoss-gcp-guest
     - googleoss-test-infra
     - googleoss-esp-v2-presubmit


### PR DESCRIPTION
This configures the `gcp-guest` to periodically run a new integ test. PR for test: https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1354

## Testing
* Ran on Prow using pj-on-kind
    * spyglass view of test results: https://oss-prow.knative.dev/view/gs/edens-test-prow/e2e/1305548384181948416/
    * The PR includes an intentionally-failing test that needs to be fixed