### PR TITLE
Bump oss-prow from v20200921-becd8c9356 to v20200925-a1858f46d6

### DIFF
--- a/prow/oss/cluster/controller-manager.yaml
+++ b/prow/oss/cluster/controller-manager.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/prow-controller-manager:v20200925-a1858f46d6
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/crier:v20200925-a1858f46d6
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/deck:v20200925-a1858f46d6
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/gerrit.yaml
+++ b/prow/oss/cluster/gerrit.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: gerrit
-        image: gcr.io/k8s-prow/gerrit:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/gerrit:v20200925-a1858f46d6
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/ghproxy.yaml
+++ b/prow/oss/cluster/ghproxy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/ghproxy:v20200925-a1858f46d6
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=49

--- a/prow/oss/cluster/grandmatriarch_default.yaml
+++ b/prow/oss/cluster/grandmatriarch_default.yaml
@@ -69,6 +69,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/grandmatriarch:v20200925-a1858f46d6
         args:
         - http-cookiefile

--- a/prow/oss/cluster/grandmatriarch_test-pods.yaml
+++ b/prow/oss/cluster/grandmatriarch_test-pods.yaml
@@ -74,6 +74,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/grandmatriarch:v20200925-a1858f46d6
         args:
         - http-cookiefile

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/hook:v20200925-a1858f46d6
         imagePullPolicy: Always
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200630

--- a/prow/oss/cluster/horologium.yaml
+++ b/prow/oss/cluster/horologium.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/horologium:v20200925-a1858f46d6
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/plank.yaml
+++ b/prow/oss/cluster/plank.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: plank
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/plank:v20200925-a1858f46d6
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --dry-run=false

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/sinker:v20200925-a1858f46d6
         args:
         - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200921-becd8c9356
+        image: gcr.io/k8s-prow/tide:v20200925-a1858f46d6
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -56,10 +56,10 @@ plank:
       timeout: 7200000000000 # 2h
       grace_period: 15000000000 # 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200921-becd8c9356"
-        initupload: "gcr.io/k8s-prow/initupload:v20200921-becd8c9356"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200921-becd8c9356"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20200921-becd8c9356"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200925-a1858f46d6"
+        initupload: "gcr.io/k8s-prow/initupload:v20200925-a1858f46d6"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200925-a1858f46d6"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20200925-a1858f46d6"
       gcs_configuration:
         bucket: "oss-prow"
         path_strategy: "explicit"

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20200921-becd8c9356
+        - image: gcr.io/k8s-prow/checkconfig:v20200925-a1858f46d6
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -61,7 +61,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20200921-becd8c9356
+        - image: gcr.io/k8s-prow/checkconfig:v20200925-a1858f46d6
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -157,7 +157,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/hmac:v20200921-becd8c9356
+      - image: gcr.io/k8s-prow/hmac:v20200925-a1858f46d6
         command:
         - /hmac
         args:
@@ -254,7 +254,7 @@ periodics:
     testgrid-tab-name: autobump-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200921-becd8c9356
+    - image: gcr.io/k8s-prow/autobump:v20200925-a1858f46d6
       command:
       - /autobump.sh
       args:
@@ -297,7 +297,7 @@ periodics:
     testgrid-tab-name: autobump-knative-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20200921-becd8c9356
+    - image: gcr.io/k8s-prow/autobump:v20200925-a1858f46d6
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
Manually created with the bump script since autobump is treating it as a no-op despite a merge conflict in the previous PR. (See https://github.com/GoogleCloudPlatform/oss-test-infra/pull/517)