### PR TITLE
Knative prow: default job cpu limit to 10

### DIFF
--- a/prow/knative/cluster/200-cpu-limitrange.yaml
+++ b/prow/knative/cluster/200-cpu-limitrange.yaml
@@ -19,8 +19,6 @@ metadata:
   namespace: test-pods
 spec:
   limits:
-    - default:
-        cpu: 8000m
-      defaultRequest:
+    - defaultRequest:
         cpu: 2000m
       type: Container

--- a/prow/knative/cluster/200-cpu-limitrange.yaml
+++ b/prow/knative/cluster/200-cpu-limitrange.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   limits:
     - default:
-        cpu: 4000m
+        cpu: 8000m
       defaultRequest:
         cpu: 2000m
       type: Container

--- a/prow/knative/cluster/200-memory-limitrange.yaml
+++ b/prow/knative/cluster/200-memory-limitrange.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   limits:
     - default:
-        memory: 8Gi
+        memory: 10Gi
       defaultRequest:
         memory: 8Gi
       type: Container


### PR DESCRIPTION
Knative serving compilation is CPU intensive, the e2e jobs transiently need to use up to 10 CPUs and get a great performance gain (from 7 minutes to 2 minutes). And the CPU spike only in the second half, which is  ~ 1 minute out of 30 - 50 minutes. So the chance of multiple jobs spiking the exactly the same time is not very high