### PR TITLE
Revert "Update oss-prow kubeconfig to config-20201002."

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -32,7 +32,7 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --github-workers=1
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config-20201002
+        - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --kubernetes-blob-storage-workers=1
         volumeMounts:
         - name: cookies

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -26,7 +26,7 @@ spec:
       - name: deck
         image: gcr.io/k8s-prow/deck:v20200925-a1858f46d6
         args:
-        - --kubeconfig=/etc/kubeconfig/config-20201002
+        - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --spyglass=true

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -28,7 +28,7 @@ spec:
         image: gcr.io/k8s-prow/hook:v20200925-a1858f46d6
         imagePullPolicy: Always
         args:
-        - --kubeconfig=/etc/kubeconfig/config-20201002
+        - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false

--- a/prow/oss/cluster/plank.yaml
+++ b/prow/oss/cluster/plank.yaml
@@ -20,7 +20,7 @@ spec:
       - name: plank
         image: gcr.io/k8s-prow/plank:v20200925-a1858f46d6
         args:
-        - --kubeconfig=/etc/kubeconfig/config-20201002
+        - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -21,7 +21,7 @@ spec:
       - name: sinker
         image: gcr.io/k8s-prow/sinker:v20200925-a1858f46d6
         args:
-        - --kubeconfig=/etc/kubeconfig/config-20201002
+        - --kubeconfig=/etc/kubeconfig/oss-config-20200630
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false


### PR DESCRIPTION
Reverts GoogleCloudPlatform/oss-test-infra#526

`"error accessing --kubeconfig: stat /etc/kubeconfig/config-20201002: no such file or directory" `