### PR TITLE
Fix oss prow autobump job path

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -271,7 +271,7 @@ periodics:
       - name: GH_REPO
         value: oss-test-infra
       - name: PLANK_DEPLOYMENT_FILE
-        value: prow/oss/cluster/cluster.yaml
+        value: prow/oss/cluster/plank.yaml
       - name: COMPONENT_FILE_DIR
         value: prow/oss/cluster
       - name: CONFIG_PATH


### PR DESCRIPTION
This job had been silently failing, fix in https://github.com/kubernetes/test-infra/pull/19454

/cc @cjwagner @fejta 