### PR TITLE
Update Knative Prow to use Google-managed SSL certificates

### DIFF
--- a/prow/knative/cluster/303-prow-knative-dev_managedcertificate.yaml
+++ b/prow/knative/cluster/303-prow-knative-dev_managedcertificate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,26 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Ingresses
-apiVersion: extensions/v1beta1
-kind: Ingress
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
 metadata:
-  name: deck-ing
-  namespace: default
-  annotations:
-    kubernetes.io/ingress.class: "gce"
-    kubernetes.io/ingress.global-static-ip-name: prow-ingress
-    networking.gke.io/managed-certificates: prow-knative-dev
+  name: prow-knative-dev
 spec:
-  rules:
-  - host: prow.knative.dev
-    http:
-      paths:
-      - path: /*
-        backend:
-          serviceName: deck
-          servicePort: 80
-      - path: /hook
-        backend:
-          serviceName: hook
-          servicePort: 8888
+  domains:
+  - prow.knative.dev


### PR DESCRIPTION
Update Knative Prow to use Google-managed SSL certificates, similar as all other Prow instances we manage. This will prevent the SSL certificates to be expired since Google Cloud can renew it automatically.

I have switched Knative Prow to use the new certificate and it's working well without downtime.

/cc @chaodaiG @coryrc 

FYI @peterfeifanchen @albertomilan