### PR TITLE
Use workload identity for Prow control plane deployments

### DIFF
--- a/prow/knative/cluster/301-rbac.yaml
+++ b/prow/knative/cluster/301-rbac.yaml
@@ -384,6 +384,8 @@ subjects:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-control-plane@knative-tests.iam.gserviceaccount.com
   name: "crier"
   namespace: default
 ---

--- a/prow/knative/cluster/400-crier.yaml
+++ b/prow/knative/cluster/400-crier.yaml
@@ -34,7 +34,6 @@ spec:
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
         - --blob-storage-workers=1
-        - --gcs-credentials-file=/etc/service-account/service-account.json # TODO(chizhg): use workload identity
         - --kubernetes-blob-storage-workers=1
         - --kubeconfig=/etc/kubeconfig/config
         - --config-path=/etc/config/config.yaml
@@ -58,9 +57,6 @@ spec:
         - name: oauth
           mountPath: /etc/github
           readOnly: true
-        - name: service-account
-          mountPath: /etc/service-account
-          readOnly: true
         - name: slack
           mountPath: /etc/slack
           readOnly: true
@@ -74,9 +70,6 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
-      - name: service-account
-        secret:
-          secretName: service-account
       - name: kubeconfig
         secret:
           defaultMode: 420


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/tree/master/workload-identity to use workload identity for Prow control plane deployments. The changes have been applied on the Knative Prow cluster and everything is still working fine.