### PR TITLE
[ESPv2] Update machine type for GKE jobs to `e2-standard-2`

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -169,7 +169,7 @@ presubmits:
         - --gcp-network=default
         - --gcp-node-image=gci
         - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-        - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+        - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
         - --gke-environment=prod
         - --provider=gke
         - --env=TEST_CASE=tight-http-bookstore-managed
@@ -228,7 +228,7 @@ presubmits:
         - --gcp-network=default
         - --gcp-node-image=gci
         - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-        - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+        - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
         - --gke-environment=prod
         - --provider=gke
         - --env=TEST_CASE=tight-http-bookstore-managed-using-sa-cred
@@ -287,7 +287,7 @@ presubmits:
         - --gcp-network=default
         - --gcp-node-image=gci
         - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-        - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+        - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
         - --gke-environment=prod
         - --provider=gke
         - --env=TEST_CASE=tight-grpc-echo-managed
@@ -346,7 +346,7 @@ presubmits:
         - --gcp-network=default
         - --gcp-node-image=gci
         - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-        - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+        - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
         - --gke-environment=prod
         - --provider=gke
         - --env=TEST_CASE=tight-grpc-interop-managed
@@ -403,6 +403,8 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --gcp-network=default
         - --gcp-node-image=gci
+        - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
+        - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
         - --gke-environment=prod
         - --provider=gke
         - --env=TEST_CASE=anthos-cloud-run-anthos-cloud-run-http-bookstore
@@ -748,7 +750,7 @@ periodics:
             - --gcp-network=default
             - --gcp-node-image=gci
             - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-            - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+            - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
             - --gke-environment=prod
             - --provider=gke
             - --test=false
@@ -812,7 +814,7 @@ periodics:
         - --gcp-network=default
         - --gcp-node-image=gci
         - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-        - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+        - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
         - --gke-environment=prod
         - --provider=gke
         - --test=false
@@ -876,7 +878,7 @@ periodics:
             - --gcp-network=default
             - --gcp-node-image=gci
             - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-            - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+            - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
             - --gke-environment=prod
             - --provider=gke
             - --test=false
@@ -940,7 +942,7 @@ periodics:
             - --gcp-network=default
             - --gcp-node-image=gci
             - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
-            - '--gke-shape={"default":{"Nodes":1,"MachineType":"n1-standard-2"}}'
+            - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
             - --gke-environment=prod
             - --provider=gke
             - --test=false
@@ -1002,6 +1004,8 @@ periodics:
             - --gcp-zone=us-west1-c
             - --gcp-network=default
             - --gcp-node-image=gci
+            - --gke-create-command=container clusters create --cluster-ipv4-cidr=/19 --quiet
+            - '--gke-shape={"default":{"Nodes":1,"MachineType":"e2-standard-2"}}'
             - --gke-environment=prod
             - --provider=gke
             - --test=false


### PR DESCRIPTION
Some tests keep failing due to resources shortages in GCE. `e2` instances optimize against this error scenario.

Signed-off-by: Teju Nareddy <nareddyt@google.com>