### PR TITLE
Enable ghproxy cache partitioning.

### DIFF
--- a/prow/knative/cluster/400-ghproxy.yaml
+++ b/prow/knative/cluster/400-ghproxy.yaml
@@ -57,6 +57,7 @@ spec:
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99
+            - --legacy-disable-disk-cache-partitions-by-auth-header=false
           ports:
             - containerPort: 8888
           volumeMounts:

--- a/prow/oss/cluster/ghproxy.yaml
+++ b/prow/oss/cluster/ghproxy.yaml
@@ -36,6 +36,7 @@ spec:
         - --cache-dir=/cache
         - --cache-sizeGB=49
         - --serve-metrics=true
+        - --legacy-disable-disk-cache-partitions-by-auth-header=false
         ports:
         - containerPort: 8888
         - containerPort: 9090


### PR DESCRIPTION
```
The deprecated `--legacy-disable-disk-cache-partitions-by-auth-header` flags value is `true`. If you are a bigger Prow setup, you should copy your existing cache directory to the directory mentioned in the `Not using a partitioned cache because legacyDisablePartitioningByAuthHeader is true` messages to warm up the partitioned-by-auth-header cache, then set the flag to false. If you are a smaller Prow setup or just started using ghproxy you can just unconditionally set it to `false`.
```
This change will effectively reset the ghproxy caches for both of these instances which will temporarily increase GitHub API ratelimit consumption. This should be safe for the small OSS prow instance and I suspect it won't be an issue for the Knative Prow instance either, but we should merge this during non-peak hours just in case. If we do see problems we can revert this PR to fall back to the old, non-partitioned cache which will remain in the persistent volume.

/assign @chaodaiG @chizhg 
/hold