### PR TITLE
Expand regexp for junit files in Spyglass

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -110,6 +110,7 @@ deck:
     - lens:
         name: junit
       required_files:
+      # Nested folders is a valid use case  
       - artifacts(/.*/|/)junit.*\.xml
     - lens:
         name: podinfo

--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -110,7 +110,7 @@ deck:
     - lens:
         name: junit
       required_files:
-      - artifacts/junit.*\.xml
+      - artifacts(/.*/|/)junit.*\.xml
     - lens:
         name: podinfo
       required_files:


### PR DESCRIPTION
Nested folders are a valid use case which other tools are prepared for and Spyglass was omitting internal inspection. This was causing inconsistent behaviors and creating mismatching signals on researches