### PR TITLE
Update crier RBAC to support pod finalizers.

### DIFF
--- a/prow/knative/cluster/301-rbac.yaml
+++ b/prow/knative/cluster/301-rbac.yaml
@@ -412,6 +412,12 @@ rules:
   verbs:
     - "get"
     - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -92,6 +92,20 @@ rules:
     - "watch"
     - "list"
     - "patch"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+    - "events"
+  verbs:
+    - "get"
+    - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
This should resolve errors like the following:
```yaml
{
  component: "crier"   
  error: "failed to report job: failed to add finalizer to pod: failed to patch pod: pods "b7351861-0caf-11eb-9b02-0242ac110002" is forbidden: User "system:serviceaccount:default:crier" cannot patch resource "pods" in API group "" in the namespace "test-pods""   
  file: "prow/crier/controller.go:149"   
  func: "k8s.io/test-infra/prow/crier.(*reconciler).Reconcile"   
  key: "default/b7351861-0caf-11eb-9b02-0242ac110002"   
  level: "error"   
  msg: "Reconciliation failed"   
  prowjob: "b7351861-0caf-11eb-9b02-0242ac110002"   
  reporter: "gcsk8sreporter"   
}
```
/assign @fejta @e-blackwelder @chases2 