### PR TITLE
Allow deck k8s SA act as prow-control-plane Google SA

### DIFF
--- a/prow/knative/cluster/301-rbac.yaml
+++ b/prow/knative/cluster/301-rbac.yaml
@@ -55,6 +55,8 @@ rules:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-control-plane@knative-tests.iam.gserviceaccount.com
   name: "deck"
   namespace: default
 ---


### PR DESCRIPTION
I missed deck when I switched Knative Prow to use workload identity in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/535

Fixes https://github.com/GoogleCloudPlatform/oss-test-infra/issues/539

/cc @cjwagner 