### PR TITLE
Add missing "app" labels to Prow services.

### DIFF
--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -86,6 +86,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: deck
   name: deck
   namespace: default
 spec:

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -81,6 +81,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: hook
   name: hook
   namespace: default
 spec:

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -56,6 +56,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: tide
   name: tide
   namespace: default
 spec:


### PR DESCRIPTION
Servicemonitor label selectors ([e.g.](https://github.com/kubernetes/test-infra/blob/e1964383f206385c7ed6f3c16c5f5c778833b57c/config/prow/cluster/monitoring/prow_servicemonitors.yaml#L19-L21)) match against the service's labels, not the labels of the pods that back the service. The `deck`, `hook`, and `tide` services were missing labels so their servicemonitors failed to match any services to scrape. The new services that were added in this pr https://github.com/GoogleCloudPlatform/oss-test-infra/pull/548 already specify labels and are working as expected.

/assign @chaodaiG @fejta 
