### PR TITLE
Add cluster to secrets-store-csi-driver-provider-gcp

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
@@ -1,6 +1,7 @@
 presubmits:
   GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp:
   - name: prow-e2e-tests
+    cluster: secretmanager-csi-build
     decorate: true           # Decorate with Prow utilities
     always_run: true         # Run for every PR, or only when requested.
     spec:


### PR DESCRIPTION
Prow tests should execute in the build cluster: secretmanager-csi-build