### PR TITLE
EN: prow jobs running 30 minutes apart

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-server/en-server.yaml
@@ -67,7 +67,7 @@ presubmits:
         secret:
           secretName: e2e-test-service-account
 periodics:
-  - cron: "0 */2 * * *"  # Run every 2 hours
+  - cron: "0 0/2 * * *"  # Run every 2 hours starting 00:00
     name: ci-en-server-terraform-smoke
     cluster: build-apollo-server
     decorate: true
@@ -109,7 +109,7 @@ periodics:
       - name: e2e-test-service-account
         secret:
           secretName: e2e-test-service-account
-  - cron: "0 */2 * * *"  # Run every 2 hours
+  - cron: "30 0/2 * * *"  # Run every 2 hours starting 00:30
     name: ci-en-server-terraform-e2e
     cluster: build-apollo-server
     decorate: true

--- a/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
@@ -64,7 +64,7 @@ presubmits:
         secret:
           secretName: e2e-test-service-account
 periodics:
-  - cron: "0 */2 * * *"  # Run every 2 hours
+  - cron: "0 1/2 * * *"  # Run every 2 hours starting 01:00
     name: ci-en-verification-server-terraform-smoke
     cluster: build-apollo-server
     decorate: true


### PR DESCRIPTION
There are 3 jobs so far, separating them by 30 minutes apart can avoid them running at the same time, which could help with a GCS concurrent read/write conflict