### PR TITLE
Add a no op receiver as default alert receiver

### DIFF
--- a/prow/oss/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
+++ b/prow/oss/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
@@ -1,4 +1,4 @@
-# Please replace '{{ smtp_app_password }}' below with the URL of slack incoming hook
+# Please replace '{{ smtp_app_username }}' and '{{ smtp_app_password }}' below with the URL of slack incoming hook
 # before `kubectl apply -f`
 apiVersion: v1
 kind: Secret
@@ -10,10 +10,10 @@ stringData:
     global:
       resolve_timeout: 5m
       smtp_smarthost: 'smtp.gmail.com:587'
-      smtp_auth_username: ''
-      smtp_auth_identity: ''
+      smtp_auth_username: '{{ smtp_app_username }}'
+      smtp_auth_identity: '{{ smtp_app_username }}'
       smtp_auth_password: '{{ smtp_app_password }}'
-      smtp_from: ''
+      smtp_from: '{{ smtp_app_username }}'
       smtp_require_tls: true
 
     route:
@@ -21,6 +21,7 @@ stringData:
       group_wait: 30s
       group_interval: 10m
       repeat_interval: 4h
+      receiver: 'no-op-alerts'
       routes:
       - receiver: 'email-alerts'
         group_interval: 5m
@@ -33,6 +34,7 @@ stringData:
       email_configs:
       - to: 'chaodai+prow-alert@google.com,colew+prow-alert@google.com'
         text: '{{ template "custom_email_text" . }}'
+    - name: 'no-op-alerts'
 
     templates:
     - '*.tmpl'


### PR DESCRIPTION
Alert manager doesn't like the idea of no default receiver, use a no op receiver

/cc @cjwagner 