### PR TITLE
EN jobs: fix verification server e2e test job entrypoint

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
@@ -86,6 +86,7 @@ periodics:
         - /bin/runner.sh
         args:
         - ./scripts/e2e-test.sh
+        - smoke
         env:
         - name: GO111MODULE
           value: "on"


### PR DESCRIPTION
It's been updated in https://github.com/google/exposure-notifications-verification-server/pull/841

/assign @p3y1c2n 