### PR TITLE
Update container registry for KUnit GoB instance

### DIFF
--- a/prow/prowjobs/kunit-review.googlesource.com/linux/kunit-linux-config.yaml
+++ b/prow/prowjobs/kunit-review.googlesource.com/linux/kunit-linux-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       - name: shared-mem
         emptyDir: {}
       containers:
-      - image: gcr.io/kunit-presubmit/kunit
+      - image: gcr.io/kunit-prow-container-registry/kunit
         securityContext:
           privileged: true
         command:


### PR DESCRIPTION
We had to migrate our GCP project containing our container registry for
our Prow Docker image recently, so update the corresponding container
registry location in Prow.