### PR TITLE
EN: update verification server jobs scripts path

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
@@ -46,7 +46,7 @@ presubmits:
         command:
         - /bin/runner.sh
         args:
-        - ./scripts/e2e-test.sh
+        - ./scripts/ci-e2e-test.sh
         env:
         - name: GO111MODULE
           value: "on"
@@ -85,7 +85,7 @@ periodics:
         command:
         - /bin/runner.sh
         args:
-        - ./scripts/e2e-test.sh
+        - ./scripts/ci-e2e-test.sh
         - smoke
         env:
         - name: GO111MODULE


### PR DESCRIPTION
It's changed from e2e-tests.sh to ci-e2e-tests.sh in https://github.com/google/exposure-notifications-verification-server/pull/884