### PR TITLE
Add missing sinker RBAC on knative prow

### DIFF
--- a/prow/knative/cluster/301-rbac.yaml
+++ b/prow/knative/cluster/301-rbac.yaml
@@ -270,6 +270,9 @@ rules:
     verbs:
       - delete
       - list
+      - watch
+      - get
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Alertmanager warned sinker not deleting pods, this should fix it

/assign @fejta 