### PR TITLE
Fixing prow autobump by using prow controller manager as reference

### DIFF
--- a/prow/knative/cluster/400-crier.yaml
+++ b/prow/knative/cluster/400-crier.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/crier:v20201030-914f29394d
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
         - --blob-storage-workers=1

--- a/prow/knative/cluster/400-deck.yaml
+++ b/prow/knative/cluster/400-deck.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/deck:v20201030-914f29394d
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/

--- a/prow/knative/cluster/400-ghproxy.yaml
+++ b/prow/knative/cluster/400-ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20201026-f7d653694b
+          image: gcr.io/k8s-prow/ghproxy:v20201030-914f29394d
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/prow/knative/cluster/400-hook.yaml
+++ b/prow/knative/cluster/400-hook.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/hook:v20201030-914f29394d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/knative/cluster/400-horologium.yaml
+++ b/prow/knative/cluster/400-horologium.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/horologium:v20201030-914f29394d
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/knative/cluster/400-prow-controller-manager.yaml
+++ b/prow/knative/cluster/400-prow-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/prow-controller-manager:v20201030-914f29394d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/knative/cluster/400-sinker.yaml
+++ b/prow/knative/cluster/400-sinker.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/sinker:v20201030-914f29394d
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/knative/cluster/400-tide.yaml
+++ b/prow/knative/cluster/400-tide.yaml
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/tide:v20201030-914f29394d
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/knative/cluster/500-needs-rebase.yaml
+++ b/prow/knative/cluster/500-needs-rebase.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20201026-f7d653694b
+        image: gcr.io/k8s-prow/needs-rebase:v20201030-914f29394d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/knative/cluster/500-status-reconciler.yaml
+++ b/prow/knative/cluster/500-status-reconciler.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20201026-f7d653694b
+          image: gcr.io/k8s-prow/status-reconciler:v20201030-914f29394d
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -25,10 +25,10 @@ plank:
       grace_period: 15s
       utility_images:
         # Update these versions when updating plank version in cluster.yaml
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20201026-f7d653694b"
-        initupload: "gcr.io/k8s-prow/initupload:v20201026-f7d653694b"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20201026-f7d653694b"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20201026-f7d653694b"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20201030-914f29394d"
+        initupload: "gcr.io/k8s-prow/initupload:v20201030-914f29394d"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20201030-914f29394d"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20201030-914f29394d"
       gcs_configuration:
         bucket: "knative-prow"
         path_strategy: "explicit"

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -257,7 +257,7 @@ periodics:
     testgrid-tab-name: autobump-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20201026-f7d653694b
+    - image: gcr.io/k8s-prow/autobump:v20201102-45eeca6478
       command:
       - /autobump.sh
       args:
@@ -300,7 +300,7 @@ periodics:
     testgrid-tab-name: autobump-knative-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20201026-f7d653694b
+    - image: gcr.io/k8s-prow/autobump:v20201102-45eeca6478
       command:
       - /autobump.sh
       args:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -273,8 +273,8 @@ periodics:
         value: GoogleCloudPlatform
       - name: GH_REPO
         value: oss-test-infra
-      - name: PLANK_DEPLOYMENT_FILE
-        value: prow/oss/cluster/plank.yaml
+      - name: PROW_CONTROLLER_MANAGER_FILE
+        value: prow/oss/cluster/controller-manager.yaml
       - name: COMPONENT_FILE_DIR
         value: prow/oss/cluster
       - name: CONFIG_PATH
@@ -316,8 +316,8 @@ periodics:
         value: GoogleCloudPlatform
       - name: GH_REPO
         value: oss-test-infra
-      - name: PLANK_DEPLOYMENT_FILE
-        value: prow/knative/cluster/400-plank.yaml
+      - name: PROW_CONTROLLER_MANAGER_FILE
+        value: prow/knative/cluster/400-prow-controller-manager.yaml
       - name: COMPONENT_FILE_DIR
         value: prow/knative/cluster
       - name: CONFIG_PATH


### PR DESCRIPTION
It's used to be plank was the reference, but now it's replaced by prow controller manager, updating it so it works

/assign @fejta @michelle192837 @e-blackwelder 