### PR TITLE
Knative prow: define the same sinker spec as oss prow

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -126,6 +126,12 @@ prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug
 
+sinker:
+  resync_period: 1m
+  max_prowjob_age: 48h
+  max_pod_age: 48h
+  terminated_pod_ttl: 30m
+
 tide:
   queries:
   - orgs:


### PR DESCRIPTION
Sinker by default runs every hour, which is not very efficient