### PR TITLE
Add exposure notification verification server e2e test to Prow.

### DIFF
--- a/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
+++ b/prow/prowjobs/google/exposure-notifications-verification-server/en-verification-server.yaml
@@ -118,3 +118,49 @@ periodics:
       - name: e2e-test-service-account
         secret:
           secretName: e2e-test-service-account
+  - cron: "30 1/2 * * *"  # Run every 2 hours starting 01:30
+    name: ci-en-verification-server-terraform-e2e
+    cluster: build-apollo-server
+    decorate: true
+    extra_refs:
+    - org: google
+      repo: exposure-notifications-verification-server
+      base_ref: main
+    annotations:
+      testgrid-dashboards: googleoss-en-server
+      testgrid-tab-name: verification-terrafrom-e2e
+      testgrid-alert-email: en-server-prow-test-alert@google.com
+      testgrid-num-failures-to-alert: '1'
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/cloud-devrel-public-resources/exposure-notifications/presubmit-test
+        command:
+        - /bin/runner.sh
+        args:
+        - ./scripts/ci-e2e-test.sh
+        - incremental
+        env:
+        - name: GO111MODULE
+          value: "on"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/e2e-test-service-account/service-account.json
+        - name: CI_POSTGRES_IMAGE
+          value: "us-docker.pkg.dev/apollo-verification-us/mirrors/postgres:12-alpine"
+        - name: CI_REDIS_IMAGE
+          value: "us-docker.pkg.dev/apollo-verification-us/mirrors/redis:6-alpine"
+        volumeMounts:
+        - name: e2e-test-service-account
+          mountPath: /etc/e2e-test-service-account
+        securityContext:
+          # We run docker-in-docker which requires privileged mode
+          privileged: true
+        resources:
+          requests:
+            cpu: 30
+            memory: '16Gi'
+      volumes:
+      - name: e2e-test-service-account
+        secret:
+          secretName: e2e-test-service-account


### PR DESCRIPTION
Runs every 2 hours with 30 minute offset from the smoke test.