### PR TITLE
Update rbac for knative-prow.

### DIFF
--- a/prow/knative/cluster/301-rbac.yaml
+++ b/prow/knative/cluster/301-rbac.yaml
@@ -232,6 +232,21 @@ metadata:
   name: "sinker"
 rules:
   - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+  - apiGroups:
       - "prow.k8s.io"
     resources:
       - prowjobs

--- a/prow/knative/cluster/400-prow-controller-manager.yaml
+++ b/prow/knative/cluster/400-prow-controller-manager.yaml
@@ -60,6 +60,21 @@ metadata:
   namespace: default
   name: "prow-controller-manager"
 rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
See kubernetes/test-infra#19906 for more
context. Applying a similar change to our other Prow instances.