### PR TITLE
Revert "Bump oss-prow from v20201106-ea76c130fa to v20201112-00537d1bb4"

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/crier:v20201106-ea76c130fa
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/deck:v20201106-ea76c130fa
         args:
         - --kubeconfig=/etc/kubeconfig/config-20201002
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/gerrit.yaml
+++ b/prow/oss/cluster/gerrit.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: gerrit
-        image: gcr.io/k8s-prow/gerrit:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/gerrit:v20201106-ea76c130fa
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/ghproxy.yaml
+++ b/prow/oss/cluster/ghproxy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/ghproxy:v20201106-ea76c130fa
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=49

--- a/prow/oss/cluster/grandmatriarch_default.yaml
+++ b/prow/oss/cluster/grandmatriarch_default.yaml
@@ -69,6 +69,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/grandmatriarch:v20201106-ea76c130fa
         args:
         - http-cookiefile

--- a/prow/oss/cluster/grandmatriarch_test-pods.yaml
+++ b/prow/oss/cluster/grandmatriarch_test-pods.yaml
@@ -74,6 +74,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/grandmatriarch:v20201106-ea76c130fa
         args:
         - http-cookiefile

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/hook:v20201106-ea76c130fa
         imagePullPolicy: Always
         args:
         - --kubeconfig=/etc/kubeconfig/config-20201002

--- a/prow/oss/cluster/horologium.yaml
+++ b/prow/oss/cluster/horologium.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/horologium:v20201106-ea76c130fa
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/prow-controller-manager:v20201106-ea76c130fa
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/sinker:v20201106-ea76c130fa
         args:
         - --kubeconfig=/etc/kubeconfig/config-20201002
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20201112-00537d1bb4
+        image: gcr.io/k8s-prow/tide:v20201106-ea76c130fa
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -56,10 +56,10 @@ plank:
       timeout: 7200000000000 # 2h
       grace_period: 15000000000 # 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20201112-00537d1bb4"
-        initupload: "gcr.io/k8s-prow/initupload:v20201112-00537d1bb4"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20201112-00537d1bb4"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20201112-00537d1bb4"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20201106-ea76c130fa"
+        initupload: "gcr.io/k8s-prow/initupload:v20201106-ea76c130fa"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20201106-ea76c130fa"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20201106-ea76c130fa"
       gcs_configuration:
         bucket: "oss-prow"
         path_strategy: "explicit"

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20201112-00537d1bb4
+        - image: gcr.io/k8s-prow/checkconfig:v20201106-ea76c130fa
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -61,7 +61,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20201112-00537d1bb4
+        - image: gcr.io/k8s-prow/checkconfig:v20201106-ea76c130fa
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -159,7 +159,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/hmac:v20201112-00537d1bb4
+      - image: gcr.io/k8s-prow/hmac:v20201106-ea76c130fa
         command:
         - /hmac
         args:
@@ -257,7 +257,7 @@ periodics:
     testgrid-tab-name: autobump-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20201112-00537d1bb4
+    - image: gcr.io/k8s-prow/autobump:v20201106-ea76c130fa
       command:
       - /autobump.sh
       args:
@@ -300,7 +300,7 @@ periodics:
     testgrid-tab-name: autobump-knative-prow
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20201112-00537d1bb4
+    - image: gcr.io/k8s-prow/autobump:v20201106-ea76c130fa
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
This reverts commit 204e8693e333d02c75aba3d1a44248352e9cd283.

Pods stopped being scheduled after this bump; reverting