### PR TITLE
Replace the image used by pull-lint-validator with a more up-to-date …

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -27,7 +27,7 @@ presubmits:
     always_run: false
     spec:
       containers:
-        - image: quay.io/kubermatic/yamllint:0.1
+        - image: cytopia/yamllint
           imagePullPolicy: Always
           command:
             - yamllint


### PR DESCRIPTION
…image

The old image quay.io/kubermatic/yamllint hasn't been updated for 2 years, his one cytopia/yamllint is updated daily