### PR TITLE
Fix yamllint job scanning path

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -33,8 +33,7 @@ presubmits:
             - yamllint
             - -c
             - common/config/.yamllint.conf
-            - config/jobs
-            - config/prow/cluster
+            - .
   - name: pull-test-infra-go-test
     branches:
       - master


### PR DESCRIPTION
It was a bad copy/paste from somewhere else, ymal lint check should be on the entire repo