### PR TITLE
Enable cherrypicker plugin for Knative orgs

### DIFF
--- a/prow/knative/plugins.yaml
+++ b/prow/knative/plugins.yaml
@@ -198,13 +198,25 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
   knative-sandbox:
   - name: needs-rebase
     events:
       - issue_comment
       - pull_request
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request
   google/knative-gcp:
   - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request
+  - name: cherrypicker
     events:
       - issue_comment
       - pull_request


### PR DESCRIPTION
Enable cherrypicker plugin for `knative`, `knative-sandbox` and `google/knative-gcp`

/cc @chaodaiG @cjwagner 