### PR TITLE
Prometheus alerts send to google group

### DIFF
--- a/prow/knative/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
+++ b/prow/knative/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
@@ -32,7 +32,7 @@ stringData:
     receivers:
     - name: 'email-alerts'
       email_configs:
-      - to: 'mdb.cloud-kubernetes-engprod-oncall+prow-alert@google.com,chaodai+prow-alert@google.com'
+      - to: 'cloud-kubernetes-engprod-oncall+prow-alert@google.com,chaodai+prow-alert@google.com'
         text: '{{ template "custom_email_text" . }}'
         headers:
           subject: '[Knative prow] {{ template "email.default.subject" . }}'

--- a/prow/oss/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
+++ b/prow/oss/cluster/monitoring/secrets/alertmanager-prow_secret.yaml
@@ -32,7 +32,7 @@ stringData:
     receivers:
     - name: 'email-alerts'
       email_configs:
-      - to: 'mdb.cloud-kubernetes-engprod-oncall+prow-alert@google.com,chaodai+prow-alert@google.com'
+      - to: 'cloud-kubernetes-engprod-oncall+prow-alert@google.com,chaodai+prow-alert@google.com'
         text: '{{ template "custom_email_text" . }}'
         headers:
           subject: '[OSS prow] {{ template "email.default.subject" . }}'


### PR DESCRIPTION
Apparently the previous email recipient was not receiving email alerts, switch to google group should work

