### PR TITLE
Add missing ssh key secret to autobump testgrid jobs

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -277,7 +277,7 @@ postsubmits:
       testgrid-num-failures-to-alert: '3'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/generic_autobump:v20210106-34a4396
+      - image: gcr.io/k8s-testimages/generic_autobump:v20210107-f3f8a3b
         command:
         - /generic_autobump
         args:
@@ -286,10 +286,16 @@ postsubmits:
         - name: github
           mountPath: /etc/github-token
           readOnly: true
+        - name: ssh
+          mountPath: /root/.ssh
       volumes:
       - name: github
         secret:
           secretName: oauth-token
+      - name: ssh
+        secret:
+          secretName: google-oss-robot-ssh-keys
+          defaultMode: 0400
 
 periodics:
 - cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
@@ -352,7 +358,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/generic_autobump:v20210106-34a4396
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210107-f3f8a3b
       command:
       - /generic_autobump
       args:
@@ -361,10 +367,16 @@ periodics:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
+      - name: ssh
+        mountPath: /root/.ssh
     volumes:
     - name: github
       secret:
         secretName: oauth-token
+    - name: ssh
+      secret:
+        secretName: google-oss-robot-ssh-keys
+        defaultMode: 0400
 - cron: "15 15-23 * * 1-5"  # Run at 7:15-15:15 PST (15:15 UTC) Mon-Fri
   name: ci-oss-test-infra-autobump-knative-prow
   cluster: test-infra-trusted


### PR DESCRIPTION
/hold
Attempting to debug testgrid autobump. Not sure if this is all that is needed