### PR TITLE
Register 'build-kubeflow' cluster with OSS-Prow.

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -32,8 +32,11 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --github-workers=1
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config-20201002
         - --kubernetes-blob-storage-workers=1
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config-20201002:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
         - name: cookies
           mountPath: /etc/cookies
@@ -46,6 +49,9 @@ spec:
           readOnly: true
         - name: kubeconfig
           mountPath: /etc/kubeconfig
+          readOnly: true
+        - name: build-kubeflow
+          mountPath: /etc/build-kubeflow
           readOnly: true
         - name: oauth
           mountPath: /etc/github
@@ -65,6 +71,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: build-kubeflow
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-kubeflow
       - name: oauth
         secret:
           secretName: oauth-token

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -26,7 +26,6 @@ spec:
       - name: deck
         image: gcr.io/k8s-prow/deck:v20210111-f6f01a1373
         args:
-        - --kubeconfig=/etc/kubeconfig/config-20201002
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --spyglass=true
@@ -40,6 +39,10 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --cookie-secret=/etc/cookie/secret
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config-20201002:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8080
@@ -62,6 +65,9 @@ spec:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
           readOnly: true
+        - name: build-kubeflow
+          mountPath: /etc/build-kubeflow
+          readOnly: true
       volumes:
       - name: oauth-config
         secret:
@@ -82,6 +88,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: build-kubeflow
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-kubeflow
 ---
 apiVersion: v1
 kind: Service

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -28,13 +28,16 @@ spec:
         image: gcr.io/k8s-prow/hook:v20210111-f6f01a1373
         imagePullPolicy: Always
         args:
-        - --kubeconfig=/etc/kubeconfig/config-20201002
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
         - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config-20201002:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8888
@@ -57,6 +60,9 @@ spec:
         - name: kubeconfig
           mountPath: /etc/kubeconfig
           readOnly: true
+        - name: build-kubeflow
+          mountPath: /etc/build-kubeflow
+          readOnly: true
       volumes:
       - name: hmac
         secret:
@@ -77,6 +83,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: build-kubeflow
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-kubeflow
 ---
 apiVersion: v1
 kind: Service

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -25,7 +25,10 @@ spec:
         - --dry-run=false
         - --enable-controller=plank
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/config-20201002
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config-20201002:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -35,6 +38,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - name: build-kubeflow
+          mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
       - name: config
@@ -47,6 +53,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: build-kubeflow
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-kubeflow
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -21,10 +21,13 @@ spec:
       - name: sinker
         image: gcr.io/k8s-prow/sinker:v20210111-f6f01a1373
         args:
-        - --kubeconfig=/etc/kubeconfig/config-20201002
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config-20201002:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -34,6 +37,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - name: build-kubeflow
+          mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
       - name: config
@@ -46,6 +52,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: build-kubeflow
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-kubeflow
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Trying out using the `KUBECONFIG` env var rather than merging all kubeconfigs into a single secret.

See the discussions [here](https://github.com/kubernetes/test-infra/pull/18695#discussion_r466087229) and [this issue](https://github.com/kubernetes/test-infra/pull/20417) for context. Our current pattern works reasonably well, but has the downside of not showing which clusters were added in the git history. Switching to using separate secrets and the `KUBECONFIG` envvar will give us the git history we want and avoid secret size limits down the road, but at the cost of making our deployment files harder to read and making the consumers of the kubeconfig implicit rather than explicit. This tradeoff didn't seem worth it at first, but does now in retrospect.

I've already created the new secret in the cluster and confirmed that the key is `kubeconfig`:
```
secret/kubeconfig-build-kubeflow created
```

/assign @chaodaiG 