### PR TITLE
Enable trigger plugin for kubeflow repos

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -138,31 +138,10 @@ plugins:
   - lifecycle
   - override
 
-  kubeflow/arena:
-  - trigger
-
-  kubeflow/batch-predict:
-  - trigger
-
-  kubeflow/caffe2-operator:
-  - trigger
-
-  kubeflow/chainer-operator:
-  - trigger
-
-  kubeflow/common:
+  kubeflow/community:
   - trigger
 
   kubeflow/community-infra:
-  - trigger
-
-  kubeflow/examples:
-  - trigger
-
-  kubeflow/experimental-seldon:
-  - trigger
-
-  kubeflow/fairing:
   - trigger
 
   kubeflow/gcp-blueprints:
@@ -171,43 +150,16 @@ plugins:
   kubeflow/internal-acls:
   - trigger
 
-  kubeflow/kfp-tekton:
-  - trigger
-
-  kubeflow/kfp-tekton-backend:
-  - trigger
-
-  kubeflow/kubebench:
-  - trigger
-
-  kubeflow/kubeflow:
-  - trigger
-
   kubeflow/metadata:
-  - trigger
-
-  kubeflow/mpi-operator:
-  - trigger
-
-  kubeflow/mxnet-operator:
   - trigger
 
   kubeflow/pipelines:
   - trigger
 
-  kubeflow/reporting:
-  - trigger
-
   kubeflow/testing:
   - trigger
 
-  kubeflow/tf-operator:
-  - trigger
-
   kubeflow/website:
-  - trigger
-
-  kubeflow/xgboost-operator:
   - trigger
 
   # This is a gerrit repo so this config doesn't do anything. It is included

--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -137,7 +137,79 @@ plugins:
   - blunderbuss
   - lifecycle
   - override
-  
+
+  kubeflow/arena:
+  - trigger
+
+  kubeflow/batch-predict:
+  - trigger
+
+  kubeflow/caffe2-operator:
+  - trigger
+
+  kubeflow/chainer-operator:
+  - trigger
+
+  kubeflow/common:
+  - trigger
+
+  kubeflow/community-infra:
+  - trigger
+
+  kubeflow/examples:
+  - trigger
+
+  kubeflow/experimental-seldon:
+  - trigger
+
+  kubeflow/fairing:
+  - trigger
+
+  kubeflow/gcp-blueprints:
+  - trigger
+
+  kubeflow/internal-acls:
+  - trigger
+
+  kubeflow/kfp-tekton:
+  - trigger
+
+  kubeflow/kfp-tekton-backend:
+  - trigger
+
+  kubeflow/kubebench:
+  - trigger
+
+  kubeflow/kubeflow:
+  - trigger
+
+  kubeflow/metadata:
+  - trigger
+
+  kubeflow/mpi-operator:
+  - trigger
+
+  kubeflow/mxnet-operator:
+  - trigger
+
+  kubeflow/pipelines:
+  - trigger
+
+  kubeflow/reporting:
+  - trigger
+
+  kubeflow/testing:
+  - trigger
+
+  kubeflow/tf-operator:
+  - trigger
+
+  kubeflow/website:
+  - trigger
+
+  kubeflow/xgboost-operator:
+  - trigger
+
   # This is a gerrit repo so this config doesn't do anything. It is included
   # to satisfy the checkconfig tool which expects all repos that configure
   # jobs to enable the trigger plugin if a plugins.yaml is specified.


### PR DESCRIPTION
Copy/pasted from https://github.com/kubernetes/test-infra/blob/bddebf7eafa01069826beb90521e4638c47e53f1/config/prow/plugins.yaml, this step only enable trigger plugin for kubeflow repo, but not anything else, after this PR oss prow will be able to trigger prow jobs in kubeflow repos, but not taking actions

/assign @cjwagner 
CC @Bodgy