### PR TITLE
Bump autobumper to working image

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -392,7 +392,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210111-f6f01a1373
+    - image: gcr.io/k8s-prow/autobump:v20210114-dfe4a7d4c0
       command:
       - /autobump.sh
       args:


### PR DESCRIPTION
autobumper.sh is broken and will not be able to bump itself out of being broken, so I am manually bumping the autobumper to the current k8s/test-infra image that has the fix.