### PR TITLE
Expose prow monitoring dashboard

### DIFF
--- a/prow/oss/cluster/monitoring/grafana_expose.yaml
+++ b/prow/oss/cluster/monitoring/grafana_expose.yaml
@@ -18,33 +18,32 @@ spec:
     targetPort: nginx
   selector:
     app: grafana
-# TODO(chaodaiG): uncomment this once figure out how to support ingress
-# ---
-# apiVersion: networking.gke.io/v1beta1
-# kind: ManagedCertificate
-# metadata:
-#   name: oss-prow-knative-dev
-#   namespace: prow-monitoring
-# spec:
-#   domains:
-#   - oss-prow.knative.dev
-# ---
-# apiVersion: extensions/v1beta1
-# kind: Ingress
-# metadata:
-#   name: grafana
-#   namespace: prow-monitoring
-#   annotations:
-#     kubernetes.io/ingress.global-static-ip-name: prow-monitoring-grafana
-#     kubernetes.io/ingress.class: "gce"
-#     kubernetes.io/tls-acme: "true"
-#     networking.gke.io/managed-certificates: oss-prow-knative-dev
-# spec:
-#   rules:
-#   - host: oss-prow.knative.dev
-#     http:
-#       paths:
-#       - path: /monitoring
-#         backend:
-#           serviceName: grafana
-#           servicePort: 80
+---
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: oss-prow-knative-dev
+  namespace: prow-monitoring
+spec:
+  domains:
+  - oss-prow-monitoring.knative.dev
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: prow-monitoring
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: oss-prow-monitoring-ip
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/tls-acme: "true"
+    networking.gke.io/managed-certificates: oss-prow-knative-dev
+spec:
+  rules:
+  - host: oss-prow-monitoring.knative.dev
+    http:
+      paths:
+      - path: /monitoring
+        backend:
+          serviceName: grafana
+          servicePort: 80

--- a/prow/oss/cluster/monitoring/grafana_expose.yaml
+++ b/prow/oss/cluster/monitoring/grafana_expose.yaml
@@ -7,7 +7,7 @@ metadata:
   name: grafana
   namespace: prow-monitoring
 spec:
-  type: NodePort
+  type: ClusterIP
   sessionAffinity: ClientIP
   ports:
   - name: http
@@ -43,7 +43,6 @@ spec:
   - host: oss-prow-monitoring.knative.dev
     http:
       paths:
-      - path: /monitoring
-        backend:
+      - backend:
           serviceName: grafana
           servicePort: 80


### PR DESCRIPTION
The DNS entry was registered to be associated with the global static ip named , this makes grafana exposed on the domain oss-prow-monitoring.knative.dev