### PR TITLE
Update generic autobump image for testgrid bump job

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -277,7 +277,7 @@ postsubmits:
       testgrid-num-failures-to-alert: '3'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/generic_autobump:v20210107-f3f8a3b
+      - image: gcr.io/k8s-testimages/generic_autobump:v20210114-14c7075
         command:
         - /generic_autobump
         args:
@@ -358,7 +358,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/generic_autobump:v20210107-f3f8a3b
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210114-14c7075
       command:
       - /generic_autobump
       args:


### PR DESCRIPTION
The testgrid autobump jobs are currently failing because the robot doing the bump does not have a fork of Testgrid. A fix has been landed in the generic autobumper to allow the robot to create the fork before doing the bump. I am bumping the generic_autobumper image to the latest version to hopefully fix the testgrid autobump jobs. 