### PR TITLE
secrets-store-csi-driver-provider-gcp: remove secret

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
@@ -5,6 +5,7 @@ presubmits:
     decorate: true           # Decorate with Prow utilities
     always_run: true         # Run for every PR, or only when requested.
     spec:
+      serviceAccountName: prow-test-sa
       containers:
       - image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
         command:

--- a/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
@@ -9,13 +9,3 @@ presubmits:
       - image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
         command:
         - test/infra/prow/presubmit.sh
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs-access-service-account/service-account.json
-        volumeMounts:
-        - name: gcs-access-service-account
-          mountPath: /etc/gcs-access-service-account
-      volumes:
-        - name: gcs-access-service-account
-          secret:
-            secretName: service-account


### PR DESCRIPTION
Switching to using workload identity instead.

https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/81 binds the `test-jobs/default` k8s SA to the correct GCP SA