### PR TITLE
Set review_acts_as_lgtm to true for lgtm plugin

### DIFF
--- a/prow/knative/plugins.yaml
+++ b/prow/knative/plugins.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # Settings for the "approve" plugin.
 approve:
 - repos:
@@ -20,11 +21,23 @@ approve:
   - "knative-prow-robot/test-infra"
   require_self_approval: false
   ignore_review_state: false
+
+# Settings for the "lgtm" plugin.
+lgtm:
+- repos:
+  # For now only start with knative-sandbox/net-contour
+  - "knative-sandbox/net-contour"
+#  - "knative"
+#  - "knative-sandbox"
+#  - "google/knative-gcp"
+  review_acts_as_lgtm: true
+
 # Settings for the "heart" plugin.
 heart:
   adorees:
   - knative-test-reporter-robot
   commentregexp: ".*"
+
 # Settings for the "milestone" plugin.
 repo_milestone:
   # Default maintainer
@@ -34,6 +47,7 @@ repo_milestone:
     # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
     maintainers_id: 3012514
     maintainers_team: knative-milestone-maintainers
+
 # Settings for the "project" plugin.
 project_config:
   project_org_configs:


### PR DESCRIPTION
As we discussed in https://knative.slack.com/archives/CCSNR4FCH/p1610649354006500, this will allow reviewers to add `lgtm` and `approve` labels with one single click.