### PR TITLE
Configure oss prow grafana exposure to match k8s prow settings

### DIFF
--- a/prow/oss/cluster/monitoring/grafana_expose.yaml
+++ b/prow/oss/cluster/monitoring/grafana_expose.yaml
@@ -22,7 +22,7 @@ spec:
 apiVersion: networking.gke.io/v1beta1
 kind: ManagedCertificate
 metadata:
-  name: oss-prow-knative-dev
+  name: oss-prow-monitoring-knative-dev
   namespace: prow-monitoring
 spec:
   domains:
@@ -35,15 +35,16 @@ metadata:
   namespace: prow-monitoring
   annotations:
     kubernetes.io/ingress.global-static-ip-name: oss-prow-monitoring-ip
-    kubernetes.io/ingress.class: "gce"
     kubernetes.io/tls-acme: "true"
-    networking.gke.io/managed-certificates: oss-prow-knative-dev
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    kubernetes.io/ingress.class: "gce"
+    networking.gke.io/managed-certificates: oss-prow-monitoring-knative-dev
 spec:
   rules:
   - host: oss-prow-monitoring.knative.dev
     http:
       paths:
-      - path: /monitoring
-        backend:
+      - backend:
           serviceName: grafana
           servicePort: 80


### PR DESCRIPTION
These annotations seem to be required for the ingress to behave normally. Also by the way:

- Rename managedcertificate so that it's not the same name as the one used for deck.
- Remove subpath `/monitoring` as it's using a subdomain now.