### PR TITLE
[ESPv2] Remove GKE version

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -163,7 +163,6 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -222,7 +221,6 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -281,7 +279,6 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -340,7 +337,6 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -412,7 +408,6 @@ presubmits:
         - --test-cmd=../prow/gcpproxy-e2e.sh
         - --test-cmd-name=gcpproxy_e2e
         - --timeout=80m
-        - --extract=v1.17.13
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -744,7 +739,6 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=v1.17.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -808,7 +802,6 @@ periodics:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-c
         - --gcp-network=default
@@ -872,7 +865,6 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=v1.17.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -936,7 +928,6 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=v1.17.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -1012,7 +1003,6 @@ periodics:
             - --test-cmd=../prow/e2e-anthos-cloud-run-anthos-cloud-run-http-bookstore.sh
             - --test-cmd-name=gcpproxy_e2e
             - --timeout=300m
-            - --extract=v1.17.13
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
I don't think this arg is needed. Our tests keep breaking every month when an old version goes out of date. Let's just remove it.

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=No valid versions with the prefix "1.17.13" found.
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>