### PR TITLE
[ESPv2] Switch back to stable releases for GKE kubekins

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -163,6 +163,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
+        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -221,6 +222,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
+        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -279,6 +281,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
+        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -337,6 +340,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
+        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -408,6 +412,7 @@ presubmits:
         - --test-cmd=../prow/gcpproxy-e2e.sh
         - --test-cmd-name=gcpproxy_e2e
         - --timeout=80m
+        - --extract=v1.17.13
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -739,6 +744,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
+            - --extract=v1.17.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -802,6 +808,7 @@ periodics:
       - args:
         - --cluster=
         - --deployment=gke
+        - --extract=v1.17.13
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-c
         - --gcp-network=default
@@ -865,6 +872,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
+            - --extract=v1.17.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -928,6 +936,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
+            - --extract=v1.17.13
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -1003,6 +1012,7 @@ periodics:
             - --test-cmd=../prow/e2e-anthos-cloud-run-anthos-cloud-run-http-bookstore.sh
             - --test-cmd-name=gcpproxy_e2e
             - --timeout=300m
+            - --extract=v1.17.13
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -163,7 +163,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -222,7 +222,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -281,7 +281,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -340,7 +340,7 @@ presubmits:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-b
         - --gcp-network=default
@@ -412,7 +412,7 @@ presubmits:
         - --test-cmd=../prow/gcpproxy-e2e.sh
         - --test-cmd-name=gcpproxy_e2e
         - --timeout=80m
-        - --extract=v1.17.13
+        - --extract=release/stable
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -744,7 +744,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=v1.17.13
+            - --extract=release/stable
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -808,7 +808,7 @@ periodics:
       - args:
         - --cluster=
         - --deployment=gke
-        - --extract=v1.17.13
+        - --extract=release/stable
         - --gcp-project=cloudesf-testing
         - --gcp-zone=us-west1-c
         - --gcp-network=default
@@ -872,7 +872,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=v1.17.13
+            - --extract=release/stable
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -936,7 +936,7 @@ periodics:
         - args:
             - --cluster=
             - --deployment=gke
-            - --extract=v1.17.13
+            - --extract=release/stable
             - --gcp-project=cloudesf-testing
             - --gcp-zone=us-west1-c
             - --gcp-network=default
@@ -1012,7 +1012,7 @@ periodics:
             - --test-cmd=../prow/e2e-anthos-cloud-run-anthos-cloud-run-http-bookstore.sh
             - --test-cmd-name=gcpproxy_e2e
             - --timeout=300m
-            - --extract=v1.17.13
+            - --extract=release/stable
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
We switched away from stable releases in #484 due to a versioning problem. Hopefully it does not exist anymore. This will reduce maintenance burden for us.