### PR TITLE
test(kubeflow): add tests for website , gcp-blueprints and testing

### DIFF
--- a/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
+++ b/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
@@ -1,0 +1,72 @@
+presubmits:
+  kubeflow/gcp-blueprints:
+  - name: kubeflow-gcp-blueprints-presubmit
+    cluster: build-kubeflow
+    decorate: true
+    optional: true    # Not required for merging
+    always_run: false # Run for every PR, or only when requested.
+    skip_report: true # No report on github
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+postsubmits:
+  kubeflow/gcp-blueprints:
+  - name: kubeflow-gcp-blueprints-postsubmit
+    cluster: build-kubeflow
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit tests for kubeflow/gcp-blueprints.
+
+# TODO(Bobgy): re-enable periodic tests.
+# periodics:
+# - name: kubeflow-gcp-blueprints-periodic-master
+#   cluster: build-kubeflow
+#   interval: 20m
+#   spec:
+#     containers:
+#     - image: gcr.io/kubeflow-ci/test-worker:latest
+#       imagePullPolicy: Always
+#       env:
+#       - name: REPO_OWNER
+#         value: kubeflow
+#       - name: REPO_NAME
+#         value: gcp-blueprints
+#       - name: BRANCH_NAME
+#         value: master
+#   annotations:
+#     testgrid-create-test-group: "false"
+#     # testgrid-dashboards: sig-big-data
+#     # description: Periodic testing of Kubeflow gcp blueprints on the latest master branch.
+#     # # TODO: use a public email group
+#     # testgrid-alert-email: kubeflow-engineering@google.com
+#     # testgrid-num-failures-to-alert: "3"
+# - name: kubeflow-gcp-blueprints-periodic-1-1
+#   cluster: build-kubeflow
+#   interval: 20m
+#   spec:
+#     containers:
+#     - image: gcr.io/kubeflow-ci/test-worker:latest
+#       imagePullPolicy: Always
+#       env:
+#       - name: REPO_OWNER
+#         value: kubeflow
+#       - name: REPO_NAME
+#         value: gcp-blueprints
+#       - name: BRANCH_NAME
+#         value: v1.1-branch
+#   annotations:
+#     testgrid-create-test-group: "false"
+#     # testgrid-dashboards: sig-big-data
+#     # description: Periodic testing of Kubeflow gcp blueprints on the 1.1 branch.
+#     # # TODO: use a public email group
+#     # testgrid-alert-email: kubeflow-engineering@google.com
+#     # testgrid-num-failures-to-alert: "3"

--- a/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
+++ b/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
@@ -22,8 +22,9 @@ postsubmits:
         imagePullPolicy: Always
 
     annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/gcp-blueprints.
+      testgrid-create-test-group: "false"
+      # testgrid-dashboards: sig-big-data
+      # description: Postsubmit tests for kubeflow/gcp-blueprints.
 
 # TODO(Bobgy): re-enable periodic tests.
 # periodics:

--- a/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
+++ b/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
@@ -2,7 +2,6 @@ presubmits:
   kubeflow/gcp-blueprints:
   - name: kubeflow-gcp-blueprints-presubmit
     cluster: build-kubeflow
-    decorate: true
     optional: true    # Not required for merging
     always_run: false # Run for every PR, or only when requested.
     skip_report: true # No report on github

--- a/prow/prowjobs/kubeflow/testing/kubeflow-testing.yaml
+++ b/prow/prowjobs/kubeflow/testing/kubeflow-testing.yaml
@@ -1,0 +1,28 @@
+presubmits:
+  kubeflow/testing:
+  - name: kubeflow-testing-presubmit
+    cluster: build-kubeflow
+    optional: true    # Not required for merging
+    always_run: false # Run for every PR, or only when requested.
+    skip_report: true # No report on github
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+postsubmits:
+  kubeflow/testing:
+  - name: kubeflow-testing-postsubmit
+    cluster: build-kubeflow
+    optional: true    # Not required for merging
+    always_run: false # Run for every PR, or only when requested.
+    skip_report: true # No report on github
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-ci/test-worker:latest
+        imagePullPolicy: Always
+
+    annotations:
+      testgrid-create-test-group: "false"
+      # testgrid-dashboards: sig-big-data
+      # description: Postsubmit kubeflow/testing.

--- a/prow/prowjobs/kubeflow/website/kubeflow-website.yaml
+++ b/prow/prowjobs/kubeflow/website/kubeflow-website.yaml
@@ -3,7 +3,6 @@ presubmits:
   # TODO(Bobgy): figure out whether this is useful
   - name: kubeflow-website-link-check
     cluster: build-kubeflow
-    decorate: true
     optional: true
     spec:
       containers:

--- a/prow/prowjobs/kubeflow/website/kubeflow-website.yaml
+++ b/prow/prowjobs/kubeflow/website/kubeflow-website.yaml
@@ -1,0 +1,11 @@
+presubmits:
+  kubeflow/website:
+  # TODO(Bobgy): figure out whether this is useful
+  - name: kubeflow-website-link-check
+    cluster: build-kubeflow
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - image: praqma/linkchecker:v9.3.1-154-g22449abb-10
+        imagePullPolicy: Always


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/14343

Move tests for website, gcp-blueprints and testing to oss prow as optional & skip_report

/assign @chaodaiG 