### PR TITLE
Fix oss autobump job pointing at knative autobump config

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -320,7 +320,7 @@ periodics:
       command:
       - /generic_autobump
       args:
-      - --config=prow/knative/knative-autobump-config.yaml
+      - --config=prow/oss/oss-autobump-config.yaml
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
Both knative and autobump jobs were pointing at the knative autobump config