### PR TITLE
Add --github-token-path flag to cherrypicker

### DIFF
--- a/prow/knative/cluster/500-cherrypicker.yaml
+++ b/prow/knative/cluster/500-cherrypicker.yaml
@@ -41,6 +41,7 @@ spec:
 #        - --create-issue-on-conflict
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         ports:
         - name: http
           containerPort: 8888


### PR DESCRIPTION
fixes #719 

/assign @chaodaiG 