### PR TITLE
[grpc-transcoder] Add Prow setup for grpc-transcoder

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -41,6 +41,7 @@ approve:
   - GoogleCloudPlatform
   - google
   - googleforgames
+  - grpc-ecosystem
   require_self_approval: false
 
 blunderbuss:
@@ -51,6 +52,7 @@ lgtm:
   - GoogleCloudPlatform
   - google
   - googleforgames
+  - grpc-ecosystem
   review_acts_as_lgtm: true
 
 plugins:
@@ -186,3 +188,20 @@ plugins:
   # https://github.com/kubernetes/test-infra/issues/14743
   https://kunit-review.googlesource.com/linux:
   - trigger
+
+  grpc-ecosystem/grpc-httpjson-transcoding:
+  - approve
+  - assign
+  - cat
+  - dog
+  - golint
+  - hold
+  - label
+  - lgtm
+  - owners-label
+  - pony
+  - shrug
+  - size
+  - trigger
+  - verify-owners
+  - yuks

--- a/prow/prowjobs/grpc-ecosystem/grpc-httpjson-transcoding/OWNERS
+++ b/prow/prowjobs/grpc-ecosystem/grpc-httpjson-transcoding/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- TAOXUY
+- qiwzhang
+- nareddyt

--- a/prow/prowjobs/grpc-ecosystem/grpc-httpjson-transcoding/transcoding.yaml
+++ b/prow/prowjobs/grpc-ecosystem/grpc-httpjson-transcoding/transcoding.yaml
@@ -1,0 +1,34 @@
+presubmits:
+  grpc-ecosystem/grpc-httpjson-transcoding:
+  - name: grpc-transcoder-presubmit
+    cluster: espv2
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-dashboards: googleoss-grpc-transcoder
+      testgrid-tab-name: presubmit
+      description: "Runs all unit tests per PR."
+    spec:
+      containers:
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
+        command:
+        - ./script/ci.sh
+
+periodics:
+- name: grpc-transcoder-periodic
+  cluster: espv2
+  cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-grpc-transcoder
+    testgrid-tab-name: periodic
+    description: "Runs all unit tests on the master branch continuously."
+  extra_refs:
+  - org: grpc-ecosystem
+    repo: grpc-httpjson-transcoding
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
+      command:
+      - ./script/ci.sh

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -8,6 +8,7 @@ dashboards:
 - name: googleoss-en-server
 - name: googleoss-kubeflow-pipelines
 - name: googleoss-kubeflow-gcp-blueprints
+- name: googleoss-grpc-transcoder
 
 dashboard_groups:
   - name: googleoss
@@ -17,6 +18,7 @@ dashboard_groups:
     - googleoss-esp-v2-presubmit
     - googleoss-esp-v2-periodic
     - googleoss-en-server
+    - googleoss-grpc-transcoder
   - name: googleoss-kubeflow
     dashboard_names:
     - googleoss-kubeflow-pipelines


### PR DESCRIPTION
Adds configurations to use Prow as CI for https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.

Configuration wise:
- Add a new presubmit and periodic job. Re-use the docker container configured in other jobs managed by our team.
- Re-use the `esp-v2` Prow cluster that our team self-hosts on GCP.
- Create a new testgrid dashboard.

Also configured the webhook, using a similar IP address and secret as our pre-existing project (esp-v2).

Signed-off-by: Teju Nareddy <nareddyt@google.com>