### PR TITLE
Fix command name being different for k8s-prow autobump image

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -282,7 +282,7 @@ postsubmits:
       containers:
       - image: gcr.io/k8s-prow/generic-autobumper:v20210310-a49501d5de
         command:
-        - /generic_autobump
+        - /app/prow/cmd/generic-autobumper/app.binary
         args:
         - --config=cluster/testgrid-prod-autobump-config.yaml
         volumeMounts:
@@ -318,7 +318,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20210310-a49501d5de
       command:
-      - /generic_autobump
+      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=prow/oss/oss-autobump-config.yaml
       volumeMounts:
@@ -352,7 +352,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20210310-a49501d5de
       command:
-      - /generic_autobump
+      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=cluster/testgrid-canary-autobump-config.yaml
       volumeMounts:
@@ -386,7 +386,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/generic-autobumper:v20210310-a49501d5de
       command:
-      - /generic_autobump
+      - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=prow/knative/knative-autobump-config.yaml
       volumeMounts:


### PR DESCRIPTION
These changes are needed as a result of this PR https://github.com/kubernetes/test-infra/pull/20813