### PR TITLE
test(kubeflow): more accurate run_if_change for kubeflow-pipeline-mkp-test

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
         - --is_integration_test
         - "true"
   - name: kubeflow-pipeline-mkp-test
-    run_if_changed: "^(manifests/gcp_marketplace/.*)|(test/presubmit-tests-mkp.sh)$"
+    run_if_changed: "^(manifests/gcp_marketplace/.*)|(test/presubmit-tests-mkp.sh)|(test/tag_for_hosted.sh)$"
     cluster: build-kubeflow
     decorate: true
     spec:

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
         - --is_integration_test
         - "true"
   - name: kubeflow-pipeline-mkp-test
-    run_if_changed: "^(manifests/gcp_marketplace/.*)|(test/presubmit-tests-mkp.sh)|(test/tag_for_hosted.sh)$"
+    run_if_changed: "^(manifests/gcp_marketplace/.*)|(test/presubmit-tests-mkp.sh)|(test/tag_for_hosted.sh)|(test/cloudbuild/mkp_verify.yaml)$"
     cluster: build-kubeflow
     decorate: true
     spec:


### PR DESCRIPTION
/assign @zijianjoy @chensun 
Can you help me review?

Context:

https://github.com/kubeflow/pipelines/pull/5278/files#diff-aa26e66c26c946af954a32651055a721a96174ce3ccabacf16149e471075d80c failed mkp test postsubmit, but it didn't trigger the test in presubmit which it should