### PR TITLE
config(kubeflow): kubeflow/pipelines require self approval for PRs

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -43,6 +43,9 @@ approve:
   - googleforgames
   - grpc-ecosystem
   require_self_approval: false
+- repos:
+  - kubeflow/pipelines
+  require_self_approval: true
 
 blunderbuss:
   use_status_availability: true


### PR DESCRIPTION
According to https://github.com/kubernetes/test-infra/issues/19896#issuecomment-724413115,

We want to restore the behavior of always requiring self approval.

/assign @chaodaiG @Ark-kun 