### PR TITLE
[http-pattern-matcher] Update branch name

### DIFF
--- a/prow/prowjobs/google/http_pattern_matcher/http-pattern-matcher.yaml
+++ b/prow/prowjobs/google/http_pattern_matcher/http-pattern-matcher.yaml
@@ -26,7 +26,7 @@ periodics:
   extra_refs:
   - org: google
     repo: http_pattern_matcher
-    base_ref: master
+    base_ref: main
   spec:
     containers:
     - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master


### PR DESCRIPTION
We use `main` instead of `master` for this new repository.