### PR TITLE
OSS prow monitoring secret: updated with a script instead of make rule

### DIFF
--- a/prow/oss/cluster/monitoring/Makefile
+++ b/prow/oss/cluster/monitoring/Makefile
@@ -24,12 +24,6 @@ apply-components: get-cluster-credentials
 
 apply: apply-components
 	$(MAKE) -C ./mixins apply
-	# Make sure keeping @ so that the token is not surfaced on command line.
-	# Makefile execute each line in separate sub-shell, so all commands have to be on the same line
-	@email="$(shell gcloud beta secrets versions access latest --secret prometheus-alerter-email-address --project ${PROJECT})"; \
-		token="$(shell gcloud beta secrets versions access latest --secret prometheus-alerter-app-password --project ${PROJECT})"; \
-		cat ./secrets/alertmanager-prow_secret.yaml | sed s/{{\ smtp_app_username\ }}/$${email}/g | \
-        sed s/{{\ smtp_app_password\ }}/$${token}/g | \
-		kubectl apply -f -
+	./secrets/replace-secrets-from-gcp.sh ${PROJECT}
 
 .PHONY: apply-components apply

--- a/prow/oss/cluster/monitoring/secrets/replace-secrets-from-gcp.sh
+++ b/prow/oss/cluster/monitoring/secrets/replace-secrets-from-gcp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+PROJECT="${1:-}"
+if [[ -z "${PROJECT}" ]]; then
+    echo "ERROR: GCP project name must be provided."
+    exit 1
+fi
+
+echo "Updating secret with secret manager from project $PROJECT"
+email="$(gcloud beta secrets versions access latest --secret prometheus-alerter-email-address --project ${PROJECT})"
+token="$(gcloud beta secrets versions access latest --secret prometheus-alerter-app-password --project ${PROJECT})"
+
+cat "${CUR_DIR}/alertmanager-prow_secret.yaml" | \
+    sed s/{{\ smtp_app_username\ }}/${email}/g | \
+    sed s/{{\ smtp_app_password\ }}/${token}/g | \
+    kubectl apply -f -
+
+echo "Secrets updated"


### PR DESCRIPTION
It's pretty hard to have make rules to exit based on wrapped subshell, turn it into a script and it should exit correctly