### PR TITLE
Add external secret for github oauth2 secrets in preparation for private deck deployment

### DIFF
--- a/prow/oss/cluster/kubernetes_external_secrets.yaml
+++ b/prow/oss/cluster/kubernetes_external_secrets.yaml
@@ -1,0 +1,34 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: private-deck-oauth2-config
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: oss-prow
+  data:
+  - key: oss-prow-private-github-oauth-config
+    name: secret
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: private-deck-oauth2
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: oss-prow
+  data:
+  - key: oss-prow-private-github-oauth2-secret
+    name: clientID
+    version: latest
+    property: clientID
+  - key: oss-prow-private-github-oauth2-secret
+    name: clientSecret
+    version: latest
+    property: clientSecret
+  - key: oss-prow-private-github-oauth2-secret
+    name: cookieSecret
+    version: latest
+    property: cookieSecret


### PR DESCRIPTION
These secrets were created from google-oss-robot account, and were already stored in oss-prow project