### PR TITLE
Update presubmit test image to use go1.15

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -41,7 +41,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: golang:1.13
+        - image: golang:1.15
           command:
             - go
             - test


### PR DESCRIPTION
This is required for updating dependencies from k8s/test-infra, see failed test at https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/GoogleCloudPlatform_oss-test-infra/785/pull-test-infra-go-test/1384690825857863680