### PR TITLE
Fix private deck deployment with oauth2 fixes

### DIFF
--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -81,18 +81,19 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       - name: oauth2-proxy
-        image: quay.io/pusher/oauth2_proxy:v5.0.0
+        image: quay.io/oauth2-proxy/oauth2-proxy
         ports:
         - containerPort: 4180
           protocol: TCP
         args:
         - --provider=github
-        - --github-org=fejtaverse
+        - --github-org=chaotoppicks
         - --http-address=0.0.0.0:4180
         - --upstream=http://localhost:8080
         - --cookie-domain=oss-prow-private.knative.dev
         - --cookie-name=oss-prow-private-knative-dev-oauth2-proxy
         - --cookie-samesite=none
+        - --cookie-expire="23h"
         - --email-domain=*
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Update to the latest image
explicit cookie expiration in 23 hours
use chaotoppicks org for faster debug turnaround