### PR TITLE
Add a separate SA for public Deck to distinguish from other control plane components.

### DIFF
--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -150,6 +150,14 @@ metadata:
   annotations:
     "iam.gke.io/gcp-service-account": "oss-prow@oss-prow.iam.gserviceaccount.com"
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deck-public
+  namespace: default
+  annotations:
+    "iam.gke.io/gcp-service-account": "oss-prow-public-deck@oss-prow.iam.gserviceaccount.com"
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:


### PR DESCRIPTION
/assign @chaodaiG 

Once this merges I'll bind the SAs with workload identity and then make another PR to switch deck to use this SA and delete the old one. Once that merges I'll delete the old SA. This should avoid any downtime.