### PR TITLE
Switch public Deck to use new SA.

### DIFF
--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         app: deck
     spec:
-      serviceAccountName: deck
+      serviceAccountName: deck-public
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
@@ -141,14 +141,6 @@ subjects:
 - kind: ServiceAccount
   name: "deck"
   namespace: "test-pods"
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: deck
-  namespace: default
-  annotations:
-    "iam.gke.io/gcp-service-account": "oss-prow@oss-prow.iam.gserviceaccount.com"
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/oss-test-infra/pull/821.  `deck-public` SA has been bound.
/assign @chaodaiG 