### PR TITLE
Add Configurator to oss-prow

### DIFF
--- a/prow/oss/serviceaccounts/GoogleCloudPlatform_testgrid_serviceaccounts.yaml
+++ b/prow/oss/serviceaccounts/GoogleCloudPlatform_testgrid_serviceaccounts.yaml
@@ -13,3 +13,11 @@ metadata:
     iam.gke.io/gcp-service-account: deployer@k8s-testgrid.iam.gserviceaccount.com
   name: testgrid-deployer
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: testgrid-config-updater@oss-prow.iam.gserviceaccount.com
+  name: testgrid-config-updater
+  namespace: test-pods

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -170,6 +170,37 @@ postsubmits:
       - name: github
         secret:
           secretName: oauth-token
+  - name: post-oss-test-infra-create-testgrid-config
+    branches:
+    - ^master$
+    max_concurrency: 1
+    labels:
+      preset-bazel-scratch-dir: "true"
+    run_if_changed: '^(prow/prowjobs/.*\.yaml)|(testgrid/config\.yaml)$'
+    decorate: true
+    annotations:
+      testgrid-dashboards: googleoss-test-infra
+      testgrid-tab-name: testgrid-gcs-upload
+      # testgrid-alert-email: k8s-infra-oncall@google.com #TODO(chases2): Email only after confirmed to be working
+      testgrid-num-failures-to-alert: '1'
+    spec:
+      serviceAccountName: testgrid-config-updater
+      containers:
+      - image: gcr.io/k8s-prow/configurator:v20210503-ee6348061c
+        command:
+        - /app/testgrid/cmd/configurator/app.binary
+        args:
+        - --yaml=testgrid/config.yaml
+        - --default=testgrid/default.yaml
+        - --prow-config=prow/oss/config.yaml
+        - --prow-job-config=prow/prowjobs
+        - --output=gs://oss-prow-own-testgrid/config
+        - --update-description
+        - --oneshot
+        - --world-readable
+        resources:
+          requests:
+            memory: "1Gi"
   - name: post-oss-test-infra-reconcile-hmacs
     cluster: test-infra-trusted
     run_if_changed: 'prow/oss/config.yaml'

--- a/testgrid/default.yaml
+++ b/testgrid/default.yaml
@@ -1,0 +1,42 @@
+# Default testgroup and dashboardtab, please do not change them
+# In this repository, if you don't set something in your configuration file or prow job, it will use the value here
+
+default_test_group:
+  # TODO: Reduce this back down to 14 once a full update has completed.
+  days_of_results: 15 # Number of days of test results to gather and serve.
+  tests_name_policy: 2 # replace the name of the test
+  ignore_pending: false # Show in-progress tests.
+  ignore_skip: true # Don't show skipped tests by default.
+  column_header:
+    - configuration_value: Commit # Shows the commit number on column header
+    - configuration_value: infra-commit
+  num_columns_recent: 10
+  use_kubernetes_client: true # These two fields are deprecated and should always be true
+  is_external: true
+  alert_stale_results_hours: 0 # Don't alert for staleness by default.
+  num_failures_to_alert: 3 # Consider a test failed if it has 3 or more consecutive failures.
+  num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes.
+  code_search_path: github.com/kubernetes/kubernetes/search # URL for regression search links.
+
+default_dashboard_tab:
+  open_test_template: # The URL template to visit after clicking on a cell
+    url: https://prow.k8s.io/view/gs/<gcs_prefix>/<changelist>
+  file_bug_template: # The URL template to visit when filing a bug
+    url: https://github.com/kubernetes/kubernetes/issues/new
+    options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+  attach_bug_template: # The URL template to visit when attaching to an existing bug
+    url: # empty
+    options: #empty
+  open_bug_template: # The URL template to visit when visiting an associated bug
+    url: https://github.com/kubernetes/kubernetes/issues/
+  results_text: See these results on Prow # Text to show in the about menu as a link to another view of the results
+  results_url_template: # The URL template to visit after clicking
+    url: https://prow.k8s.io/job-history/<gcs_prefix>
+  code_search_path: github.com/kubernetes/kubernetes/search # URL for regression search links.
+  num_columns_recent: 10
+  code_search_url_template: # The URL template to visit when searching for changelists
+    url: https://github.com/kubernetes/kubernetes/compare/<start-custom-0>...<end-custom-0>


### PR DESCRIPTION
Adds a configurator job to oss-prow to write TestGrid config to an oss-prow specific location.

Copies the exact default from [kubernetes/test-infra](https://github.com/kubernetes/test-infra/blob/master/config/testgrids/default.yaml) to make proto comparisons easier.
Service account created with [config-updater-sa.sh](https://github.com/kubernetes/test-infra/blob/master/testgrid/config-updater-sa.sh) and workload identity association has been made.

/assign @chaodaiG @cjwagner 