### PR TITLE
Update deck-private RBAC.

### DIFF
--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -194,6 +194,8 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
This was missing and preventing build logs from streaming. The error was hidden by our logging filters because it wasn't from logrus.