### PR TITLE
Add external secret from build cluster for knative

### DIFF
--- a/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
+++ b/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: s390x-cluster1
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: s390x-knative
+  data:
+  - key: kubeconfig
+    name: config
+    version: latest
+  - key: ko-docker-repository
+    name: ko-docker-repo
+    version: latest
+  - key: registry-certificate
+    name: registry.crt
+    version: latest


### PR DESCRIPTION
Fixes https://github.com/knative/test-infra/issues/2775 and https://github.com/knative/test-infra/issues/2760

The current secret configuration for the knative prow job is tightly coupled with the ownership of the build cluster, which can be loosened by the kubernetes external secret. The installation of the CRDs and the controller has been recently finished (https://github.com/GoogleCloudPlatform/oss-test-infra/pull/807). This PR is a follow-up task for the s390x knative test. 

MAINTAINERS, **please** delete the existing secret `s390x-cluster1` before merging this. 