### PR TITLE
Set up a periodic test job to run e2e tests against main once a day

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
@@ -16,6 +16,10 @@ periodics:
   cluster: build-secretmanager-csi
   cron: '0 9 * * *' # Run once a day at 9am.
   decorate: true
+  annotations:
+    testgrid-dashboards: secrets-store-csi-driver-provider-gcp
+    testgrid-tab-name: periodic
+    description: "Runs E2E tests on the main branch continuously."
   extra_refs: # Run test against main branch.
   - org: GoogleCloudPlatform
     repo: secrets-store-csi-driver-provider-gcp

--- a/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
@@ -10,3 +10,19 @@ presubmits:
       - image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
         command:
         - test/infra/prow/presubmit.sh
+
+periodics:
+- name: prow-e2e-tests-periodic
+  cluster: build-secretmanager-csi
+  cron: '0 9 * * *' # Run once a day at 9am.
+  decorate: true
+  extra_refs: # Run test against main branch.
+  - org: GoogleCloudPlatform
+    repo: secrets-store-csi-driver-provider-gcp
+    base_ref: main  
+  spec:
+    serviceAccountName: prow-test-sa
+    containers:
+    - image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
+      command:
+      - test/infra/prow/presubmit.sh

--- a/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
@@ -17,7 +17,7 @@ periodics:
   cron: '0 9 * * *' # Run once a day at 9am.
   decorate: true
   annotations:
-    testgrid-dashboards: secrets-store-csi-driver-provider-gcp
+    testgrid-dashboards: googleoss-secrets-store-csi-driver-provider-gcp
     testgrid-tab-name: periodic
     description: "Runs E2E tests on the main branch continuously."
   extra_refs: # Run test against main branch.

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -9,6 +9,7 @@ dashboards:
 - name: googleoss-kubeflow-gcp-blueprints
 - name: googleoss-grpc-transcoder
 - name: googleoss-http-pattern-matcher
+- name: googleoss-secrets-store-csi-driver-provider-gcp
 
 dashboard_groups:
   - name: googleoss
@@ -19,6 +20,7 @@ dashboard_groups:
     - googleoss-esp-v2-periodic
     - googleoss-grpc-transcoder
     - googleoss-http-pattern-matcher
+    - googleoss-secrets-store-csi-driver-provider-gcp
   - name: googleoss-kubeflow
     dashboard_names:
     - googleoss-kubeflow-pipelines


### PR DESCRIPTION
Running the e2e tests at least once a day will help handle any dependency/test issues as they arise. This PR will resolve [Secrets CSI - Issue 103](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/103). 

The periodic job was set up following the examples in the [Prow Test Jobs Examples doc](https://github.com/kubernetes/test-infra/blob/master/config/jobs/README.md#job-examples) and the [grpc-httpjson-transcoding](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/grpc-ecosystem/grpc-httpjson-transcoding/transcoding.yaml) setup.