### PR TITLE
Automated continuous deployment of oss prow

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -63,6 +63,16 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
+  - author: google-oss-robot
+    labels: # google-oss-robot should only create autobump PR with this label
+    - skip-review
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    repos:
+    - GoogleCloudPlatform/oss-test-infra
 
 plank:
   job_url_prefix_config:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -332,7 +332,7 @@ postsubmits:
           defaultMode: 0400
 
 periodics:
-- cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
+- cron: "30 * * * 1-5"  # Bump don't label `skip-review`. Run at :30 past every hour Mon-Fri
   name: ci-oss-test-infra-autobump-prow
   cluster: test-infra-trusted
   decorate: true
@@ -352,6 +352,41 @@ periodics:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
       - --config=prow/oss/oss-autobump-config.yaml
+      volumeMounts:
+      - name: github
+        mountPath: /etc/github-token
+        readOnly: true
+      - name: ssh
+        mountPath: /root/.ssh
+    volumes:
+    - name: github
+      secret:
+        secretName: oauth-token
+    - name: ssh
+      secret:
+        secretName: google-oss-robot-ssh-keys
+        defaultMode: 0400
+- cron: "05 17 * * 1-5"  # Bump with label `skip-review`. Run at 10:05 PST (17:05 UTC) Mon-Fri
+  name: ci-oss-test-infra-autobump-prow-for-auto-deploy
+  cluster: test-infra-trusted
+  decorate: true
+  extra_refs:
+  - org: GoogleCloudPlatform
+    repo: oss-test-infra
+    base_ref: master
+  annotations:
+    testgrid-dashboards: googleoss-test-infra
+    testgrid-tab-name: autobump-prow-for-auto-deploy
+    testgrid-alert-email: k8s-infra-oncall@google.com
+    testgrid-num-failures-to-alert: '1'
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210515-9461f01d36
+      command:
+      - /app/prow/cmd/generic-autobumper/app.binary
+      args:
+      - --config=prow/oss/oss-autobump-config.yaml
+      - --labels-override=skip-review # This label is used by tide for identifying trusted PR
       volumeMounts:
       - name: github
         mountPath: /etc/github-token


### PR DESCRIPTION
As discussed among prow oncalls, it's agreed that:
- OSS prow has been pretty stable lately
- All errors were caught by automated alerts

This gives us enough confidence to enable automated continuous deployment of oss prow, the steps are the same as https://github.com/kubernetes/enhancements/tree/master/keps/sig-testing/2539-continuously-deploy-k8s-prow