### PR TITLE
Move TestGrid Upload job to trusted cluster

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -171,6 +171,7 @@ postsubmits:
         secret:
           secretName: oauth-token
   - name: post-oss-test-infra-create-testgrid-config
+    cluster: test-infra-trusted
     branches:
     - ^master$
     max_concurrency: 1


### PR DESCRIPTION
The job is currently failing since I put the job in a different cluster than the credentials.

https://oss-prow.knative.dev/?job=post-oss-test-infra-create-testgrid-config