### PR TITLE
Add prow job config path on testgrid

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -195,6 +195,7 @@ postsubmits:
         - --prow-config=prow/oss/config.yaml
         - --prow-job-config=prow/prowjobs
         - --output=gs://oss-prow-own-testgrid/config
+        - --prowjob-url-prefix=https://github.com/GoogleCloudPlatform/oss-test-infra/tree/master/prow/prowjobs/
         - --update-description
         - --oneshot
         - --world-readable


### PR DESCRIPTION
See https://github.com/kubernetes/test-infra/blob/6b3c4eecea921dd6598121b01a945387c3347148/testgrid/cmd/configurator/main.go#L86 for usage and https://testgrid.k8s.io/wg-k8s-infra-k8sio#ci-k8sio-audit for example output