### PR TITLE
Undo #714 and use prow /lgtm and /approve

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -137,6 +137,7 @@ tide:
   queries:
   - orgs:
     - "knative"
+    - "knative-sandbox"
     excludedRepos:
     - knative/build
     - knative/build-templates
@@ -159,11 +160,7 @@ tide:
     - lgtm
     - approved
     - "cla: yes"
-    missingLabels: &knative_tide_missing_labels
-    - do-not-merge/hold
-    - do-not-merge/work-in-progress
-    - do-not-merge/invalid-owners-file
-    - needs-rebase
+    missingLabels: *knative_tide_missing_labels
   - repos:
     # Allow PRs for test-infra to be automatically merged without manual approval
     - "knative/test-infra"
@@ -173,12 +170,6 @@ tide:
     missingLabels: *knative_tide_missing_labels
     author: knative-prow-updater-robot
     reviewApprovedRequired: false
-  - orgs:
-    - "knative-sandbox"
-    labels:
-    - "cla: yes"
-    missingLabels: *knative_tide_missing_labels
-    reviewApprovedRequired: true
   merge_method:
     knative: squash
     knative-sandbox: squash

--- a/prow/knative/plugins.yaml
+++ b/prow/knative/plugins.yaml
@@ -16,19 +16,17 @@
 approve:
 - repos:
   - "knative"
-  # TODO(mattmoor): Should we disable this for sandbox?
   - "knative-sandbox"
   - "google/knative-gcp"
   - "knative-prow-robot/test-infra"
-  require_self_approval: true
   ignore_review_state: false
 
 # Settings for the "lgtm" plugin.
 lgtm:
 - repos:
-   - "knative-sandbox"
-#  - "knative"
-#  - "google/knative-gcp"
+  - "knative-sandbox"
+  - "knative"
+  - "google/knative-gcp"
   review_acts_as_lgtm: true
 
 # Settings for the "heart" plugin.


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/oss-test-infra/pull/714 and preceeding:

* https://github.com/GoogleCloudPlatform/oss-test-infra/pull/711
* https://github.com/GoogleCloudPlatform/oss-test-infra/pull/709 
* https://github.com/GoogleCloudPlatform/oss-test-infra/pull/702
* https://github.com/GoogleCloudPlatform/oss-test-infra/pull/659

This also carries over the "GitHub Review = LGTM + Approve" from this PR ([conversation](https://knative.slack.com/archives/CCSNR4FCH/p1610649354006500)):
* https://github.com/GoogleCloudPlatform/oss-test-infra/pull/667

Fixes https://github.com/knative/test-infra/issues/2752