### PR TITLE
Add external secret for knative build cluster

### DIFF
--- a/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
+++ b/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
@@ -16,3 +16,6 @@ spec:
   - key: registry-certificate
     name: registry.crt
     version: latest
+  - key: knative01-ssh
+    name: knative01.pem
+    version: latest


### PR DESCRIPTION
This PR is to add an additional external secret for the knative e2e test against the s390x test machine.