### PR TITLE
Add external secret for knative build cluster

### DIFF
--- a/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
+++ b/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
@@ -19,3 +19,6 @@ spec:
   - key: knative01-ssh
     name: knative01.pem
     version: latest
+  - key: docker-config
+    name: config.json
+    version: latest


### PR DESCRIPTION
This PR is to add an additional external secret named `docker-config` for the knative e2e test against the s390x test machine.