### PR TITLE
TG config upload: stop setting file-level permission

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -199,7 +199,6 @@ postsubmits:
         - --prowjob-url-prefix=https://github.com/GoogleCloudPlatform/oss-test-infra/tree/master/prow/prowjobs/
         - --update-description
         - --oneshot
-        - --world-readable
         resources:
           requests:
             memory: "1Gi"


### PR DESCRIPTION
Context: #832
The newly-created bucket has bucket-wide permissions, causing the `--world-readable` flag, which sets a file-level permission, to fail.

https://oss-prow.knative.dev/view/gs/oss-prow/logs/post-oss-test-infra-create-testgrid-config/1397600094118744064

Prow job: https://oss-prow.knative.dev/?job=post-oss-test-infra-create-testgrid-config