### PR TITLE
Require self-approval for kubeflow/kubeflow

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -48,6 +48,7 @@ approve:
   - kubeflow/chainer-operator
   - kubeflow/common
   - kubeflow/fate-operator
+  - kubeflow/kubeflow
   - kubeflow/mpi-operator
   - kubeflow/mxnet-operator
   - kubeflow/pipelines
@@ -166,7 +167,7 @@ plugins:
     - yuks
 
   kubeflow:
-    plugins:  
+    plugins:
     - approve   # Enable /approve and /assign commands.
     - assign
     - blunderbuss


### PR DESCRIPTION
As we (Notebooks WG leads) discussed https://github.com/kubeflow/kubeflow/issues/5953 we'd like to explicitly require self-approval for our PRs.

This is also the case for the other repos of the Kubeflow org.

cc @yanniszark @elikatsis @StefanoFioravanzo @thesuperzapper @Bobgy 