### PR TITLE
Automatically posting knative prow deploy message on slack

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -27,6 +27,7 @@ spec:
         - --cookiefile=/etc/cookies/cookies
         - --gerrit-projects=https://kunit-review.googlesource.com=linux
         - --gerrit-workers=1
+        - --additional-slack-token-files=knative=/etc/knative-slack-token/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
@@ -62,6 +63,9 @@ spec:
         - name: oauth
           mountPath: /etc/github
           readOnly: true
+        - name: knative-slack-token
+          mountPath: etc/knative-slack-token
+          readonly: true
       volumes:
       - name: build-elcarro
         secret:
@@ -92,6 +96,9 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
+      - name: knative-slack-token
+        secret:
+          secretName: knative-slack-token
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -153,6 +153,16 @@ postsubmits:
       testgrid-tab-name: knative-prow-deploy
       testgrid-alert-email: k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '2'
+    reporter_config:
+      slack:
+        host: "knative" # Must match additional-slack-token-files in crier deployment
+        channel: "test"
+        job_states_to_report:
+        - success
+        - failure
+        - aborted
+        - error
+        report_template: 'Deploying prow: {{.Status.State}}. <{{.Spec.Refs.BaseLink}}|Commit {{.Spec.Refs.BaseSHA}}> <{{.Status.URL}}|View logs> <https://testgrid.k8s.io/googleoss-test-infra#knative-prow-deploy|Job history on Testgrid>'
     spec:
       serviceAccountName: prow-deployer
       containers:


### PR DESCRIPTION
Note: this will not work until https://github.com/kubernetes/test-infra/pull/22386 is in oss-prow, which should happen on Monday 06/07. Also the secret knative-slack-token is not in either, I'll create a separate PR adding this secret

/hold