### PR TITLE
Add build cluster kubeconfig for blueprints

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -37,8 +37,11 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
         - mountPath: /etc/build-elcarro
           name: build-elcarro
           readOnly: true
@@ -67,6 +70,10 @@ spec:
           mountPath: etc/knative-slack-token
           readOnly: true
       volumes:
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
       - name: build-elcarro
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -43,11 +43,14 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8080
         volumeMounts:
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
         - mountPath: /etc/build-elcarro
           name: build-elcarro
           readOnly: true
@@ -92,6 +95,10 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       volumes:
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
       - name: build-elcarro
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -47,8 +47,11 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
         - mountPath: /etc/build-elcarro
           name: build-elcarro
           readOnly: true
@@ -137,6 +140,10 @@ spec:
               name: private-deck-oauth2
               key: cookieSecret
       volumes:
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
       - name: build-elcarro
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -37,11 +37,14 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8888
         volumeMounts:
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
         - mountPath: /etc/build-elcarro
           name: build-elcarro
           readOnly: true
@@ -70,6 +73,10 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
       - name: build-elcarro
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -28,8 +28,11 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
         - mountPath: /etc/build-elcarro
           name: build-elcarro
           readOnly: true
@@ -49,6 +52,10 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
       - name: build-elcarro
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -27,8 +27,11 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
         - mountPath: /etc/build-elcarro
           name: build-elcarro
           readOnly: true
@@ -48,6 +51,10 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
       - name: build-elcarro
         secret:
           defaultMode: 420


### PR DESCRIPTION
Please submit this change after the previous PR was submitted and postsubmit job succeeded.
Prow oncall: please don't submit this change until the secret is created successfully, which will be indicated by prow alerts in 2 minutes after the postsubmit job.