### PR TITLE
secrets-store-csi-driver-provider-gcp: configure periodic envvars

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/secrets-store-csi-driver-provider-gcp-config.yaml
@@ -30,3 +30,8 @@ periodics:
     - image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
       command:
       - test/infra/prow/presubmit.sh
+      env:
+        - name: GKE_VERSION
+          value: "RAPID"
+        - name: GCP_PROVIDER_SHA
+          value: main


### PR DESCRIPTION
Set envvars so that the periodic job will use the `main` branch instead of `PULL_PULL_SHA`:

https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/issues/103

blocked on https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/pull/115