### PR TITLE
Add postsubmit jobs building image for release

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -579,10 +579,38 @@ presubmits:
         secret:
           secretName: cloudesf-testing-github-prow-service-account
 
+postsubmits:
+  GoogleCloudPlatform/esp-v2:
+  - name: ESPv2-postsubmit-build
+    cluster: espv2
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-dashboards: googleoss-esp-v2-postsubmit
+      testgrid-tab-name: build
+      description: "Generates docker images for potential release"
+    spec:
+      containers:
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
+        command:
+        - ./prow/gcpproxy-build.sh
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/cloudesf-testing-github-prow-service-account/service-account.json
+        - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+          value: /etc/cloudesf-testing-github-prow-service-account/service-account.json
+        volumeMounts:
+        - name: cloudesf-testing-github-prow-service-account
+          mountPath: /etc/cloudesf-testing-github-prow-service-account
+      volumes:
+      - name: cloudesf-testing-github-prow-service-account
+        secret:
+          secretName: cloudesf-testing-github-prow-service-account
+
 periodics:
   - name: ESPv2-continuous-build
     cluster: espv2
-    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
+    cron: '*/30 * * * *' # Run every half hour
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic

--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -610,7 +610,7 @@ postsubmits:
 periodics:
   - name: ESPv2-continuous-build
     cluster: espv2
-    cron: '*/30 * * * *' # Run every half hour
+    cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
     decorate: true
     annotations:
       testgrid-dashboards: googleoss-esp-v2-periodic

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -4,6 +4,7 @@ dashboards:
 - name: googleoss-gcp-guest
 - name: googleoss-test-infra
 - name: googleoss-esp-v2-presubmit
+- name: googleoss-esp-v2-postsubmit
 - name: googleoss-esp-v2-periodic
 - name: googleoss-kubeflow-pipelines
 - name: googleoss-kubeflow-gcp-blueprints

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -17,6 +17,7 @@ dashboard_groups:
     - googleoss-gcp-guest
     - googleoss-test-infra
     - googleoss-esp-v2-presubmit
+    - googleoss-esp-v2-postsubmit
     - googleoss-esp-v2-periodic
     - googleoss-grpc-transcoder
     - googleoss-http-pattern-matcher


### PR DESCRIPTION
Our release images are built from the master head(we relied on continuous build job before) so we need a post submit job to build it.