### PR TITLE
Add a slack worker on oss prow

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -27,6 +27,7 @@ spec:
         - --cookiefile=/etc/cookies/cookies
         - --gerrit-projects=https://kunit-review.googlesource.com=linux
         - --gerrit-workers=1
+        - --slack-workers=1
         - --additional-slack-token-files=knative=/etc/knative-slack-token/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com


### PR DESCRIPTION
so that it can post slack message when knative prow is automatically updated

/hold
This will cause prow failure, will only work after changes from https://github.com/kubernetes/test-infra/pull/22600 is in oss prow