### PR TITLE
Revert "Add a slack worker on oss prow"

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -27,7 +27,6 @@ spec:
         - --cookiefile=/etc/cookies/cookies
         - --gerrit-projects=https://kunit-review.googlesource.com=linux
         - --gerrit-workers=1
-        - --slack-workers=1
         - --additional-slack-token-files=knative=/etc/knative-slack-token/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com


### PR DESCRIPTION
This reverts commit ea3f66829c8527945226b62de50081fb77cfbacf.

Got an error `slackreporter is enabled but has no config`