### PR TITLE
Move branchprotector config for Knative to the core Prow config file

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -186,3 +186,45 @@ tide:
   context_options:
     # Treat unknown contexts as optional
     skip-unknown-contexts: true
+
+# Configure GitHub branch protection rules according to the specified policy.
+branch-protection:
+  # Allows a child to disable all protection even if the branch has inherited protection options from a parent.
+  allow_disabled_policies: true
+  orgs:
+    knative-sandbox:
+      # Protect all branches in knative-sandbox
+      protect: true
+      required_status_checks:
+        contexts:
+        - cla/google
+        - tide
+      exclude:
+      - "^dependabot/" # don't protect branches created by dependabot
+      # Enforce all configured restrictions above for administrators.
+      enforce_admins: true
+
+    knative:
+      # Protect all branches in knative
+      protect: true
+      required_status_checks:
+        contexts:
+        - cla/google
+        - tide
+      # Enforce all configured restrictions above for administrators.
+      enforce_admins: true
+      repos:
+        .github:
+          protect: false
+
+    google:
+      repos:
+        # Protect all branches in google/knative-gcp
+        knative-gcp:
+          protect: true
+          required_status_checks:
+            contexts:
+            - cla/google
+            - tide
+          # Enforce all configured restrictions above for administrators.
+          enforce_admins: true


### PR DESCRIPTION
Some recent change in k8s.io/test-infra made it a hard requirement to have the branchprotector config in the Prow core config file - https://prow.knative.dev/job-history/gs/knative-prow/logs/ci-knative-test-infra-branchprotector. This PR is moving the Knative branchprotector config file in https://github.com/knative/test-infra/tree/main/config/branch_protector