### PR TITLE
Add announcement banner promoting prow-announce@google.com group.

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -192,6 +192,7 @@ branch-protection:
 deck:
   google_analytics: G-NQ9CERRMYD
   spyglass:
+    announcement: "Googlers: Please join <a href='https://groups.google.com/a/google.com/g/prow-announce'>the prow-announce@google.com group</a> to receive important Prow related updates. Consider adding your team as a subgroup!"
     size_limit: 500000000 # 500MB
     gcs_browser_prefix: https://pantheon.corp.google.com/storage/browser/ # TODO(fejta): something publicly accessible
     testgrid_config: gs://k8s-testgrid/config


### PR DESCRIPTION
This is an internal group, but the majority of OSS Prow users are Googlers so I think it is worth advertising here.
/assign @mpherman2 