### PR TITLE
Temporarily remove problematic PodMonitor.

### DIFF
--- a/prow/oss/cluster/monitoring/prow_podmonitors.yaml
+++ b/prow/oss/cluster/monitoring/prow_podmonitors.yaml
@@ -151,23 +151,3 @@ spec:
   selector:
     matchLabels:
       app: crier
----
-apiVersion: monitoring.gke.io/v1alpha1
-kind: PodMonitor
-metadata:
-  labels:
-    app.kubernetes.io/name: kubernetes-external-secrets
-    app: kubernetes-external-secrets
-  name: kubernetes-external-secrets
-  namespace: prow-monitoring
-spec:
-  podMetricsEndpoints:
-  - interval: 30s
-    port: prometheus
-    scheme: http
-  namespaceSelector:
-    matchNames:
-    - default
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: kubernetes-external-secrets


### PR DESCRIPTION
This PodMonitor is causing issues with the monitoring services. It has been recommended that we temporarily remove it so that we can continue the demo.
Once this PR merges I'll run `kubectl delete -n prow-monitoring podmonitor kubernetes-external-secrets`.
/assign @mpherman2 @fejta 