### PR TITLE
oss-prow reporting build clusters statuses in GCS

### DIFF
--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -87,6 +87,8 @@ kind: ServiceAccount
 metadata:
   namespace: default
   name: "prow-controller-manager"
+  annotations:
+    "iam.gke.io/gcp-service-account": "oss-prow@oss-prow.iam.gserviceaccount.com"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -81,6 +81,7 @@ plank:
     'looker': https://oss-prow-private.knative.dev/view/
   pod_pending_timeout: 15m
   pod_unscheduled_timeout: 5m
+  build_cluster_status_file: 'gs://oss-prow/oss-prow-build-clusters-statuses.json'
   default_decoration_config_entries:
   - config:
       timeout: 7200000000000 # 2h


### PR DESCRIPTION
/hold
This won't work until version v20210730-5757a5d200, which was from https://github.com/kubernetes/test-infra/pull/23068
