### PR TITLE
Terraform alert on pod crashlooping

### DIFF
--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -35,4 +35,11 @@ module "alert" {
         alert_interval = "1200s"
     }
     notification_channel_id = "14031735832803168422"
+    prow_components = {
+        "deck" = {"namespace": "default"}
+        "hook" = {"namespace": "default"}
+        "prow-controller-manager" = {"namespace": "default"}
+        "sinker" = {"namespace": "default"}
+        "tide" = {"namespace": "default"}
+    }
 }

--- a/prow/oss/terraform/modules/alerts/main.tf
+++ b/prow/oss/terraform/modules/alerts/main.tf
@@ -12,6 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+resource "google_monitoring_alert_policy" "pod-crashlooping" {
+  for_each     = var.prow_components
+  project      = var.project
+  display_name = "pod-crashlooping-${each.key}"
+  combiner     = "OR" # required
+
+  conditions {
+    display_name = "pod-crashlooping-${each.key}"
+
+    condition_monitoring_query_language {
+      # Alert if the service crashlooped, which results in restarts with exponential backoff.
+      # This threshold is higher than the default crashloop backoff threshold, mainly due to
+      # the fact prow components would crashloop when kubernetes master is upgrading, which
+      # normally takes 5 minutes. Setting this to 12 minutes for excluding this case
+      duration = "720s"
+      query    = <<-EOT
+      fetch k8s_container
+      | metric 'kubernetes.io/container/restart_count'
+      | filter
+          (resource.container_name == '${each.key}' && resource.namespace_name == '${each.value.namespace}')
+      | align delta(6m)
+      | every 6m
+      | group_by [], [value_restart_count_aggregate: aggregate(value.restart_count)]
+      | condition val() > 0 '1'
+      EOT
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "The service `${each.key}` has been restarting for more than 6 minutes, very likely crashlooping."
+    mime_type = "text/markdown"
+  }
+
+  # gcloud beta monitoring channels list --project=oss-prow
+  notification_channels = ["projects/${var.project}/notificationChannels/${var.notification_channel_id}"]
+}
+
+
 resource "google_monitoring_alert_policy" "heartbeat-job-stale" {
   project      = var.project
   display_name = "heartbeat-job-stale"

--- a/prow/oss/terraform/modules/alerts/variables.tf
+++ b/prow/oss/terraform/modules/alerts/variables.tf
@@ -28,3 +28,10 @@ variable "heartbeat_job" {
 variable "notification_channel_id" {
   type = string
 }
+
+variable "prow_components" {
+  type = map
+  default = {
+    "svc_not_exist" = {"namespace": "default"}
+  }
+}


### PR DESCRIPTION
This is on top of #995 

Wasn't able to find an equivalent of `up` from prometheus https://github.com/GoogleCloudPlatform/oss-test-infra/blob/cd38a59352b0225b4ebfb5601089fa6edfa4ab83/prow/oss/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet#L11, catching pod crashlooping might be a good starting point

/hold
more to be added