### PR TITLE
Add podmonitor for external secrets and sub

### DIFF
--- a/prow/oss/cluster/kubernetes-external-secrets_deployment.yaml
+++ b/prow/oss/cluster/kubernetes-external-secrets_deployment.yaml
@@ -24,6 +24,8 @@ spec:
           ports:
           - name: prometheus
             containerPort: 3001
+          - name: metrics
+            containerPort: 9090
           imagePullPolicy: IfNotPresent
           resources:
             {}

--- a/prow/oss/cluster/monitoring/prow_podmonitors.yaml
+++ b/prow/oss/cluster/monitoring/prow_podmonitors.yaml
@@ -151,3 +151,42 @@ spec:
   selector:
     matchLabels:
       app: crier
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app: sub
+  name: sub
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: sub
+---
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    app: kubernetes-external-secrets
+  name: kubernetes-external-secrets
+  namespace: prow-monitoring
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    port: prometheus
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-external-secrets

--- a/prow/oss/cluster/sub.yaml
+++ b/prow/oss/cluster/sub.yaml
@@ -29,6 +29,8 @@ spec:
         ports:
         - name: http
           containerPort: 80
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
Noticed that the metrics port was not added initially, which probably was the reason why podmonitor was not so happy last time