### PR TITLE
add gcp-guest bucket for spyglass

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -227,6 +227,7 @@ deck:
       - GoogleCloudPlatform
   additional_allowed_buckets:
     - compute-image-tools-test
+    - gcp-guest-testgrid
   hidden_repos:
   - looker
 


### PR DESCRIPTION
we want to permit use of spyglass against our custom job logs in this bucket