### PR TITLE
Use testgrid variant of gcloud-bazel

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -262,7 +262,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-deployer
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20200520-v0.4-30-g9d6313a
+      - image: gcr.io/k8s-testgrid/gcloud-bazel:v20210806-v0.6-37-g8086289
         command:
         - ./cluster/deploy.sh
         args:
@@ -280,7 +280,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-deployer
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20200520-v0.4-30-g9d6313a
+      - image: gcr.io/k8s-testgrid/gcloud-bazel:v20210806-v0.6-37-g8086289
         command:
         - ./cluster/deploy.sh
         args:


### PR DESCRIPTION
Fixes https://oss-prow.knative.dev/view/gs/oss-prow/logs/post-testgrid-deploy-canary/1423772252528185344