### PR TITLE
All jobs using default build cluster use WI by default

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -95,6 +95,10 @@ plank:
         bucket: "oss-prow"
         path_strategy: "explicit"
       gcs_credentials_secret: "service-account" # TODO(fejta): remove https://github.com/GoogleCloudPlatform/oss-test-infra/issues/202
+  - cluster: default
+    config:
+      gcs_credentials_secret: "" # Use workload identity
+      default_service_account_name: "prowjob-default-sa" # SA in build cluster
   - cluster: build-looker-private
     config:
       gcs_configuration:


### PR DESCRIPTION
There are 9 jobs using default cluster:
- 6 from https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml, none of these 6 jobs seem to need extra GCP permissions.
- 1 from https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/GoogleCloudPlatform/k8s-cloud-provider/k8s-cloud-provider-config.yaml, will need to monitor.
- 1 from https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/kunit-review.googlesource.com/linux/kunit-linux-config.yaml, will need to monitor.
- 1 from https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-images.yaml, this was already fixed

