### PR TITLE
Increase hook replicas to 6 and set resource requests

### DIFF
--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: hook
 spec:
-  replicas: 2
+  replicas: 6
   selector:
     matchLabels:
       app: hook
@@ -74,6 +74,10 @@ spec:
         - name: build-kubeflow
           mountPath: /etc/build-kubeflow
           readOnly: true
+        resources:
+          requests: # peak usage sampled by most recent usages of hook
+            memory: "4Gi"
+            cpu: "2"
       volumes:
       - name: build-blueprints
         secret:


### PR DESCRIPTION
Hook is responsible for triggering inrepoconfig jobs, it figures out how to run it by cloning the entire target repo, which could be throttled when encounters large repo at scale. Increasing the replicas should be able to help