### PR TITLE
Add liveliness and readinessprobe for hook

### DIFF
--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -78,6 +78,19 @@ spec:
           requests: # peak usage sampled by most recent usages of hook
             memory: "4Gi"
             cpu: "2"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
       volumes:
       - name: build-blueprints
         secret:


### PR DESCRIPTION
For consistency reason with other prow instances, also makes the service more resilient