### PR TITLE
Create SA for running jobs in test-infra-trusted cluster

### DIFF
--- a/prow/oss/serviceaccounts/GoogleCloudPlatform_oss-test-infra_serviceaccounts.yaml
+++ b/prow/oss/serviceaccounts/GoogleCloudPlatform_oss-test-infra_serviceaccounts.yaml
@@ -13,3 +13,12 @@ metadata:
     iam.gke.io/gcp-service-account: kubernetes-external-secrets-sa@oss-prow.iam.gserviceaccount.com
   name: kubernetes-external-secrets-sa
   namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prowjob-default-sa@oss-prow.iam.gserviceaccount.com
+  name: prowjob-default-sa
+  namespace: test-pods
+---


### PR DESCRIPTION
test-infra-trusted cluster is the test-pods namespace in oss-prow cluster, creating this service account so that jobs using this cluster can use this SA by default