### PR TITLE
Add build cluster kubeconfig for looker-int-test

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -38,11 +38,14 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
         - mountPath: /etc/build-blueprints
           name: build-blueprints
           readOnly: true
@@ -74,6 +77,10 @@ spec:
           mountPath: etc/knative-slack-token
           readOnly: true
       volumes:
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
       - name: build-blueprints
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -43,13 +43,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8080
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
         - mountPath: /etc/build-blueprints
           name: build-blueprints
           readOnly: true
@@ -97,6 +100,10 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       volumes:
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
       - name: build-blueprints
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -47,8 +47,11 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         volumeMounts:
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
         - mountPath: /etc/build-blueprints
           name: build-blueprints
           readOnly: true
@@ -140,6 +143,10 @@ spec:
               name: private-deck-oauth2
               key: cookieSecret
       volumes:
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
       - name: build-blueprints
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -37,13 +37,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8888
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
         - mountPath: /etc/build-blueprints
           name: build-blueprints
           readOnly: true
@@ -92,6 +95,10 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       volumes:
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
       - name: build-blueprints
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -28,11 +28,14 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
         - mountPath: /etc/build-blueprints
           name: build-blueprints
           readOnly: true
@@ -55,6 +58,10 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
       - name: build-blueprints
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -27,11 +27,14 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20201002:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
         - mountPath: /etc/build-blueprints
           name: build-blueprints
           readOnly: true
@@ -54,6 +57,10 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
       - name: build-blueprints
         secret:
           defaultMode: 420


### PR DESCRIPTION
Please submit this change after the previous PR was submitted and postsubmit job succeeded.
Prow oncall: please don't submit this change until the secret is created successfully, which will be indicated by prow alerts in 2 minutes after the postsubmit job.