### PR TITLE
Revert "Bumping oss-prow"

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/crier:v20210818-b81cb0bc7b
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/deck:v20210818-b81cb0bc7b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck-private
-        image: gcr.io/k8s-prow/deck:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/deck:v20210818-b81cb0bc7b
         ports:
         - name: http
           containerPort: 8080

--- a/prow/oss/cluster/gerrit.yaml
+++ b/prow/oss/cluster/gerrit.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: gerrit
-        image: gcr.io/k8s-prow/gerrit:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/gerrit:v20210818-b81cb0bc7b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/ghproxy.yaml
+++ b/prow/oss/cluster/ghproxy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/ghproxy:v20210818-b81cb0bc7b
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=49

--- a/prow/oss/cluster/grandmatriarch_default.yaml
+++ b/prow/oss/cluster/grandmatriarch_default.yaml
@@ -69,6 +69,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/grandmatriarch:v20210818-b81cb0bc7b
         args:
         - http-cookiefile

--- a/prow/oss/cluster/grandmatriarch_test-pods.yaml
+++ b/prow/oss/cluster/grandmatriarch_test-pods.yaml
@@ -74,6 +74,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/grandmatriarch:v20210818-b81cb0bc7b
         args:
         - http-cookiefile

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/hook:v20210818-b81cb0bc7b
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/horologium.yaml
+++ b/prow/oss/cluster/horologium.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/horologium:v20210818-b81cb0bc7b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210818-b81cb0bc7b
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/sinker:v20210818-b81cb0bc7b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/sub.yaml
+++ b/prow/oss/cluster/sub.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: sub
       containers:
       - name: sub
-        image: gcr.io/k8s-prow/sub:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/sub:v20210818-b81cb0bc7b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210824-9ef10941f6
+        image: gcr.io/k8s-prow/tide:v20210818-b81cb0bc7b
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -87,10 +87,10 @@ plank:
       timeout: 7200000000000 # 2h
       grace_period: 15000000000 # 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210824-9ef10941f6"
-        initupload: "gcr.io/k8s-prow/initupload:v20210824-9ef10941f6"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210824-9ef10941f6"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210824-9ef10941f6"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210818-b81cb0bc7b"
+        initupload: "gcr.io/k8s-prow/initupload:v20210818-b81cb0bc7b"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210818-b81cb0bc7b"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210818-b81cb0bc7b"
       gcs_configuration:
         bucket: "oss-prow"
         path_strategy: "explicit"

--- a/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
@@ -10,7 +10,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20210824-9ef10941f6
+      - image: gcr.io/k8s-prow/checkconfig:v20210818-b81cb0bc7b
         command:
         - /app/prow/cmd/checkconfig/app.binary
         args:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20210824-9ef10941f6
+        - image: gcr.io/k8s-prow/checkconfig:v20210818-b81cb0bc7b
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -56,7 +56,7 @@ presubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20210824-9ef10941f6
+      - image: gcr.io/k8s-prow/configurator:v20210818-b81cb0bc7b
         command:
         - /app/testgrid/cmd/configurator/app.binary
         args:
@@ -82,7 +82,7 @@ presubmits:
       base_ref: main
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20210824-9ef10941f6
+        - image: gcr.io/k8s-prow/checkconfig:v20210818-b81cb0bc7b
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -190,7 +190,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-config-updater
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20210824-9ef10941f6
+      - image: gcr.io/k8s-prow/configurator:v20210818-b81cb0bc7b
         command:
         - /app/testgrid/cmd/configurator/app.binary
         args:
@@ -218,7 +218,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/hmac:v20210824-9ef10941f6
+      - image: gcr.io/k8s-prow/hmac:v20210818-b81cb0bc7b
         command:
         - /hmac
         args:
@@ -315,7 +315,7 @@ postsubmits:
       testgrid-num-failures-to-alert: '3'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/generic-autobumper:v20210824-9ef10941f6
+      - image: gcr.io/k8s-prow/generic-autobumper:v20210818-b81cb0bc7b
         command:
         - /app/prow/cmd/generic-autobumper/app.binary
         args:
@@ -351,7 +351,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210824-9ef10941f6
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210818-b81cb0bc7b
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -385,7 +385,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210824-9ef10941f6
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210818-b81cb0bc7b
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -421,7 +421,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210824-9ef10941f6
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210818-b81cb0bc7b
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -455,7 +455,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210824-9ef10941f6
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210818-b81cb0bc7b
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:
@@ -489,7 +489,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20210824-9ef10941f6
+    - image: gcr.io/k8s-prow/generic-autobumper:v20210818-b81cb0bc7b
       command:
       - /app/prow/cmd/generic-autobumper/app.binary
       args:

--- a/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
+++ b/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
@@ -11,7 +11,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20210824-9ef10941f6
+      - image: gcr.io/k8s-prow/checkconfig:v20210818-b81cb0bc7b
         command:
         - /app/prow/cmd/checkconfig/app.binary
         args:


### PR DESCRIPTION
This reverts commit b35c7f7a50f305463932f075bb489e43e77a96e7.

Unfortunately still seeing errors like:
```
failed to merge: error checking out 814343493f0f8f98f8923d4400ad45ed9d6520ad: exit status 128. output: fatal: reference is not a tree: 814343493f0f8f98f8923d4400ad45ed9d6520ad
```

revert for now so that pubsub still works