### PR TITLE
Knative prow: update rbac.authorization.k8s.io to v1

### DIFF
--- a/prow/knative/cluster/301-rbac.yaml
+++ b/prow/knative/cluster/301-rbac.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: test-pods
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "test-pods-default"
   namespace: test-pods
@@ -39,7 +39,7 @@ subjects:
   namespace: test-pods
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "test-pods-default"
   namespace: test-pods
@@ -61,7 +61,7 @@ metadata:
   namespace: default
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "deck"
@@ -75,7 +75,7 @@ subjects:
   namespace: default
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "deck"
@@ -89,7 +89,7 @@ subjects:
   namespace: default
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "deck"
@@ -106,7 +106,7 @@ rules:
       - create
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "deck"
@@ -126,7 +126,7 @@ metadata:
   namespace: default
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "horologium"
 rules:
@@ -140,7 +140,7 @@ rules:
       - watch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "horologium"
 roleRef:
@@ -160,7 +160,7 @@ metadata:
   namespace: default
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "plank"
@@ -177,7 +177,7 @@ rules:
       - patch
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "plank"
@@ -192,7 +192,7 @@ rules:
       - list
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "plank"
@@ -206,7 +206,7 @@ subjects:
   namespace: default
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "plank"
@@ -227,7 +227,7 @@ metadata:
   namespace: default
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "sinker"
@@ -274,7 +274,7 @@ rules:
       - create
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "sinker"
@@ -291,7 +291,7 @@ rules:
       - patch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "sinker"
@@ -305,7 +305,7 @@ subjects:
   namespace: default
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "sinker"
@@ -326,7 +326,7 @@ metadata:
   namespace: default
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "hook"
 rules:
@@ -349,7 +349,7 @@ rules:
       - update
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "hook"
 roleRef:
@@ -369,7 +369,7 @@ metadata:
   namespace: default
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "tide"
 rules:
@@ -389,7 +389,7 @@ rules:
       - update
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "tide"
 roleRef:
@@ -441,7 +441,7 @@ rules:
     - "patch"
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "crier"
 roleRef:
@@ -460,7 +460,7 @@ metadata:
   name: "statusreconciler"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "statusreconciler"
@@ -473,7 +473,7 @@ rules:
       - "create"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "statusreconciler"

--- a/prow/knative/cluster/400-prow-controller-manager.yaml
+++ b/prow/knative/cluster/400-prow-controller-manager.yaml
@@ -55,7 +55,7 @@ metadata:
   name: "prow-controller-manager"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "prow-controller-manager"
@@ -104,7 +104,7 @@ rules:
     - patch
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "prow-controller-manager"
@@ -122,7 +122,7 @@ rules:
   - patch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
   name: "prow-controller-manager"
@@ -135,7 +135,7 @@ subjects:
   name: "prow-controller-manager"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "prow-controller-manager"

--- a/prow/knative/cluster/build/301-rbac.yaml
+++ b/prow/knative/cluster/build/301-rbac.yaml
@@ -57,7 +57,7 @@ metadata:
   namespace: test-pods
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "test-pods-default"
   namespace: test-pods
@@ -71,7 +71,7 @@ subjects:
   namespace: test-pods
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "test-pods-default"
   namespace: test-pods


### PR DESCRIPTION
v1beta1 is deprecated v.1.22+ as https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122, updating it before we ran into it