### PR TITLE
Switch Deck Private instance from hidden only to tenantID

### DIFF
--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - --job-config-path=/etc/job-config
         - --redirect-http-to=oss-prow-private.knative.dev
         - --spyglass=true
-        - --hidden-only=true
+        - --tenant-id=looker
         - --rerun-creates-job
         - --oauth-url=/github-login
         - --github-token-path=/etc/github/oauth


### PR DESCRIPTION
We fixed the issue with labeling Prowjobs and created some integration tests to confirm this works as expected.
/hold
/assign @chaodaiG @cjwagner 