### PR TITLE
Oss prow crier: increase github worker to 6

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -33,7 +33,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
-        - --github-workers=1
+        - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1
         env:


### PR DESCRIPTION
Reporting for inrepoconfig is sequential when there is only a single worker, as cloning is mutex locked. Increasing to 6 can help with performance.

Ideally we should wait until https://github.com/kubernetes/test-infra/pull/23589 is on oss prow, which switches from massive disk I/O by cloning repo to incremental fetching of refs