### PR TITLE
remove Knative Milestone Maintainers

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -121,7 +121,6 @@ deck:
   rerun_auth_configs:
     '*':
       github_team_ids:
-        - 3012514 # Knative Milestone Maintainers
         - 3996822 # Knative Release Team
         - 3288907 # Knative TOC
 


### PR DESCRIPTION
Before we can [remove knative milestone maintainers](https://github.com/knative/community/issues/92) role in:
https://github.com/knative/community/pull/768

We need to remove it from here first.
