### PR TITLE
oss-prow: move crier and tide to dedicated nodepool

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -132,6 +132,21 @@ spec:
       - name: knative-slack-token
         secret:
           secretName: knative-slack-token
+      resources:
+        # Crier does inrepoconfig prowjob lookup, which is very
+        # disk and cpu intensive. This is even worse when there
+        # is a spike of PRs going on.
+        # The node has 7.91CPU in total, set requests and limits,
+        # so that crier uses a single node.
+        requests:
+          cpu: 7
+      tolerations:
+      - key: "highcpu"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      nodeSelector:
+        highcpu: "true"
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -54,6 +54,21 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      resources:
+        # Tide does inrepoconfig prowjob lookup, which is very
+        # disk and cpu intensive. This is even worse when there
+        # is a spike of PRs going on.
+        # The node has 7.91CPU in total, set requests and limits,
+        # so that tide uses a single node.
+        requests:
+          cpu: 7
+      tolerations:
+      - key: "highcpu"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      nodeSelector:
+        highcpu: "true"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
These are components that might experience high cpu and disk I/O for inrepoconfig lookup, move them to a dedicated nodepool, so that they can be scheduled on a node with no neighbor, and the availability is guaranteened