### PR TITLE
bump crier to v20210914-d9fade61b4

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210913-b6578706d1
+        image: gcr.io/k8s-prow/crier:v20210914-d9fade61b4
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml


### PR DESCRIPTION
This includes updating crier to use git cache client https://github.com/kubernetes/test-infra/pull/23589, should speed up crier reporting