### PR TITLE
Crier github worker set to 100

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -33,7 +33,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
-        - --github-workers=6
+        - --github-workers=100
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1
         env:


### PR DESCRIPTION
Crier is currently blocked on reporting inrepoconfig jobs, the number of github workers are filled by inrepoconfig jobs and started to wait in a queue fetching inrepoconfig jobs, make it 100 so non-inrepoconfig jobs get a bit higher chance getting reported