### PR TITLE
Roll back crier to v20210908-3a373c2cdd

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210914-d9fade61b4
+        image: gcr.io/k8s-prow/crier:v20210908-3a373c2cdd
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml


### PR DESCRIPTION
Crier started to use inrepoconfig since https://github.com/kubernetes/test-infra/pull/23484 on 09/10, rolling back to before this date can unblock crier