### PR TITLE
Revert "oss-prow: move crier and tide to dedicated nodepool"

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -132,21 +132,6 @@ spec:
       - name: knative-slack-token
         secret:
           secretName: knative-slack-token
-      resources:
-        # Crier does inrepoconfig prowjob lookup, which is very
-        # disk and cpu intensive. This is even worse when there
-        # is a spike of PRs going on.
-        # The node has 7.91CPU in total, set requests and limits,
-        # so that crier uses a single node.
-        requests:
-          cpu: 7
-      tolerations:
-      - key: "highcpu"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-      nodeSelector:
-        highcpu: "true"
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -54,21 +54,6 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      resources:
-        # Tide does inrepoconfig prowjob lookup, which is very
-        # disk and cpu intensive. This is even worse when there
-        # is a spike of PRs going on.
-        # The node has 7.91CPU in total, set requests and limits,
-        # so that tide uses a single node.
-        requests:
-          cpu: 7
-      tolerations:
-      - key: "highcpu"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-      nodeSelector:
-        highcpu: "true"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This reverts commit 15ab02e219087834bb850e5a8bf9cc5dba2f96b5.

These were not needed, as crier is not doing inrepoconfig any more, and tide is not throttled either