### PR TITLE
Bump crier for allowing skip comment on PR

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210914-fd2c6cfd90
+        image: gcr.io/k8s-prow/crier:v20210915-1112f4f614
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/23606 allows opt out of crier commenting on PRs, bumping crier with this change to help lower github token usage