### PR TITLE
Opting out looker/helltool from bot commenting job failure

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -302,6 +302,12 @@ in_repo_config:
     "looker/helltool": ["build-looker-private", "build-looker-int-test", "build-looker-16", "build-looker-32"]
     "GoogleCloudPlatform/blueprints": ["build-blueprints"]
 
+# settings for github reporter from crier
+github_reporter:
+  # no_comment_repos opt out of prow robot comments on job failures, the statuses of prow jobs are still reported on PRs
+  no_comment_repos:
+  - looker/helltool
+
 presets:
 # docker-in-docker preset
 #


### PR DESCRIPTION
Opts out of this comment on PRs, for example:
![Screen Shot 2021-09-15 at 10 26 24 AM](https://user-images.githubusercontent.com/45011425/133480816-3e38d564-73fb-40cb-8c55-63bc87c53f57.png)

This feature doesn't really provide too much value, but appears to be using lots of github tokens from prow robot account. Opting out can avoid depletion of prow robot account token, which might fail prow components that rely on github APIs

/hold