### PR TITLE
Rotate Prow deployments to a new oauth token.

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -128,7 +128,7 @@ spec:
           secretName: kubeconfig-build-kubeflow
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: oauth-token-2
       - name: knative-slack-token
         secret:
           secretName: knative-slack-token

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -107,7 +107,7 @@ spec:
           secretName: github-oauth-config-20200326-oss-prow-knative-dev
       - name: oauth-token
         secret:
-          secretName: oauth-token
+          secretName: oauth-token-2
       - name: cookie-secret
         secret:
           secretName: cookie

--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -171,7 +171,7 @@ spec:
           secretName: private-deck-oauth2-config
       - name: oauth-token
         secret:
-          secretName: oauth-token
+          secretName: oauth-token-2
       - name: cookie-secret
         secret:
           secretName: cookie

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -130,7 +130,7 @@ spec:
           secretName: hmac-token
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: oauth-token-2
       - name: config
         configMap:
           name: config

--- a/prow/oss/cluster/sub.yaml
+++ b/prow/oss/cluster/sub.yaml
@@ -56,7 +56,7 @@ spec:
           name: job-config
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: oauth-token-2
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -47,7 +47,7 @@ spec:
       volumes:
       - name: oauth
         secret:
-          secretName: oauth-token
+          secretName: oauth-token-2
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
/assign @chaodaiG 

Hoping to get 2 things out of this.
- Tracking down some token usage that we are having trouble identifying
- Switch to GitHub's new, more secure personal access token format.

This token has the same scopes, is for the same bot, and is under the same secret key (`oauth`).