### PR TITLE
Update Knative Boskos reaper expire to 11min to recycle the resources more efficiently

### DIFF
--- a/prow/knative/cluster/build/400-boskos-reaper.yaml
+++ b/prow/knative/cluster/build/400-boskos-reaper.yaml
@@ -37,6 +37,7 @@ spec:
         image: gcr.io/k8s-staging-boskos/reaper:v20200819-984516e
         args:
         - --resource-type=gke-project
+        - --expire=11m
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
With this small change, Boskos Janitor will start clean up the GCP projects 11 minutes (which was 30 minutes by default) after the Prow jobs are terminated, which'll help save some resources.