### PR TITLE
Decrease Sub replicas from 10 to 2

### DIFF
--- a/prow/oss/cluster/sub.yaml
+++ b/prow/oss/cluster/sub.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: sub
 spec:
-  replicas: 10
+  replicas: 2
   selector:
     matchLabels:
       app: sub


### PR DESCRIPTION
The new inrepoconfig caching feature has been deployed with
PR #1146 (approximately ~2:55 PM PDT on 2021-09-27). Having multiple
replicas hurts cache efficiency because each replica maintains its own
in-memory cache.

/assign @cjwagner