### PR TITLE
Revert "Looker opt in summary comment"

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -314,9 +314,8 @@ in_repo_config:
 
 # settings for github reporter from crier
 github_reporter:
-  # summary_comment_repos is a list of orgs and org/repos for which failure report
-  # comments is only sent when all jobs from current PR are finished.
-  summary_comment_repos:
+  # no_comment_repos opt out of prow robot comments on job failures, the statuses of prow jobs are still reported on PRs
+  no_comment_repos:
   - looker/helltool
 
 presets:


### PR DESCRIPTION
This reverts commit 138714c7389f12df5c41b30d883ce6156d63908f.

oss-prow just ran out of all github tokens during one of the peak hours today, which co-incidentally happened on the day we enabled looker summary comment, this could be related but we are not sure whether this is the only driven factor. Oncall please onhold this PR if it happens again tomorrow, while we are actively investigating the root cause.
/hold

Note: This is affecting the entire prow instance, including all other prow users.