### PR TITLE
Hook, crier and ingress set to work with GitHub app

### DIFF
--- a/prow/oss/cluster/cluster.yaml
+++ b/prow/oss/cluster/cluster.yaml
@@ -128,6 +128,32 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  name: hook-ghapp-ing
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "oss-prow"
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/tls-acme: "true"
+    networking.gke.io/managed-certificates: oss-prow-knative-dev
+    # Rewrite path to strip /fakeghserver from path to match in cluster traffic.
+    # Doc: https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/rewrite/README.md#rewrite-target
+    nginx.ingress.kubernetes.io/rewrite-target: $1
+spec:
+  rules:
+  - host: oss-prow.knative.dev
+    http:
+      paths:
+      # `/ghapp-hook/hook` is the webhook endpoint exclusively for repos onboarding by installing GitHub app,
+      # hook expects path with prefix of `/hook`, have to strip off `/ghapp-hook`.
+      # Naming it `ghapp-hook` instead of `hook-ghapp` to avoid potential collision with ingress rule above that matches `/hook`.
+      - path: /ghapp-hook(/hook.*)
+        backend:
+          serviceName: hook-ghapp
+          servicePort: 8888
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
   name: deck-blueprints
   namespace: default
   annotations:

--- a/prow/oss/cluster/crier-ghapp.yaml
+++ b/prow/oss/cluster/crier-ghapp.yaml
@@ -1,0 +1,200 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crier
+  namespace: default
+  labels:
+    app: crier
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crier
+  template:
+    metadata:
+      labels:
+        app: crier
+    spec:
+      serviceAccountName: crier
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: crier
+        image: gcr.io/k8s-prow/crier:v20211005-887a381aed
+        args:
+        - --blob-storage-workers=1
+        - --config-path=/etc/config/config.yaml
+        - --cookiefile=/etc/cookies/cookies
+        - --gerrit-projects=https://kunit-review.googlesource.com=linux
+        - --gerrit-projects=https://linux-review.googlesource.com=linux/kernel/git/torvalds/linux
+        - --gerrit-workers=1
+        - --additional-slack-token-files=knative=/etc/knative-slack-token/token
+        - --pubsub-workers=1
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
+        - --github-workers=6
+        - --job-config-path=/etc/job-config
+        - --kubernetes-blob-storage-workers=1
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-32/kubeconfig:/etc/build-looker-16/kubeconfig:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+        ports:
+        - name: metrics
+          containerPort: 9090
+        volumeMounts:
+        - mountPath: /etc/build-looker-32
+          name: build-looker-32
+          readOnly: true
+        - mountPath: /etc/build-looker-16
+          name: build-looker-16
+          readOnly: true
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
+        - mountPath: /etc/build-elcarro
+          name: build-elcarro
+          readOnly: true
+        - mountPath: /etc/build-looker-private
+          name: build-looker-private
+          readOnly: true
+        - name: cookies
+          mountPath: /etc/cookies
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
+        - name: build-kubeflow
+          mountPath: /etc/build-kubeflow
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: knative-slack-token
+          mountPath: etc/knative-slack-token
+          readOnly: true
+      volumes:
+      - name: build-looker-32
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-32
+      - name: build-looker-16
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-16
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
+      - name: build-elcarro
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-elcarro
+      - name: build-looker-private
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-private
+      - name: cookies
+        secret:
+          defaultMode: 420
+          secretName: http-cookiefile
+      - name: config
+        configMap:
+          name: config
+      - name: job-config
+        configMap:
+          name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
+      - name: build-kubeflow
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-kubeflow
+      - name: oauth
+        secret:
+          secretName: oauth-token-2
+      - name: knative-slack-token
+        secret:
+          secretName: knative-slack-token
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: crier
+  namespace: default
+  annotations:
+    "iam.gke.io/gcp-service-account": "oss-prow@oss-prow.iam.gserviceaccount.com"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+  # namespace: not-namespaced, todo: fix (prowjobs live in one namespace)
+rules:
+- apiGroups:
+    - "prow.k8s.io"
+  resources:
+    - "prowjobs"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+    - "patch"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+    - "events"
+  verbs:
+    - "get"
+    - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "crier"
+subjects:
+- kind: ServiceAccount
+  name: "crier"
+  namespace: "default"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crier
+  namespace: default
+  name: crier
+spec:
+  ports:
+  - name: metrics
+    port: 9090
+  selector:
+    app: crier

--- a/prow/oss/cluster/crier-ghapp.yaml
+++ b/prow/oss/cluster/crier-ghapp.yaml
@@ -2,19 +2,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: crier
+  name: crier-ghapp
   namespace: default
   labels:
-    app: crier
+    app: crier-ghapp
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: crier
+      app: crier-ghapp
   template:
     metadata:
       labels:
-        app: crier
+        app: crier-ghapp
     spec:
       serviceAccountName: crier
       terminationGracePeriodSeconds: 30
@@ -32,7 +32,9 @@ spec:
         - --pubsub-workers=1
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github/oauth
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
+        - --github-enabled-org=repo-does-not-exist
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1
@@ -40,6 +42,11 @@ spec:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config-20201002:/etc/build-looker-32/kubeconfig:/etc/build-looker-16/kubeconfig:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: ghapp-token
+              key: appid
         ports:
         - name: metrics
           containerPort: 9090
@@ -77,7 +84,7 @@ spec:
         - name: build-kubeflow
           mountPath: /etc/build-kubeflow
           readOnly: true
-        - name: oauth
+        - name: ghapp-token
           mountPath: /etc/github
           readOnly: true
         - name: knative-slack-token
@@ -126,75 +133,23 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-kubeflow
-      - name: oauth
+      - name: ghapp-token
         secret:
-          secretName: oauth-token-2
+          secretName: ghapp-token
       - name: knative-slack-token
         secret:
           secretName: knative-slack-token
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: crier
-  namespace: default
-  annotations:
-    "iam.gke.io/gcp-service-account": "oss-prow@oss-prow.iam.gserviceaccount.com"
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: crier
-  # namespace: not-namespaced, todo: fix (prowjobs live in one namespace)
-rules:
-- apiGroups:
-    - "prow.k8s.io"
-  resources:
-    - "prowjobs"
-  verbs:
-    - "get"
-    - "watch"
-    - "list"
-    - "patch"
-- apiGroups:
-    - ""
-  resources:
-    - "pods"
-    - "events"
-  verbs:
-    - "get"
-    - "list"
-- apiGroups:
-    - ""
-  resources:
-    - "pods"
-  verbs:
-    - "patch"
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: crier
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "crier"
-subjects:
-- kind: ServiceAccount
-  name: "crier"
-  namespace: "default"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: crier
+    app: crier-ghapp
   namespace: default
-  name: crier
+  name: crier-ghapp
 spec:
   ports:
   - name: metrics
     port: 9090
   selector:
-    app: crier
+    app: crier-ghapp

--- a/prow/oss/cluster/hook-ghapp.yaml
+++ b/prow/oss/cluster/hook-ghapp.yaml
@@ -2,15 +2,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hook
+  name: hook-ghapp
   namespace: default
   labels:
-    app: hook
+    app: hook-ghapp
 spec:
   replicas: 6
   selector:
     matchLabels:
-      app: hook
+      app: hook-ghapp
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        app: hook
+        app: hook-ghapp
     spec:
       serviceAccountName: hook
       terminationGracePeriodSeconds: 180
@@ -31,13 +31,20 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
+        - --github-enabled-org=repo-does-not-exist
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config-20201002:/etc/build-looker-32/kubeconfig:/etc/build-looker-16/kubeconfig:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: ghapp-token
+              key: appid
         ports:
         - name: http
           containerPort: 8888
@@ -65,7 +72,7 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: oauth
+        - name: ghapp-token
           mountPath: /etc/github
           readOnly: true
         - name: config
@@ -127,10 +134,10 @@ spec:
           secretName: kubeconfig-build-looker-private
       - name: hmac
         secret:
-          secretName: hmac-token
-      - name: oauth
+          secretName: ghapp-hmac-token
+      - name: ghapp-token
         secret:
-          secretName: oauth-token-2
+          secretName: ghapp-token
       - name: config
         configMap:
           name: config
@@ -153,58 +160,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: hook
-  name: hook
+    app: hook-ghapp
+  name: hook-ghapp
   namespace: default
 spec:
   selector:
-    app: hook
+    app: hook-ghapp
   ports:
   - name: main
     port: 8888
   - name: metrics
     port: 9090
   type: NodePort
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: hook
-  namespace: default
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hook
-  namespace: default
-rules:
-  - apiGroups:
-      - "prow.k8s.io"
-    resources:
-      - prowjobs
-    verbs:
-      - create
-      - get
-      - list
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - update
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hook
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: "hook"
-subjects:
-- kind: ServiceAccount
-  name: "hook"

--- a/prow/oss/cluster/hook-ghapp.yaml
+++ b/prow/oss/cluster/hook-ghapp.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hook
+  namespace: default
+  labels:
+    app: hook
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: hook
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: hook
+    spec:
+      serviceAccountName: hook
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: hook
+        image: gcr.io/k8s-prow/hook:v20211005-887a381aed
+        imagePullPolicy: Always
+        args:
+        - --config-path=/etc/config/config.yaml
+        - --job-config-path=/etc/job-config
+        - --dry-run=false
+        - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config-20201002:/etc/build-looker-32/kubeconfig:/etc/build-looker-16/kubeconfig:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+        ports:
+        - name: http
+          containerPort: 8888
+        - name: metrics
+          containerPort: 9090
+        volumeMounts:
+        - mountPath: /etc/build-looker-32
+          name: build-looker-32
+          readOnly: true
+        - mountPath: /etc/build-looker-16
+          name: build-looker-16
+          readOnly: true
+        - mountPath: /etc/build-looker-int-test
+          name: build-looker-int-test
+          readOnly: true
+        - mountPath: /etc/build-blueprints
+          name: build-blueprints
+          readOnly: true
+        - mountPath: /etc/build-elcarro
+          name: build-elcarro
+          readOnly: true
+        - mountPath: /etc/build-looker-private
+          name: build-looker-private
+          readOnly: true
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
+        - name: build-kubeflow
+          mountPath: /etc/build-kubeflow
+          readOnly: true
+        resources:
+          requests: # peak usage sampled by most recent usages of hook
+            memory: "4Gi"
+            cpu: "2"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 600
+      volumes:
+      - name: build-looker-32
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-32
+      - name: build-looker-16
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-16
+      - name: build-looker-int-test
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-int-test
+      - name: build-blueprints
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-blueprints
+      - name: build-elcarro
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-elcarro
+      - name: build-looker-private
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-looker-private
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: oauth-token-2
+      - name: config
+        configMap:
+          name: config
+      - name: job-config
+        configMap:
+          name: job-config
+      - name: plugins
+        configMap:
+          name: plugins
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
+      - name: build-kubeflow
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-kubeflow
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hook
+  name: hook
+  namespace: default
+spec:
+  selector:
+    app: hook
+  ports:
+  - name: main
+    port: 8888
+  - name: metrics
+    port: 9090
+  type: NodePort
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hook
+  namespace: default
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hook
+  namespace: default
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hook
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "hook"
+subjects:
+- kind: ServiceAccount
+  name: "hook"


### PR DESCRIPTION
Part of #1171 

This PR only sets up the ground for GitHub app workflow, prow won't take any action even if an org/repo installed the prow app, until they are added to allowlist with `- --github-enabled-org=<ORGREPO>`.

For easier code review this PR is broken down into 2 commits:
1. Copy/paste crier.yaml and hook.yaml
2. Change the new files to work with GitHub app