### PR TITLE
Chaotoppicks org opts in authentication with GH app

### DIFF
--- a/prow/oss/cluster/crier-ghapp.yaml
+++ b/prow/oss/cluster/crier-ghapp.yaml
@@ -35,6 +35,7 @@ spec:
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         - --github-enabled-org=repo-does-not-exist
+        - --github-enabled-org=chaotoppicks
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -33,6 +33,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/oauth
+        - --github-disabled-org=chaotoppicks
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1

--- a/prow/oss/cluster/hook-ghapp.yaml
+++ b/prow/oss/cluster/hook-ghapp.yaml
@@ -36,6 +36,7 @@ spec:
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         - --github-enabled-org=repo-does-not-exist
+        - --github-enabled-org=chaotoppicks
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -34,6 +34,7 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-disabled-org=chaotoppicks
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG


### PR DESCRIPTION
This change will make chaotoppicks org opt out of PAT auth, and use GH app auth instead.

This is for piloting GH app flow, will remove once everything is verified