### PR TITLE
Fix ingress for /ghapp-hook/hook

### DIFF
--- a/prow/oss/cluster/cluster.yaml
+++ b/prow/oss/cluster/cluster.yaml
@@ -104,38 +104,7 @@ metadata:
     kubernetes.io/ingress.class: "gce"
     kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: oss-prow-knative-dev,oss-prow-private-knative-dev
-spec:
-  rules:
-  - host: oss-prow.knative.dev
-    http:
-      paths:
-      - path: /*
-        backend:
-          serviceName: deck
-          servicePort: 80
-      - path: /hook
-        backend:
-          serviceName: hook
-          servicePort: 8888
-  - host: oss-prow-private.knative.dev
-    http:
-      paths:
-      - path: /*
-        backend:
-          serviceName: deck-private
-          servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: hook-ghapp-ing
-  namespace: default
-  annotations:
-    kubernetes.io/ingress.global-static-ip-name: "oss-prow"
-    kubernetes.io/ingress.class: "gce"
-    kubernetes.io/tls-acme: "true"
-    networking.gke.io/managed-certificates: oss-prow-knative-dev
-    # Rewrite path to strip /fakeghserver from path to match in cluster traffic.
+    # Rewrite path so that certain parts of the path can be picked.
     # Doc: https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/rewrite/README.md#rewrite-target
     nginx.ingress.kubernetes.io/rewrite-target: $1
 spec:
@@ -143,13 +112,28 @@ spec:
   - host: oss-prow.knative.dev
     http:
       paths:
+      - path: (/*)
+        backend:
+          serviceName: deck
+          servicePort: 80
+      - path: (/hook)
+        backend:
+          serviceName: hook
+          servicePort: 8888
       # `/ghapp-hook/hook` is the webhook endpoint exclusively for repos onboarding by installing GitHub app,
       # hook expects path with prefix of `/hook`, have to strip off `/ghapp-hook`.
       # Naming it `ghapp-hook` instead of `hook-ghapp` to avoid potential collision with ingress rule above that matches `/hook`.
-      - path: /ghapp-hook(/hook.*)
+      - path: /ghapp-hook(/hook)
         backend:
           serviceName: hook-ghapp
           servicePort: 8888
+  - host: oss-prow-private.knative.dev
+    http:
+      paths:
+      - path: (/*)
+        backend:
+          serviceName: deck-private
+          servicePort: 80
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
The existing ingress didn't work, very likely due to two ingresses using the same static ip address