### PR TITLE
Update terraform rules to switch to using 'prow-metrics' scoping project.

### DIFF
--- a/prow/oss/terraform/README.md
+++ b/prow/oss/terraform/README.md
@@ -18,8 +18,8 @@ This directory contains terrafrom configurations for provisioning monitoring and
 This is done once before initial provisioning of monitoring and alerting stacks.
 
 ```text
-    $ gsutil mb -p oss-prow gs://oss-prow-terraform
-    $ gsutil versioning set on gs://oss-prow-terraform
+    $ gsutil mb -p prow-metrics gs://prow-metrics-terraform
+    $ gsutil versioning set on gs://prow-metrics-terraform
 ```
 
 ### Provisioning

--- a/prow/oss/terraform/modules/alerts/boskos/main.tf
+++ b/prow/oss/terraform/modules/alerts/boskos/main.tf
@@ -57,7 +57,7 @@ resource "google_monitoring_alert_policy" "boskos-alerts" {
 # Enabled only when allowed_list is not empty, not enabled by default
 resource "google_monitoring_alert_policy" "boskos-alerts-selected" {
   project      = var.project
-  for_each      = var.allowed_list
+  for_each     = var.allowed_list
   display_name = "boskos-alerts-selected-${each.key}"
   combiner     = "OR" # required
 

--- a/prow/oss/terraform/modules/alerts/boskos/variables.tf
+++ b/prow/oss/terraform/modules/alerts/boskos/variables.tf
@@ -21,6 +21,6 @@ variable "notification_channel_id" {
 }
 
 variable "allowed_list" {
-  type = set(string)
+  type    = set(string)
   default = []
 }

--- a/prow/oss/terraform/modules/alerts/probers.tf
+++ b/prow/oss/terraform/modules/alerts/probers.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "google_monitoring_uptime_check_config" "https" {
-  project = var.project
+  project          = var.project
   selected_regions = []
 
   for_each = var.blackbox_probers
@@ -24,7 +24,7 @@ resource "google_monitoring_uptime_check_config" "https" {
 
   http_check {
     port         = "443"
-    use_ssl = true
+    use_ssl      = true
     validate_ssl = true
   }
 

--- a/prow/oss/terraform/modules/alerts/variables.tf
+++ b/prow/oss/terraform/modules/alerts/variables.tf
@@ -16,27 +16,33 @@ variable "project" {
   type = string
 }
 
-variable "heartbeat_job" {
-  type = map
-  default = {
-    job_name = ""
-    interval = ""
-    alert_interval = ""
-  }
+variable "heartbeat_jobs" {
+  // TODO(cjwagner): add object() specifications to type.
+  type    = list(any)
+  default = []
 }
 
 variable "notification_channel_id" {
   type = string
 }
 
-variable "prow_components" {
-  type = map
+variable "prow_instances" {
+  type = map(any)
   default = {
-    "svc_not_exist" = {"namespace": "default"}
+    "svc_not_exist" = { "namespace" : "default" }
   }
 }
 
 variable "blackbox_probers" {
-  type = set(string)
+  type    = set(string)
   default = []
+}
+
+variable "bot_token_hashes" {
+  type = list(string)
+}
+
+variable "no_webhook_alert_minutes" {
+  type    = map(number)
+  default = {}
 }


### PR DESCRIPTION
The 'prow-metrics' scoping project includes metrics from all the Prow
instances we manage. By deploying dashboards and alerts there we can
avoid duplication and additional infra for managing terraform in each
project.

/assign @chaodaiG 