### PR TITLE
Bump pull-test-infra-go-test to go version 1.16.

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -41,7 +41,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: golang:1.15
+        - image: golang:1.16
           command:
             - go
             - test


### PR DESCRIPTION
/assign @chaodaiG @listx 

This is needed to unblock https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1202.
It has to be in a separate PR like this because we are not using in-repo config for this repo.