### PR TITLE
Update alert notification channel to match channel in prow-metrics project.

### DIFF
--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -34,9 +34,9 @@ module "alert" {
     interval       = "300s"
     alert_interval = "1200s"
   }]
-  # gcloud alpha monitoring channels list --project=oss-prow
+  # gcloud alpha monitoring channels list --project=prow-metrics
   # grep displayName: prow-alert-pioneer
-  notification_channel_id = "13760821420809417519"
+  notification_channel_id = "1206225022273963240"
   prow_instances = {
     oss-prow = {
       deck : { namespace : "default" }


### PR DESCRIPTION
Follow up for something I missed in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1198

Once this merges I'll locally revert both these PRs, run `terraform destroy` to remove the alerts from oss-prow, checkout latest master, and finally run `terraform apply` to add alerts to prow-metrics.
/assign @chaodaiG 