### PR TITLE
Remove uptime_url checks that specify a path.

### DIFF
--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -73,9 +73,6 @@ module "alert" {
     "prow.k8s.io" : "k8s-prow",
     "testgrid.k8s.io" : "k8s-prow",
     "gubernator.k8s.io" : "k8s-prow",
-    "gubernator.k8s.io/pr/fejta" : "k8s-prow",
-    "storage.googleapis.com/k8s-gubernator/triage/index.html" : "k8s-prow",
-    "storage.googleapis.com/test-infra-oncall/oncall.html" : "k8s-prow",
   }
 
   bot_token_hashes = [

--- a/prow/oss/terraform/modules/alerts/probers.tf
+++ b/prow/oss/terraform/modules/alerts/probers.tf
@@ -32,8 +32,7 @@ resource "google_monitoring_uptime_check_config" "https" {
     type = "uptime_url"
     labels = {
       project_id = each.value
-      host       = split("/", each.key)[0]
-      path = (length(split("/", each.key)[0]) > 1 ? trimprefix(each.key, split("/", each.key)[0]) : null)
+      host       = each.key
     }
   }
 }


### PR DESCRIPTION
These checks failed to apply with errors like the following:
```
 Error: Error creating UptimeCheckConfig: googleapi: Error 400: A host name should not contain '/'. Consider moving everything following the first '/' to the 'path' field.;
│ uptime_url check has malformed host
│ 
│   with module.alert.google_monitoring_uptime_check_config.https["gubernator.k8s.io/pr/fejta"],
│   on modules/alerts/probers.tf line 15, in resource "google_monitoring_uptime_check_config" "https":
│   15: resource "google_monitoring_uptime_check_config" "https" {
│ 
╵
```

I tried to specify a `path` field as suggested (see first commit) and the apply was successful, but it doesn't seem like the field is being respected by terraform. Inspecting the check in the cloud console indicates that the path was never actually set. I suspect this field is not supported by the terraform rules which would explain why I couldn't find it in the documentation for the rule: 
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_uptime_check_config#argument-reference
- https://cloud.google.com/monitoring/api/resources#tag_uptime_url

For now I'm just removing the checks that don't target the root path of a host. I've already applied this change.

/assign @chaodaiG 