### PR TITLE
looker and oss-test-infra stop hmac rotation

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -244,16 +244,12 @@ managed_webhooks:
       token_created_after: 2021-04-22T00:10:00Z
     GoogleCloudPlatform/osconfig:
       token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/oss-test-infra:
-      token_created_after: 2021-04-22T00:10:00Z
     GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp:
       token_created_after: 2020-10-13T00:10:00Z
     GoogleCloudPlatform/testgrid:
       token_created_after: 2021-04-21T00:10:00Z
     kubeflow:
       token_created_after: 2020-12-06T00:10:00Z
-    looker:
-      token_created_after: 2021-04-28T00:10:00Z
     chaotoppicks:
       token_created_after: 2021-10-05T00:10:00Z
     google/bms-toolkit:


### PR DESCRIPTION
Both repos have migrated to webhooks configured with prow app. And currently these two repos are sending duplicated webhooks to prow, because of  and  settings on hook deployment only one set of them are handled, but still this is unnecessary burden to prow, so deleting the old webhook here