### PR TITLE
testgrid repo uses github app for authentication

### DIFF
--- a/prow/oss/cluster/crier-ghapp.yaml
+++ b/prow/oss/cluster/crier-ghapp.yaml
@@ -38,6 +38,7 @@ spec:
         - --github-enabled-org=chaotoppicks
         - --github-enabled-org=looker
         - --github-enabled-repo=GoogleCloudPlatform/oss-test-infra
+        - --github-enabled-repo=GoogleCloudPlatform/testgrid
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -36,6 +36,7 @@ spec:
         - --github-disabled-org=chaotoppicks
         - --github-disabled-org=looker
         - --github-disabled-repo=GoogleCloudPlatform/oss-test-infra
+        - --github-disabled-repo=GoogleCloudPlatform/testgrid
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1

--- a/prow/oss/cluster/hook-ghapp.yaml
+++ b/prow/oss/cluster/hook-ghapp.yaml
@@ -40,6 +40,7 @@ spec:
         - --github-enabled-org=chaotoppicks
         - --github-enabled-org=looker
         - --github-enabled-repo=GoogleCloudPlatform/oss-test-infra
+        - --github-enabled-repo=GoogleCloudPlatform/testgrid
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -37,6 +37,7 @@ spec:
         - --github-disabled-org=chaotoppicks
         - --github-disabled-org=looker
         - --github-disabled-repo=GoogleCloudPlatform/oss-test-infra
+        - --github-disabled-repo=GoogleCloudPlatform/testgrid
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG


### PR DESCRIPTION
This is part of https://github.com/GoogleCloudPlatform/oss-test-infra/issues/1171, I have requested installation of all repos under GoogleCloudPlatform that are currently using prow, and so far it seems like they are all approved. Trying this out on testgrid repo, will migrate others all at once if this proves to be working