### PR TITLE
Make helltool checkconfig job include core job config.

### DIFF
--- a/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
+++ b/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
@@ -17,4 +17,5 @@ presubmits:
         args:
         - --plugin-config=../../GoogleCloudPlatform/oss-test-infra/prow/oss/plugins.yaml
         - --config-path=../../GoogleCloudPlatform/oss-test-infra/prow/oss/config.yaml
+        - --job-config-path=../../GoogleCloudPlatform/oss-test-infra/prow/prowjobs
         - --prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)


### PR DESCRIPTION
I don't think this will make a difference, but should be done for consistency. May be important if we start caring about naming collisions later or for some subtle reasons.
/assign @chaodaiG 
/hold