### PR TITLE
Stop managing hmac tokens for GoogleCloudPlatform repos

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -216,42 +216,8 @@ managed_webhooks:
       token_created_after: 2021-04-22T00:10:00Z
     grpc-ecosystem/grpc-httpjson-transcoding:
       token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/artifact-registry-apt-transport:
-      token_created_after: 2021-03-04T00:10:00Z
-    GoogleCloudPlatform/artifact-registry-yum-plugin:
-      token_created_after: 2021-03-04T00:10:00Z
-    GoogleCloudPlatform/blueprints:
-      token_created_after: 2021-04-28T00:10:00Z
-    GoogleCloudPlatform/compute-image-tools:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/elcarro-oracle-operator:
-      token_created_after: 2021-05-01T00:10:00Z
-    GoogleCloudPlatform/esp-v2:
-      token_created_after: 2021-04-21T00:10:00Z
-    GoogleCloudPlatform/guest-agent:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/guest-configs:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/guest-diskexpand:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/guest-logging-go:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/guest-oslogin:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/guest-test-infra:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/k8s-cloud-provider:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/osconfig:
-      token_created_after: 2021-04-22T00:10:00Z
-    GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp:
-      token_created_after: 2020-10-13T00:10:00Z
-    GoogleCloudPlatform/testgrid:
-      token_created_after: 2021-04-21T00:10:00Z
     kubeflow:
       token_created_after: 2020-12-06T00:10:00Z
-    chaotoppicks:
-      token_created_after: 2021-10-05T00:10:00Z
     google/bms-toolkit:
       token_created_after: 2021-10-11T00:10:00Z      
 #    [org_name]/[repo_name]:


### PR DESCRIPTION
Managed hmac tokens are for setting up webhooks from legacy prow robot token, they are not required since GoogleCloudPlatform has migrated to use prow GitHub app for setting up webhooks