### PR TITLE
Looker performance tests dashboards typo fix

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -85,7 +85,7 @@ plank:
   pod_unscheduled_timeout: 5m
   build_cluster_status_file: 'gs://oss-prow/oss-prow-build-clusters-statuses.json'
   report_templates:
-    "looker/helltool": "View Performance Test Results Here:\n  [FrontEnd Tests](https://meta.looker.com/dashboards/8194?My%20Commit={{with index .Spec.Refs.Pulls 0}}{{.SHA}}{{end}})\n  [Backend Tests](https://meta.looker.com/dashboards/8195?My%20Commit={{with index .Spec.Refs.Pulls 0}}{{.SHA}}{{end}})"
+    "looker/helltool": "View Performance Test Results Here:\n  [Frontend Tests](https://meta.looker.com/dashboards/8195?My%20Commit={{with index .Spec.Refs.Pulls 0}}{{.SHA}}{{end}})\n  [Backend Tests](https://meta.looker.com/dashboards/8194?My%20Commit={{with index .Spec.Refs.Pulls 0}}{{.SHA}}{{end}})"
   default_decoration_config_entries:
   - config:
       timeout: 7200000000000 # 2h


### PR DESCRIPTION
The performance dashboards labeled Frontend tests as dashboard 8195 but they're actually 8194, likewise Backend tests are on dashboard 8195 but were labeled as 8194. This pull request fixes this labeling in the prow robot message for looker pull requests.