### PR TITLE
Add checkconfig canary jobs for looker and blueprints to try out unknown field validation of in repo config.

### DIFF
--- a/.prow/presubmits.yaml
+++ b/.prow/presubmits.yaml
@@ -17,6 +17,8 @@ presubmits:
           # Details: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/131#discussion_r334208082
           - --exclude-warning=mismatched-tide
           - --exclude-warning=non-decorated-jobs
+          - --warnings=unknown-fields-all
+          - --include-default-warnings
 - name: pull-lint-validator
   decorate: true
   always_run: true

--- a/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
@@ -17,3 +17,33 @@ presubmits:
         - --plugin-config=../../GoogleCloudPlatform/oss-test-infra/prow/oss/plugins.yaml
         - --config-path=../../GoogleCloudPlatform/oss-test-infra/prow/oss/config.yaml
         - --prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
+
+periodics:
+- name: ci-blueprints-validate-prow-yaml-canary
+  cluster: build-blueprints
+  interval: 30m
+  decorate: true
+  extra_refs:
+  - org: GoogleCloudPlatform
+    repo: blueprints
+    base_ref: master
+  - org: GoogleCloudPlatform
+    repo: oss-test-infra
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: "false"
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/checkconfig:v20211101-4a1678f936
+      command:
+      - /app/prow/cmd/checkconfig/app.binary
+      args:
+      - --plugin-config=../../GoogleCloudPlatform/oss-test-infra/prow/oss/plugins.yaml
+      - --config-path=../../GoogleCloudPlatform/oss-test-infra/prow/oss/config.yaml
+      - --job-config-path=../../GoogleCloudPlatform/oss-test-infra/prow/prowjobs
+      - --prow-yaml-repo-name=GoogleCloudPlatform/blueprints
+      - --strict
+      - --exclude-warning=mismatched-tide
+      - --exclude-warning=non-decorated-jobs
+      - --warnings=unknown-fields-all
+      - --include-default-warnings

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-postsubmits.yaml
@@ -5,21 +5,6 @@ postsubmits:
     branches:
     - ^master|release-.+$
     decorate: true
-    env:
-    - name: DOCKER_IN_DOCKER_ENABLED
-      value: "true"
-    volumes:
-    # kubekins-e2e legacy path
-    - name: docker-graph
-      emptyDir: {}
-    # krte (normal) path
-    - name: docker-root
-      emptyDir: {}
-    volumeMounts:
-    - name: docker-graph
-      mountPath: /docker-graph
-    - name: docker-root
-      mountPath: /var/lib/docker
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master

--- a/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
+++ b/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
@@ -19,3 +19,33 @@ presubmits:
         - --config-path=../../GoogleCloudPlatform/oss-test-infra/prow/oss/config.yaml
         - --job-config-path=../../GoogleCloudPlatform/oss-test-infra/prow/prowjobs
         - --prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
+
+periodics:
+- name: ci-looker-helltool-validate-prow-yaml-canary
+  cluster: build-looker-private
+  interval: 30m
+  decorate: true
+  extra_refs:
+  - org: looker
+    repo: helltool
+    base_ref: master
+  - org: GoogleCloudPlatform
+    repo: oss-test-infra
+    base_ref: master
+  annotations:
+    testgrid-create-test-group: "false"
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/checkconfig:v20211101-4a1678f936
+      command:
+      - /app/prow/cmd/checkconfig/app.binary
+      args:
+      - --plugin-config=../../GoogleCloudPlatform/oss-test-infra/prow/oss/plugins.yaml
+      - --config-path=../../GoogleCloudPlatform/oss-test-infra/prow/oss/config.yaml
+      - --job-config-path=../../GoogleCloudPlatform/oss-test-infra/prow/prowjobs
+      - --prow-yaml-repo-name=looker/helltool
+      - --strict
+      - --exclude-warning=mismatched-tide
+      - --exclude-warning=non-decorated-jobs
+      - --warnings=unknown-fields-all
+      - --include-default-warnings


### PR DESCRIPTION
Depends on https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1260 Only the latest commit is unique to this PR.
/hold
/assign @chaodaiG 

/cc @2nd-half @bharathkkb 
Once this is merged we'll get signal about any existing unknown field errors in the in-repo config. After we've addressed the errors we can enable these options for the main checkconfig presubmit.