### PR TITLE
Add missing clone_uri for looker checkconfig canary.

### DIFF
--- a/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
+++ b/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
@@ -29,6 +29,7 @@ periodics:
   - org: looker
     repo: helltool
     base_ref: master
+    clone_uri: git@github.com:looker/helltool.git
   - org: GoogleCloudPlatform
     repo: oss-test-infra
     base_ref: master


### PR DESCRIPTION
/assign @listx @mpherman2 

Clone is failing because I missed this.