### PR TITLE
Update uptime probe alerts to ignore extraneous uptime_checks.

### DIFF
--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -67,13 +67,13 @@ module "alert" {
     }
   }
   // blackbox_probers maps HTTPS hosts to the project they should be associated with.
-  blackbox_probers = {
-    "oss-prow.knative.dev" : "oss-prow",
+  blackbox_probers = [
+    "oss-prow.knative.dev",
 
-    "prow.k8s.io" : "k8s-prow",
-    "testgrid.k8s.io" : "k8s-prow",
-    "gubernator.k8s.io" : "k8s-prow",
-  }
+    "prow.k8s.io",
+    "testgrid.k8s.io",
+    "gubernator.k8s.io",
+  ]
 
   bot_token_hashes = [
     "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38" // google-oss-robot

--- a/prow/oss/terraform/modules/alerts/main.tf
+++ b/prow/oss/terraform/modules/alerts/main.tf
@@ -212,6 +212,7 @@ resource "google_monitoring_alert_policy" "probers" {
       fetch uptime_url
       | metric 'monitoring.googleapis.com/uptime_check/check_passed'
       | align next_older(1m)
+      | filter resource.project_id == '${var.project}'
       | every 1m
       | group_by [resource.host],
           [value_check_passed_not_count_true: count_true(not(value.check_passed))]

--- a/prow/oss/terraform/modules/alerts/probers.tf
+++ b/prow/oss/terraform/modules/alerts/probers.tf
@@ -31,7 +31,7 @@ resource "google_monitoring_uptime_check_config" "https" {
   monitored_resource {
     type = "uptime_url"
     labels = {
-      project_id = each.value
+      project_id = var.project
       host       = each.key
     }
   }

--- a/prow/oss/terraform/modules/alerts/variables.tf
+++ b/prow/oss/terraform/modules/alerts/variables.tf
@@ -35,8 +35,8 @@ variable "prow_instances" {
 
 // blackbox_probers maps HTTPS hosts to the project they should be associated with.
 variable "blackbox_probers" {
-  type    = map(string)
-  default = {}
+  type    = list(string)
+  default = []
 }
 
 variable "bot_token_hashes" {


### PR DESCRIPTION
Without this, `uptime_checks` configured in scoped projects will also be included, but we only care about the `uptime_checks` we are explicitly enumerating here.

/assign @chaodaiG 