### PR TITLE
Enable cloud monitoring alerts for knative-prow.

### DIFF
--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -39,6 +39,11 @@ module "alert" {
       job_name       = "ci-test-infra-prow-checkconfig"
       interval       = "300s"
       alert_interval = "1200s"
+    },
+    { // knative-prow
+      job_name       = "ci-knative-heartbeat"
+      interval       = "300s"
+      alert_interval = "1200s"
     }
   ]
   # gcloud alpha monitoring channels list --project=prow-metrics
@@ -65,23 +70,38 @@ module "alert" {
       sinker : { namespace : "default" }
       tide : { namespace : "default" }
     }
+    knative-prow = {
+      crier : { namespace : "default" }
+      deck : { namespace : "default" }
+      ghproxy : { namespace : "default" }
+      hook : { namespace : "default" }
+      horologium : { namespace : "default" }
+      prow-controller-manager : { namespace : "default" }
+      sinker : { namespace : "default" }
+      tide : { namespace : "default" }
+    }
   }
   // blackbox_probers maps HTTPS hosts to the project they should be associated with.
   blackbox_probers = [
+    // oss-prow
     "oss-prow.knative.dev",
-
+    // k8s-prow
     "prow.k8s.io",
     "testgrid.k8s.io",
     "gubernator.k8s.io",
+    // knative-prow
+    "https://prow.knative.dev",
   ]
 
   bot_token_hashes = [
-    "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38" // google-oss-robot
+    "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38", // google-oss-robot
+    "c7abc22fe95b5e3f849ab9fe9cd4809b5a1b950b44d0ea2bff1a5f1402d92b60", // knative-prow-robot
     // Ignore k8s-ci-robot until we resolve the token remaining inaccuracies.
-    // "6624f39f2213835d6c820aff41666853557f99155d23cc52cd9171bcbed3dccc" // k8s-ci-robot
+    // "6624f39f2213835d6c820aff41666853557f99155d23cc52cd9171bcbed3dccc", // k8s-ci-robot
   ]
   no_webhook_alert_minutes = {
     "oss-prow" = 15
     "k8s-prow" = 10
+    "knative-prow" = 60
   }
 }

--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -67,13 +67,13 @@ module "alert" {
     }
   }
   // blackbox_probers maps HTTPS hosts to the project they should be associated with.
-  blackbox_probers = {
-    "oss-prow.knative.dev" : "oss-prow",
+  blackbox_probers = [
+    "oss-prow.knative.dev",
 
-    "prow.k8s.io" : "k8s-prow",
-    "testgrid.k8s.io" : "k8s-prow",
-    "gubernator.k8s.io" : "k8s-prow",
-  }
+    "prow.k8s.io",
+    "testgrid.k8s.io",
+    "gubernator.k8s.io",
+  ]
 
   bot_token_hashes = [
     "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38" // google-oss-robot

--- a/prow/oss/terraform/modules/alerts/main.tf
+++ b/prow/oss/terraform/modules/alerts/main.tf
@@ -212,6 +212,7 @@ resource "google_monitoring_alert_policy" "probers" {
       fetch uptime_url
       | metric 'monitoring.googleapis.com/uptime_check/check_passed'
       | align next_older(1m)
+      | filter resource.project_id == '${var.project}'
       | every 1m
       | group_by [resource.host],
           [value_check_passed_not_count_true: count_true(not(value.check_passed))]

--- a/prow/oss/terraform/modules/alerts/probers.tf
+++ b/prow/oss/terraform/modules/alerts/probers.tf
@@ -31,7 +31,7 @@ resource "google_monitoring_uptime_check_config" "https" {
   monitored_resource {
     type = "uptime_url"
     labels = {
-      project_id = each.value
+      project_id = var.project
       host       = each.key
     }
   }

--- a/prow/oss/terraform/modules/alerts/variables.tf
+++ b/prow/oss/terraform/modules/alerts/variables.tf
@@ -35,8 +35,8 @@ variable "prow_instances" {
 
 // blackbox_probers maps HTTPS hosts to the project they should be associated with.
 variable "blackbox_probers" {
-  type    = map(string)
-  default = {}
+  type    = list(string)
+  default = []
 }
 
 variable "bot_token_hashes" {


### PR DESCRIPTION
Depends on https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1267
/hold

The first commit is from the other PR, just wanted to avoid a rebase.

/assign @chaodaiG 