### PR TITLE
Fix default branch name for blueprints checkconfig canary.

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
@@ -26,7 +26,7 @@ periodics:
   extra_refs:
   - org: GoogleCloudPlatform
     repo: blueprints
-    base_ref: master
+    base_ref: main
   - org: GoogleCloudPlatform
     repo: oss-test-infra
     base_ref: master


### PR DESCRIPTION
/assign @listx @mpherman2 
/cc @bharathkkb 

Whoops.