### PR TITLE
Add alerting config for istio-testing.

### DIFF
--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -39,6 +39,11 @@ module "alert" {
       job_name       = "ci-test-infra-prow-checkconfig"
       interval       = "300s"
       alert_interval = "1200s"
+    },
+    { // knative-prow
+      job_name       = "ci-knative-heartbeat"
+      interval       = "300s"
+      alert_interval = "1200s"
     }
   ]
   # gcloud alpha monitoring channels list --project=prow-metrics
@@ -65,23 +70,38 @@ module "alert" {
       sinker : { namespace : "default" }
       tide : { namespace : "default" }
     }
+    knative-prow = {
+      crier : { namespace : "default" }
+      deck : { namespace : "default" }
+      ghproxy : { namespace : "default" }
+      hook : { namespace : "default" }
+      horologium : { namespace : "default" }
+      prow-controller-manager : { namespace : "default" }
+      sinker : { namespace : "default" }
+      tide : { namespace : "default" }
+    }
   }
   // blackbox_probers maps HTTPS hosts to the project they should be associated with.
   blackbox_probers = [
+    // oss-prow
     "oss-prow.knative.dev",
-
+    // k8s-prow
     "prow.k8s.io",
     "testgrid.k8s.io",
     "gubernator.k8s.io",
+    // knative-prow
+    "https://prow.knative.dev",
   ]
 
   bot_token_hashes = [
-    "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38" // google-oss-robot
+    "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38", // google-oss-robot
+    "c7abc22fe95b5e3f849ab9fe9cd4809b5a1b950b44d0ea2bff1a5f1402d92b60", // knative-prow-robot
     // Ignore k8s-ci-robot until we resolve the token remaining inaccuracies.
-    // "6624f39f2213835d6c820aff41666853557f99155d23cc52cd9171bcbed3dccc" // k8s-ci-robot
+    // "6624f39f2213835d6c820aff41666853557f99155d23cc52cd9171bcbed3dccc", // k8s-ci-robot
   ]
   no_webhook_alert_minutes = {
     "oss-prow" = 15
     "k8s-prow" = 10
+    "knative-prow" = 60
   }
 }

--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -67,13 +67,13 @@ module "alert" {
     }
   }
   // blackbox_probers maps HTTPS hosts to the project they should be associated with.
-  blackbox_probers = {
-    "oss-prow.knative.dev" : "oss-prow",
+  blackbox_probers = [
+    "oss-prow.knative.dev",
 
-    "prow.k8s.io" : "k8s-prow",
-    "testgrid.k8s.io" : "k8s-prow",
-    "gubernator.k8s.io" : "k8s-prow",
-  }
+    "prow.k8s.io",
+    "testgrid.k8s.io",
+    "gubernator.k8s.io",
+  ]
 
   bot_token_hashes = [
     "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38" // google-oss-robot

--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -80,6 +80,16 @@ module "alert" {
       sinker : { namespace : "default" }
       tide : { namespace : "default" }
     }
+    istio-testing = {
+      crier : { namespace : "default" }
+      deck : { namespace : "default" }
+      ghproxy : { namespace : "default" }
+      hook : { namespace : "default" }
+      horologium : { namespace : "default" }
+      prow-controller-manager : { namespace : "default" }
+      sinker : { namespace : "default" }
+      tide : { namespace : "default" }
+    }
   }
   // blackbox_probers maps HTTPS hosts to the project they should be associated with.
   blackbox_probers = [
@@ -91,11 +101,14 @@ module "alert" {
     "gubernator.k8s.io",
     // knative-prow
     "https://prow.knative.dev",
+    // istio-testing
+    "https://prow.istio.io",
   ]
 
   bot_token_hashes = [
     "5514c8081c74362c58993e5de935cb92e38cc9397e57a72883c1878cfcdd4b38", // google-oss-robot
     "c7abc22fe95b5e3f849ab9fe9cd4809b5a1b950b44d0ea2bff1a5f1402d92b60", // knative-prow-robot
+    "89baaef92d6c5da4c2261911d273d4a01ef27d80f2bb7d517185f6f0416be8b5", // istio-testing
     // Ignore k8s-ci-robot until we resolve the token remaining inaccuracies.
     // "6624f39f2213835d6c820aff41666853557f99155d23cc52cd9171bcbed3dccc", // k8s-ci-robot
   ]
@@ -103,5 +116,6 @@ module "alert" {
     "oss-prow" = 15
     "k8s-prow" = 10
     "knative-prow" = 60
+    "istio-testing" = 30
   }
 }

--- a/prow/oss/terraform/modules/alerts/main.tf
+++ b/prow/oss/terraform/modules/alerts/main.tf
@@ -212,6 +212,7 @@ resource "google_monitoring_alert_policy" "probers" {
       fetch uptime_url
       | metric 'monitoring.googleapis.com/uptime_check/check_passed'
       | align next_older(1m)
+      | filter resource.project_id == '${var.project}'
       | every 1m
       | group_by [resource.host],
           [value_check_passed_not_count_true: count_true(not(value.check_passed))]

--- a/prow/oss/terraform/modules/alerts/probers.tf
+++ b/prow/oss/terraform/modules/alerts/probers.tf
@@ -31,7 +31,7 @@ resource "google_monitoring_uptime_check_config" "https" {
   monitored_resource {
     type = "uptime_url"
     labels = {
-      project_id = each.value
+      project_id = var.project
       host       = each.key
     }
   }

--- a/prow/oss/terraform/modules/alerts/variables.tf
+++ b/prow/oss/terraform/modules/alerts/variables.tf
@@ -35,8 +35,8 @@ variable "prow_instances" {
 
 // blackbox_probers maps HTTPS hosts to the project they should be associated with.
 variable "blackbox_probers" {
-  type    = map(string)
-  default = {}
+  type    = list(string)
+  default = []
 }
 
 variable "bot_token_hashes" {


### PR DESCRIPTION
Depends on https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1268 which depends on https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1267
/hold
First two commits are from those PRs.

/assign @chaodaiG 