### PR TITLE
Fix blackbox probe terraform config.

### DIFF
--- a/prow/oss/terraform/main.tf
+++ b/prow/oss/terraform/main.tf
@@ -100,9 +100,9 @@ module "alert" {
     "testgrid.k8s.io",
     "gubernator.k8s.io",
     // knative-prow
-    "https://prow.knative.dev",
+    "prow.knative.dev",
     // istio-testing
-    "https://prow.istio.io",
+    "prow.istio.io",
   ]
 
   bot_token_hashes = [

--- a/prow/oss/terraform/modules/alerts/variables.tf
+++ b/prow/oss/terraform/modules/alerts/variables.tf
@@ -35,7 +35,7 @@ variable "prow_instances" {
 
 // blackbox_probers maps HTTPS hosts to the project they should be associated with.
 variable "blackbox_probers" {
-  type    = list(string)
+  type    = set(string)
   default = []
 }
 


### PR DESCRIPTION
`terraform validate` didn't catch
1. the invalid host names
2. the type problem. `for_each` only works for sets and maps, not lists. (I'm surprised this wasn't caught)

I've already applied the config with these changes.
/assign @chaodaiG 