### PR TITLE
Make looker checkconfig presubmit include strict validation.

### DIFF
--- a/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
+++ b/prow/prowjobs/private-inrepoconfig-configcheck/looker/helltool/hellotool.yaml
@@ -19,34 +19,8 @@ presubmits:
         - --config-path=../../GoogleCloudPlatform/oss-test-infra/prow/oss/config.yaml
         - --job-config-path=../../GoogleCloudPlatform/oss-test-infra/prow/prowjobs
         - --prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
-
-periodics:
-- name: ci-looker-helltool-validate-prow-yaml-canary
-  cluster: build-looker-private
-  interval: 30m
-  decorate: true
-  extra_refs:
-  - org: looker
-    repo: helltool
-    base_ref: master
-    clone_uri: git@github.com:looker/helltool.git
-  - org: GoogleCloudPlatform
-    repo: oss-test-infra
-    base_ref: master
-  annotations:
-    testgrid-create-test-group: "false"
-  spec:
-    containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20211104-890606cd6b
-      command:
-      - /app/prow/cmd/checkconfig/app.binary
-      args:
-      - --plugin-config=../../GoogleCloudPlatform/oss-test-infra/prow/oss/plugins.yaml
-      - --config-path=../../GoogleCloudPlatform/oss-test-infra/prow/oss/config.yaml
-      - --job-config-path=../../GoogleCloudPlatform/oss-test-infra/prow/prowjobs
-      - --prow-yaml-repo-name=looker/helltool
-      - --strict
-      - --exclude-warning=mismatched-tide
-      - --exclude-warning=non-decorated-jobs
-      - --warnings=unknown-fields-all
-      - --include-default-warnings
+        - --strict
+        - --exclude-warning=mismatched-tide
+        - --exclude-warning=non-decorated-jobs
+        - --warnings=unknown-fields-all
+        - --include-default-warnings


### PR DESCRIPTION
/hold

This change has been tested with a canary periodic job to confirm there are no existing problems that would cause the new stricter validation to block PRs: https://oss-prow-private.knative.dev/?job=ci-looker-helltool-validate-prow-yaml-canary
@2nd-half 

/assign @chaodaiG 