### PR TITLE
github/google org switches to use GitHub app for prow

### DIFF
--- a/prow/oss/cluster/crier-ghapp.yaml
+++ b/prow/oss/cluster/crier-ghapp.yaml
@@ -39,6 +39,7 @@ spec:
         - --github-enabled-org=looker
         - --github-enabled-org=GoogleCloudPlatform
         - --github-enabled-org=kubeflow
+        - --github-enabled-org=google
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -37,6 +37,7 @@ spec:
         - --github-disabled-org=looker
         - --github-disabled-org=GoogleCloudPlatform
         - --github-disabled-org=kubeflow
+        - --github-disabled-org=google
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1

--- a/prow/oss/cluster/hook-ghapp.yaml
+++ b/prow/oss/cluster/hook-ghapp.yaml
@@ -41,6 +41,7 @@ spec:
         - --github-enabled-org=looker
         - --github-enabled-org=GoogleCloudPlatform
         - --github-enabled-org=kubeflow
+        - --github-enabled-org=google
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -38,6 +38,7 @@ spec:
         - --github-disabled-org=looker
         - --github-disabled-org=GoogleCloudPlatform
         - --github-disabled-org=kubeflow
+        - --github-disabled-org=google
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG


### PR DESCRIPTION
The prow app was installed in http_pattern_matcher and bms-toolkit repos