### PR TITLE
Stop managing hmac tokens for grpc repos

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -212,8 +212,6 @@ managed_webhooks:
   org_repo_config:
     googleforgames/agones:
       token_created_after: 2021-04-22T00:10:00Z
-    grpc-ecosystem/grpc-httpjson-transcoding:
-      token_created_after: 2021-04-22T00:10:00Z
 #    [org_name]/[repo_name]:
 #      token_created_after: 2020-08-18T00:10:00Z
 


### PR DESCRIPTION
Managed hmac tokens are for setting up webhooks from legacy prow robot token, they are not required since grpc has migrated to use prow GitHub app for setting up webhooks