### PR TITLE
Migrate tide to use GitHub app

### DIFF
--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -26,34 +26,41 @@ spec:
         - --dry-run=false
         - --history-uri=gs://oss-prow/tide-history.json
         - --status-path=gs://oss-prow/tide-status-checkpoint.yaml
-        - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: ghapp-token
+              key: appid
         ports:
         - name: http
           containerPort: 8888
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - name: oauth
-          mountPath: /etc/github
-          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: ghapp-token
+          mountPath: /etc/github
+          readOnly: true
       volumes:
-      - name: oauth
-        secret:
-          secretName: oauth-token-2
       - name: config
         configMap:
           name: config
       - name: job-config
         configMap:
           name: job-config
+      - name: ghapp-token
+        secret:
+          secretName: ghapp-token
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Now that all prow tenants have migrated to use GitHub apps, migrate tide to use app authentication should be no blockers.

Note that tide doesn't get the tokens benefits as hook and crier, so we might still run into rate limit issue when there are lots of repos enable tide. However it shouldn't be worse than today