### PR TITLE
Migrate sub to use GitHub app

### DIFF
--- a/prow/oss/cluster/sub.yaml
+++ b/prow/oss/cluster/sub.yaml
@@ -29,8 +29,15 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --grace-period=110s
-        - --github-token-path=/etc/github/oauth
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --dry-run=false
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: ghapp-token
+              key: appid
         ports:
         - name: http
           containerPort: 80
@@ -41,7 +48,7 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
-        - name: oauth
+        - name: ghapp-token
           mountPath: /etc/github
           readOnly: true
         resources:
@@ -59,9 +66,9 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      - name: oauth
+      - name: ghapp-token
         secret:
-          secretName: oauth-token-2
+          secretName: ghapp-token
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Now that all prow tenants have migrated to use GitHub apps, migrate sub to use app authentication should be no blockers.

The only place where GitHub authentication is used in sub is for cloning repos to figure out inrepoconfig prow jobs, this had been proved to be working in hook, the risk should be low