### PR TITLE
Oss prow: crier and hook use GitHub app only

### DIFF
--- a/prow/oss/cluster/crier-ghapp.yaml
+++ b/prow/oss/cluster/crier-ghapp.yaml
@@ -7,7 +7,8 @@ metadata:
   labels:
     app: crier-ghapp
 spec:
-  replicas: 1
+  # The postsubmit job doesn't delete deployment, scaling this down to 0 so that there is no duplicated deployments handling the same workloads
+  replicas: 0
   selector:
     matchLabels:
       app: crier-ghapp

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -32,14 +32,8 @@ spec:
         - --pubsub-workers=1
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github/oauth
-        - --github-disabled-org=chaotoppicks
-        - --github-disabled-org=looker
-        - --github-disabled-org=GoogleCloudPlatform
-        - --github-disabled-org=kubeflow
-        - --github-disabled-org=google
-        - --github-disabled-org=googleforgames
-        - --github-disabled-repo=grpc-ecosystem/grpc-httpjson-transcoding
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --github-workers=6
         - --job-config-path=/etc/job-config
         - --kubernetes-blob-storage-workers=1
@@ -47,6 +41,11 @@ spec:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-looker-32/kubeconfig:/etc/build-looker-16/kubeconfig:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: ghapp-token
+              key: appid
         ports:
         - name: metrics
           containerPort: 9090
@@ -87,7 +86,7 @@ spec:
         - name: build-kubeflow
           mountPath: /etc/build-kubeflow
           readOnly: true
-        - name: oauth
+        - name: ghapp-token
           mountPath: /etc/github
           readOnly: true
         - name: knative-slack-token
@@ -140,9 +139,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-kubeflow
-      - name: oauth
+      - name: ghapp-token
         secret:
-          secretName: oauth-token-2
+          secretName: ghapp-token
       - name: knative-slack-token
         secret:
           secretName: knative-slack-token

--- a/prow/oss/cluster/hook-ghapp.yaml
+++ b/prow/oss/cluster/hook-ghapp.yaml
@@ -7,7 +7,8 @@ metadata:
   labels:
     app: hook-ghapp
 spec:
-  replicas: 6
+  # # The postsubmit job doesn't delete deployment, scaling this down to 0 so that there is no duplicated deployments handling the same workloads
+  replicas: 0
   selector:
     matchLabels:
       app: hook-ghapp

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -28,23 +28,23 @@ spec:
         image: gcr.io/k8s-prow/hook:v20211104-24023f1a35
         imagePullPolicy: Always
         args:
+        - --webhook-path=/ghapp-hook
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-disabled-org=chaotoppicks
-        - --github-disabled-org=looker
-        - --github-disabled-org=GoogleCloudPlatform
-        - --github-disabled-org=kubeflow
-        - --github-disabled-org=google
-        - --github-disabled-org=googleforgames
-        - --github-disabled-repo=grpc-ecosystem/grpc-httpjson-transcoding
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
           value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-looker-32/kubeconfig:/etc/build-looker-16/kubeconfig:/etc/build-looker-int-test/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-looker-private/kubeconfig:/etc/build-kubeflow/kubeconfig"
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: ghapp-token
+              key: appid
         ports:
         - name: http
           containerPort: 8888
@@ -75,7 +75,7 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: oauth
+        - name: ghapp-token
           mountPath: /etc/github
           readOnly: true
         - name: config
@@ -141,10 +141,10 @@ spec:
           secretName: kubeconfig-build-looker-private
       - name: hmac
         secret:
-          secretName: hmac-token
-      - name: oauth
+          secretName: ghapp-hmac-token
+      - name: ghapp-token
         secret:
-          secretName: oauth-token-2
+          secretName: ghapp-token
       - name: config
         configMap:
           name: config

--- a/prow/oss/cluster/monitoring/prow_podmonitors.yaml
+++ b/prow/oss/cluster/monitoring/prow_podmonitors.yaml
@@ -61,25 +61,6 @@ apiVersion: monitoring.gke.io/v1alpha1
 kind: PodMonitor
 metadata:
   labels:
-    app: hook-ghapp
-  name: hook-ghapp
-  namespace: prow-monitoring
-spec:
-  podMetricsEndpoints:
-  - interval: 30s
-    port: metrics
-    scheme: http
-  namespaceSelector:
-    matchNames:
-    - default
-  selector:
-    matchLabels:
-      app: hook-ghapp
----
-apiVersion: monitoring.gke.io/v1alpha1
-kind: PodMonitor
-metadata:
-  labels:
     app: plank
   name: plank
   namespace: prow-monitoring
@@ -170,25 +151,6 @@ spec:
   selector:
     matchLabels:
       app: crier
----
-apiVersion: monitoring.gke.io/v1alpha1
-kind: PodMonitor
-metadata:
-  labels:
-    app: crier-ghapp
-  name: crier-ghapp
-  namespace: prow-monitoring
-spec:
-  podMetricsEndpoints:
-  - interval: 30s
-    port: metrics
-    scheme: http
-  namespaceSelector:
-    matchNames:
-    - default
-  selector:
-    matchLabels:
-      app: crier-ghapp
 ---
 apiVersion: monitoring.gke.io/v1alpha1
 kind: PodMonitor


### PR DESCRIPTION
Now that everything has migrated, crier and hook deployments that use PAT are no longer serving any traffics. Remove them so that we don't need to do the --enabled-repos and --disabled-repos trick any more