### PR TITLE
Webhooks from prow app send to hook

### DIFF
--- a/prow/oss/cluster/cluster.yaml
+++ b/prow/oss/cluster/cluster.yaml
@@ -113,13 +113,9 @@ spec:
         backend:
           serviceName: deck
           servicePort: 80
-      - path: /hook
-        backend:
-          serviceName: hook
-          servicePort: 8888
       - path: /ghapp-hook
         backend:
-          serviceName: hook-ghapp
+          serviceName: hook
           servicePort: 8888
   - host: oss-prow-private.knative.dev
     http:


### PR DESCRIPTION
This was missing from previous PR, and hook didn't work. Prow cluster is fixed temporarily with https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1299. We can choose merging either that one or this PR