### PR TITLE
compute-image-tools: Add presubmit for module tests

### DIFF
--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -26,4 +26,4 @@ set -o pipefail
 export CONFIG_PATH="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/oss/config.yaml)"
 export JOB_CONFIG_PATH="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/prowjobs)"
 
-bash <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"
+bash -x  <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"

--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -26,4 +26,4 @@ set -o pipefail
 export CONFIG_PATH="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/oss/config.yaml)"
 export JOB_CONFIG_PATH="$(readlink -f $(dirname "${BASH_SOURCE[0]}")/prowjobs)"
 
-bash -x  <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"
+bash <(curl -sSfL https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/pj-on-kind.sh) "$@"

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -1,3 +1,31 @@
+postsubmits:
+  GoogleCloudPlatform/compute-image-tools:
+  - name: cli-tools-postsubmit-module-tests
+    cluster: gcp-guest
+    decorate: true
+    annotations:
+      testgrid-dashboards: google-gce-compute-image-tools
+      testgrid-tab-name: module-tests
+      description: "Postsubmit tests; executes cli_tools_tests/module/"
+    branches:
+      - ^master$
+    labels:
+      preset-daisy: "true"
+    spec:
+      containers:
+        - image: gcr.io/gcp-guest/gotest:latest
+          imagePullPolicy: Always
+          command:
+            - "/go/main.sh"
+          args:
+           - "cli_tools_tests/module/"
+           - "-test.timeout=30m"
+          env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: compute-image-test-pool-001
+            - name: GOOGLE_CLOUD_ZONE
+              value: us-central1-a
+
 presubmits:
   GoogleCloudPlatform/compute-image-tools:
   - name: compute-image-tools-flake8
@@ -41,52 +69,6 @@ presubmits:
         command:
         - "/go/main.sh"
         args: ["cli_tools/"]
-  - name: cli-tools-presubmit-diskinspect-module-tests
-    cluster: gcp-guest
-    skip_report: true
-    always_run: false
-    run_if_changed: 'daisy_workflows/image_import/inspection/.*|cli_tools/common/disk/.*|cli_tools_tests/module/diskinspect/.*'
-    trigger: "(?m)^/cli-tools-module-tests$"
-    rerun_command: "/cli-tools-module-tests"
-    context: prow/presubmit/cli-tools-presubmit-diskinspect-module-tests
-    decorate: true
-    labels:
-      preset-daisy: "true"
-    spec:
-      containers:
-        - image: gcr.io/gcp-guest/gotest:latest
-          imagePullPolicy: Always
-          command:
-            - "/go/main.sh"
-          args: ["cli_tools_tests/module/diskinspect/"]
-          env:
-            - name: GOOGLE_CLOUD_PROJECT
-              value: compute-image-test-pool-001
-            - name: GOOGLE_CLOUD_ZONE
-              value: us-central1-a
-  - name: cli-tools-presubmit-import-module-tests
-    cluster: gcp-guest
-    skip_report: true
-    always_run: false
-    run_if_changed: 'cli_tools/gce_vm_image_import/.*|cli_tools/common/image/.*|cli_tools_tests/module/import/.*'
-    trigger: "(?m)^/cli-tools-module-tests$"
-    rerun_command: "/cli-tools-module-tests"
-    context: prow/presubmit/cli-tools-presubmit-import-module-tests
-    decorate: true
-    labels:
-      preset-daisy: "true"
-    spec:
-      containers:
-        - image: gcr.io/gcp-guest/gotest:latest
-          imagePullPolicy: Always
-          command:
-            - "/go/main.sh"
-          args: ["cli_tools_tests/module/import/"]
-          env:
-            - name: GOOGLE_CLOUD_PROJECT
-              value: compute-image-test-pool-001
-            - name: GOOGLE_CLOUD_ZONE
-              value: us-central1-a
   - name: cli-tools-presubmit-gotest
     cluster: gcp-guest
     run_if_changed: 'cli_tools/.*'

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -41,14 +41,14 @@ presubmits:
         command:
         - "/go/main.sh"
         args: ["cli_tools/"]
-  - name: cli-tools-presubmit-module-tests
+  - name: cli-tools-presubmit-diskinspect-module-tests
     cluster: gcp-guest
     skip_report: true
     always_run: false
-    run_if_changed: 'cli_tools/.*'
+    run_if_changed: 'daisy_workflows/image_import/inspection/.*|cli_tools/common/disk/.*|cli_tools_tests/module/diskinspect/.*'
     trigger: "(?m)^/cli-tools-module-tests$"
     rerun_command: "/cli-tools-module-tests"
-    context: prow/presubmit/module-tests
+    context: prow/presubmit/cli-tools-presubmit-diskinspect-module-tests
     decorate: true
     labels:
       preset-daisy: "true"
@@ -58,7 +58,35 @@ presubmits:
           imagePullPolicy: Always
           command:
             - "/go/main.sh"
-          args: ["cli_tools_tests/module/"]
+          args: ["cli_tools_tests/module/diskinspect/"]
+          env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: compute-image-test-pool-001
+            - name: GOOGLE_CLOUD_ZONE
+              value: us-central1-a
+  - name: cli-tools-presubmit-import-module-tests
+    cluster: gcp-guest
+    skip_report: true
+    always_run: false
+    run_if_changed: 'cli_tools/gce_vm_image_import/.*|cli_tools/common/image/.*|cli_tools_tests/module/import/.*'
+    trigger: "(?m)^/cli-tools-module-tests$"
+    rerun_command: "/cli-tools-module-tests"
+    context: prow/presubmit/cli-tools-presubmit-import-module-tests
+    decorate: true
+    labels:
+      preset-daisy: "true"
+    spec:
+      containers:
+        - image: gcr.io/gcp-guest/gotest:latest
+          imagePullPolicy: Always
+          command:
+            - "/go/main.sh"
+          args: ["cli_tools_tests/module/import/"]
+          env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: compute-image-test-pool-001
+            - name: GOOGLE_CLOUD_ZONE
+              value: us-central1-a
   - name: cli-tools-presubmit-gotest
     cluster: gcp-guest
     run_if_changed: 'cli_tools/.*'

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -4,7 +4,7 @@ postsubmits:
     cluster: gcp-guest
     decorate: true
     annotations:
-      testgrid-dashboards: google-gce-compute-image-tools
+      testgrid-dashboards: googleoss-gcp-guest-import-export
       testgrid-tab-name: module-tests
       description: "Postsubmit tests; executes cli_tools_tests/module/"
     branches:

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -41,6 +41,24 @@ presubmits:
         command:
         - "/go/main.sh"
         args: ["cli_tools/"]
+  - name: cli-tools-presubmit-module-tests
+    cluster: gcp-guest
+    skip_report: true
+    always_run: false
+    run_if_changed: 'cli_tools/.*'
+    trigger: "(?m)^/cli-tools-module-tests$"
+    rerun_command: "/cli-tools-module-tests"
+    context: prow/presubmit/module-tests
+    decorate: true
+    labels:
+      preset-daisy: "true"
+    spec:
+      containers:
+        - image: gcr.io/gcp-guest/gotest:latest
+          imagePullPolicy: Always
+          command:
+            - "/go/main.sh"
+          args: ["cli_tools_tests/module/"]
   - name: cli-tools-presubmit-gotest
     cluster: gcp-guest
     run_if_changed: 'cli_tools/.*'

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -1,5 +1,6 @@
 postsubmits:
   GoogleCloudPlatform/compute-image-tools:
+  # Integ tests that need credentials to create resources in a GCP project.
   - name: cli-tools-postsubmit-module-tests
     cluster: gcp-guest
     decorate: true

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -2,6 +2,7 @@
 # A prow annotation will be invalid if it references a dashboard that doesn't exist
 dashboards:
 - name: googleoss-gcp-guest
+- name: googleoss-gcp-guest-import-export
 - name: googleoss-test-infra
 - name: googleoss-esp-v2-presubmit
 - name: googleoss-esp-v2-postsubmit
@@ -15,6 +16,7 @@ dashboard_groups:
   - name: googleoss
     dashboard_names:
     - googleoss-gcp-guest
+    - googleoss-gcp-guest-import-export
     - googleoss-test-infra
     - googleoss-esp-v2-presubmit
     - googleoss-esp-v2-postsubmit


### PR DESCRIPTION
This configures a new job that will run the module tests in `cli_tools_test/module`. They're configured using the recommendation from  [jobs.md](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md):

> A useful pattern when adding new jobs is to start with always_run set to false and skip_report set to true. Test it out a few times by manually triggering, then switch always_run to true. Watch for a couple days, then switch skip_report to false.