### PR TITLE
Revert "Revert "Migrate sub to use GitHub app""

### DIFF
--- a/prow/oss/cluster/sub.yaml
+++ b/prow/oss/cluster/sub.yaml
@@ -29,8 +29,15 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --grace-period=110s
-        - --github-token-path=/etc/github/oauth
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --dry-run=false
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: ghapp-token
+              key: appid
         ports:
         - name: http
           containerPort: 80
@@ -41,7 +48,7 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
-        - name: oauth
+        - name: ghapp-token
           mountPath: /etc/github
           readOnly: true
         resources:
@@ -59,9 +66,9 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      - name: oauth
+      - name: ghapp-token
         secret:
-          secretName: oauth-token-2
+          secretName: ghapp-token
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
This reverts commit 903422627e7cda928d286fa9dc11a998cded914c.

The initial bug was fixed in https://github.com/kubernetes/test-infra/pull/24317, should work now