### PR TITLE
Oss-prow autobump PR not assigned to anyone

### DIFF
--- a/prow/oss/oss-autobump-config.yaml
+++ b/prow/oss/oss-autobump-config.yaml
@@ -3,6 +3,7 @@ gitHubLogin: "google-oss-robot"
 gitHubToken: "/etc/github-token/oauth"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
 skipPullRequest: false
+selfAssign: true # Commenting `/cc`, so that autobump PR is not assigned to anyone
 gitHubOrg: "GoogleCloudPlatform"
 gitHubRepo: "oss-test-infra"
 remoteName: "oss-test-infra"


### PR DESCRIPTION
It's proved to work as https://github.com/kubernetes/test-infra/pull/24414