### PR TITLE
Use cli-tools-module-tests image for import/export module tests

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -14,13 +14,17 @@ postsubmits:
       preset-daisy: "true"
     spec:
       containers:
-        - image: gcr.io/gcp-guest/gotest:latest
+        - image: gcr.io/gcp-guest/cli-tools-module-tests:latest
+          # The security context is required to allow gcsfuse to create a mount.
+          securityContext:
+            privileged: true
           imagePullPolicy: Always
           command:
             - "/go/main.sh"
           args:
            - "cli_tools_tests/module/"
            - "-test.timeout=30m"
+           - "-test.parallel=8"
           env:
             - name: GOOGLE_CLOUD_PROJECT
               value: compute-image-test-pool-001


### PR DESCRIPTION
This fixes the failure in the [file_inspection_test](https://oss-prow.knative.dev/view/gs/oss-prow/logs/cli-tools-postsubmit-module-tests/1461800655155892224) from https://github.com/GoogleCloudPlatform/compute-image-tools/pull/1790.

`exec: "gcsfuse": executable file not found in $PATH`

Testing:
  - Ran `pj-on-kind.sh cli-tools-postsubmit-module-tests` using a locally-built image.

@dntczdx 