### PR TITLE
gcp-guest: exclude oslogin from CIT

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -502,3 +502,4 @@ periodics:
       - "-zone=us-west1-a"
       - "-images=projects/bct-prod-images/global/images/family/debian-9,projects/bct-prod-images/global/images/family/debian-10,projects/bct-prod-images/global/images/family/debian-11,projects/bct-prod-images/global/images/family/centos-7,projects/bct-prod-images/global/images/family/centos-8,projects/bct-prod-images/global/images/family/rhel-7,projects/bct-prod-images/global/images/family/rhel-8,projects/bct-prod-images/global/images/family/almalinux-8"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-exclude=oslogin"


### PR DESCRIPTION
OS Login tests only work in one project - we will start by running them separately