### PR TITLE
pipelines: Add gcp_marketplace presubmit test

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -84,7 +84,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
+      - image: alpine:3.15.0
         command:
         - ./manifests/gcp_marketplace/test/presubmit.sh
   - name: kubeflow-pipeline-upgrade-test

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -78,6 +78,15 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
         command:
         - ./test/presubmit-tests-mkp.sh
+  - name: kubeflow-pipeline-mkp-snapshot-test
+    run_if_changed: "^(manifests/gcp_marketplace/.*)$"
+    cluster: build-kubeflow
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
+        command:
+        - ./manifests/gcp_marketplace/test/presubmit.sh
   - name: kubeflow-pipeline-upgrade-test
     run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
     cluster: build-kubeflow


### PR DESCRIPTION
Enable snapshot test to enforce validation.

https://github.com/kubeflow/pipelines/blob/master/manifests/gcp_marketplace/test/presubmit.sh