### PR TITLE
pipelines: Merge two commands to one line for mkp-snapshot-test

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -55,8 +55,7 @@ presubmits:
         - /bin/sh 
         args:
         - -c
-        - cd ./manifests/gcp_marketplace/test
-        - sh ./presubmit.sh
+        - cd ./manifests/gcp_marketplace/test && sh ./presubmit.sh
   - name: kubeflow-pipeline-upgrade-test
     run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
     cluster: build-kubeflow


### PR DESCRIPTION
The test doesn't generate any log, try to combine two commands to test it out.

https://pantheon.corp.google.com/storage/browser/_details/oss-prow/pr-logs/pull/kubeflow_pipelines/7153/kubeflow-pipeline-mkp-snapshot-test/1479705100409638912/build-log.txt;tab=live_object

@Bobgy 