### PR TITLE
pipelines: Use bash alpine for mktplace snapshot presubmit

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -50,13 +50,12 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: alpine:3.15.0
+      - image: bash:alpine3.14
         command:
-        - /bin/sh 
+        - /usr/local/bin/bash
         args:
         - -c
-        - cd ./manifests/gcp_marketplace/test
-        - sh ./presubmit.sh
+        - cd ./manifests/gcp_marketplace/test && bash ./presubmit.sh
   - name: kubeflow-pipeline-upgrade-test
     run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
     cluster: build-kubeflow


### PR DESCRIPTION
Due to the snapshot test currently produces no log, I am switching to use bash:alpine image which allows me to run bash directly. It has the tool we need during the presubmit script, and matches the shebang in the shell script.
I also merged two commands into one line so the commands are wrapped in one quoted sentence following `-c` flag.

cc @chensun @Bobgy 