### PR TITLE
gcp-blueprints: Run postsubmit only when it is master branch or release branch

### DIFF
--- a/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
+++ b/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
@@ -15,7 +15,7 @@ postsubmits:
   - name: kubeflow-gcp-blueprints-postsubmit
     cluster: build-kubeflow
     branches:
-    - ^master|.+-branch$
+    - ^master|.+-branch$ # in gcp-blueprints, release branch is in the format `v1.1-branch`.
     spec:
       containers:
       - image: gcr.io/kubeflow-ci/test-worker:latest

--- a/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
+++ b/prow/prowjobs/kubeflow/gcp-blueprints/kubeflow-gcp-blueprints.yaml
@@ -14,6 +14,8 @@ postsubmits:
   kubeflow/gcp-blueprints:
   - name: kubeflow-gcp-blueprints-postsubmit
     cluster: build-kubeflow
+    branches:
+    - ^master|.+-branch$
     spec:
       containers:
       - image: gcr.io/kubeflow-ci/test-worker:latest


### PR DESCRIPTION
Currently any PR on kubeflow/gcp-blueprints will trigger postsubmit test during PR creation. Therefore we should restrict to only the master branch and release branches.