### PR TITLE
test(pipelines): fix kubeflow-pipeline-backend-test

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -20,6 +20,8 @@ presubmits:
       containers:
       - image: golang:1.17.6-alpine3.15
         command:
+        - /bin/sh
+        args:
         - ./test/presubmit-backend-test.sh
   - name: kubeflow-pipeline-e2e-test
     run_if_changed: "^(frontend/.*)|(backend/.*)|(proxy/.*)|(manifests/kustomize/.*)|(test/.*)$"


### PR DESCRIPTION
golang:1.17.6-alpine3.15 doesn't have `bash` but `/bin/sh`