### PR TITLE
test(pipelines): use golang:1.17.6-bullseye for backend presubmit

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -18,10 +18,8 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: golang:1.17.6-alpine3.15
+      - image: golang:1.17.6-bullseye
         command:
-        - /bin/sh
-        args:
         - ./test/presubmit-backend-test.sh
   - name: kubeflow-pipeline-e2e-test
     run_if_changed: "^(frontend/.*)|(backend/.*)|(proxy/.*)|(manifests/kustomize/.*)|(test/.*)$"


### PR DESCRIPTION
/assign @zijianjoy 

Sorry for the back and forth. Even our go unit test requires `gcc` that the alpine image doesn't have.
```
+ go test -v -cover ./backend/...
# runtime/cgo
cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
```

Verified that this image has `/bin/bash`, `gcc`, `git`, etc. 