### PR TITLE
Fix Knative job config path.

### DIFF
--- a/.prow/presubmits.yaml
+++ b/.prow/presubmits.yaml
@@ -79,7 +79,7 @@ presubmits:
           - /checkconfig
         args:
           - --config-path=./prow/knative/config.yaml
-          - --job-config-path=../../knative/test-infra/config/prod/prow/jobs
+          - --job-config-path=../../knative/test-infra/config/prow/jobs
           - --plugin-config=prow/knative/plugins.yaml
           - --strict
           # This warning can forbid valid (and convenient) config. Exclude it.

--- a/prow/knative/plugins.yaml
+++ b/prow/knative/plugins.yaml
@@ -87,7 +87,7 @@ label:
 # Settings for the "config-updater" plugin.
 config_updater:
   maps:
-    config/prod/prow/jobs/**/*.yaml:
+    config/prow/jobs/**/*.yaml:
       name: job-config
       gzip: true
 


### PR DESCRIPTION
This PR (https://github.com/knative/test-infra/pull/3044) changed the Knative ProwJob config path which broke the config updating logic, the checkconfig job in this repo, and subsequently blocked [the Prow update](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1439).

/assign @chizhg 
Please note that any config changes since the break have not been applied and a new change will be required to pick up the changes that were dropped.