### PR TITLE
compute-daisy: Onboard for presubmits

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -111,6 +111,14 @@ plugins:
     - owners-label
     - size
     - verify-owners
+  GoogleCloudPlatform/compute-daisy:
+    plugins:
+    - approve
+    - blunderbuss
+    - lgtm
+    - owners-label
+    - size
+    - verify-owners
   GoogleCloudPlatform/compute-image-tools:
     plugins:
     - approve

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-daisy.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-daisy.yaml
@@ -1,0 +1,44 @@
+presubmits:
+  GoogleCloudPlatform/compute-daisy:
+  - name: compute-daisy-presubmit-gocheck
+    cluster: gcp-guest
+    run_if_changed: '.*'
+    trigger: "(?m)^/gocheck-daisy$"
+    rerun_command: "/gocheck-daisy"
+    context: prow/presubmit/gocheck/daisy
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gocheck:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+        args: ["."]
+  - name: compute-daisy-presubmit-gotest
+    cluster: gcp-guest
+    run_if_changed: '.*'
+    trigger: "(?m)^/gotest-daisy$"
+    rerun_command: "/gotest-daisy"
+    context: prow/presubmit/gotest/daisy
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gotest:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+        args: ["."]
+  - name: compute-daisy-presubmit-gobuild
+    cluster: gcp-guest
+    run_if_changed: '.*'
+    trigger: "(?m)^/gobuild-daisy$"
+    rerun_command: "/gobuild-daisy"
+    context: prow/presubmit/gobuild/daisy
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gobuild:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+        args: ["."]


### PR DESCRIPTION
[compute-daisy](https://github.com/GoogleCloudPlatform/compute-daisy) is the new home for Daisy. This PR emulates the current behavior in [compute-image-tools](https://github.com/GoogleCloudPlatform/compute-image-tools); a subsequent PR will remove the daisy presubmits from compute-image-tools.

# Testing:
 - Ran `pj-on-kind` for the three new jobs. 

@hopkiw @adjackura