### PR TITLE
chore: allow blueprint-solutions-contrib access to prow frontend

### DIFF
--- a/prow/oss/cluster/deck_blueprints_deployment.yaml
+++ b/prow/oss/cluster/deck_blueprints_deployment.yaml
@@ -105,7 +105,7 @@ spec:
         args:
         - --provider=github
         - --github-org=GoogleCloudPlatform
-        - --github-team=blueprint-solutions
+        - --github-team=blueprint-solutions,blueprint-solutions-contrib
         - --http-address=0.0.0.0:4180
         - --upstream=http://localhost:8080
         - --cookie-domain=prow.infra.cft.dev


### PR DESCRIPTION
We want to allow an additional GH team to view Prow logs.