### PR TITLE
compute-daisy: Add periodic e2e test

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-daisy.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-daisy.yaml
@@ -1,3 +1,35 @@
+periodics:
+- name: compute-daisy-e2e
+  cluster: gcp-guest
+  decorate: true
+  interval: 3h
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: daisy-e2e
+  spec:
+    containers:
+      - image: gcr.io/compute-image-tools-test/test-runner:latest
+        command:
+        - "/main.sh"
+        args:
+          - "-out_path=$(ARTIFACTS)/junit.xml"
+          - "-projects=compute-image-test-pool-001"
+          - "-zone=us-central1-c"
+          - "daisy_integration_tests/daisy_e2e.test.gotmpl"
+        env:
+          - name: REPO_OWNER
+            value: GoogleCloudPlatform
+          - name: REPO_NAME
+            value: compute-daisy
+        volumeMounts:
+          - name: daisy-service-account
+            mountPath: /etc/compute-image-tools-test-service-account
+            readOnly: true
+    volumes:
+      - name: daisy-service-account
+        secret:
+          secretName: daisy-service-account
+
 presubmits:
   GoogleCloudPlatform/compute-daisy:
   - name: compute-daisy-presubmit-gocheck


### PR DESCRIPTION
This adds e2e periodic tests for compute-daisy.

# Testing

- Ran pj-on-kind and confirmed that the `junit.xml` file was created in `/artifacts`:

```
/mnt/disks/prowjob-out/compute-daisy-e2e/1491857579528163328
├── artifacts
│   └── junit.xml
├── build-log.txt
├── finished.json
└── started.json
```

@hopkiw @adjackura 