### PR TITLE
gcp-guest: add legacy periodics commands

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -9,21 +9,23 @@ periodics:
   interval: 24h
   agent: kubernetes
   spec:
-   activeDeadlineSeconds: 1800
-   containers:
-   - image: gcr.io/compute-image-tools-test/cleanerupper:latest
-     args:
-     - "-dry_run=false"
-     - "-duration=24h"
-     - "-instances=true"
-     - "-disks=true"
-     - "-images=true"
-     - "-machine_images=true"
-     - "-networks=true"
-     - "-snapshots=true"
-     - "-guest_policies=true"
-     - "-ospolicy_assignments=true"
-     - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2"
+    activeDeadlineSeconds: 1800
+    containers:
+    - image: gcr.io/compute-image-tools-test/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=24h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-guest_policies=true"
+      - "-ospolicy_assignments=true"
+      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2"
 - name: ci-daisy-e2e
   cluster: gcp-guest
   decorate: true
@@ -33,21 +35,21 @@ periodics:
   interval: 3h
   agent: kubernetes
   spec:
-   containers:
-     - image: gcr.io/compute-image-tools-test/test-runner:latest
-       args:
-         - "-out_path=/artifacts/junit.xml"
-         # One project is enough for daisy tests, no test requires a write lock.
-         - "-projects=compute-image-test-pool-001"
-         - "-zone=us-central1-c"
-         - "daisy_integration_tests/daisy_e2e.test.gotmpl"
-       env:
-         - name: REPO_OWNER
-           value: GoogleCloudPlatform
-         - name: REPO_NAME
-           value: compute-image-tools
-         - name: ARTIFACTS
-           value: /artifacts
+    containers:
+    - image: gcr.io/compute-image-tools-test/test-runner:latest
+      command:
+      - "/main.sh"
+      args:
+      - "-out_path=$(ARTIFACTS)/junit.xml"
+      # One project is enough for daisy tests, no test requires a write lock.
+      - "-projects=compute-image-test-pool-001"
+      - "-zone=us-central1-c"
+      - "daisy_integration_tests/daisy_e2e.test.gotmpl"
+      env:
+      - name: REPO_OWNER
+        value: GoogleCloudPlatform
+      - name: REPO_NAME
+        value: compute-image-tools
 - name: ci-daisy-e2e-daily
   cluster: gcp-guest
   decorate: true
@@ -57,21 +59,21 @@ periodics:
   interval: 24h
   agent: kubernetes
   spec:
-   containers:
-   - image: gcr.io/compute-image-tools-test/test-runner:latest
-     args:
-     - "-out_path=/artifacts/junit.xml"
-     # One project is enough for daisy tests, no test requires a write lock.
-     - "-projects=compute-image-test-pool-001"
-     - "-zone=us-central1-c"
-     - "daisy_integration_tests/daisy_e2e_daily.test.gotmpl"
-     env:
-     - name: REPO_OWNER
-       value: GoogleCloudPlatform
-     - name: REPO_NAME
-       value: compute-image-tools
-     - name: ARTIFACTS
-       value: /artifacts
+    containers:
+    - image: gcr.io/compute-image-tools-test/test-runner:latest
+      command:
+      - "/main.sh"
+      args:
+      - "-out_path=$(ARTIFACTS)/junit.xml"
+      # One project is enough for daisy tests, no test requires a write lock.
+      - "-projects=compute-image-test-pool-001"
+      - "-zone=us-central1-c"
+      - "daisy_integration_tests/daisy_e2e_daily.test.gotmpl"
+      env:
+      - name: REPO_OWNER
+        value: GoogleCloudPlatform
+      - name: REPO_NAME
+        value: compute-image-tools
 - name: ci-daisy-e2e-weekly
   cluster: gcp-guest
   decorate: true
@@ -81,21 +83,21 @@ periodics:
   interval: 168h
   agent: kubernetes
   spec:
-   containers:
-   - image: gcr.io/compute-image-tools-test/test-runner:latest
-     args:
-     - "-out_path=/artifacts/junit.xml"
-     # One project is enough for daisy tests, no test requires a write lock.
-     - "-projects=compute-image-test-pool-001"
-     - "-zone=us-central1-c"
-     - "daisy_integration_tests/daisy_e2e_weekly.test.gotmpl"
-     env:
-     - name: REPO_OWNER
-       value: GoogleCloudPlatform
-     - name: REPO_NAME
-       value: compute-image-tools
-     - name: ARTIFACTS
-       value: /artifacts
+    containers:
+    - image: gcr.io/compute-image-tools-test/test-runner:latest
+      command:
+      - "/main.sh"
+      args:
+      - "-out_path=$(ARTIFACTS)/junit.xml"
+      # One project is enough for daisy tests, no test requires a write lock.
+      - "-projects=compute-image-test-pool-001"
+      - "-zone=us-central1-c"
+      - "daisy_integration_tests/daisy_e2e_weekly.test.gotmpl"
+      env:
+      - name: REPO_OWNER
+        value: GoogleCloudPlatform
+      - name: REPO_NAME
+        value: compute-image-tools
 - name: ci-ovf-import-e2e-tests-daily
   cluster: gcp-guest
   decorate: true
@@ -107,8 +109,10 @@ periodics:
   spec:
     containers:
     - image: gcr.io/compute-image-tools-test/gce-ovf-import-tests:latest
+      command:
+      - "/gce_ovf_import_test_runner"
       args:
-      - "-out_dir=/artifacts"
+      - "-out_dir=$(ARTIFACTS)"
       - "-test_project_id=compute-image-test-pool-001"
       - "-test_zone=us-central1-c"
       - "-variables=compute_service_account_without_default_service_account=pool-001-1-sa@compute-image-test-pool-001-1.iam.gserviceaccount.com,\
@@ -117,9 +121,6 @@ periodics:
           instance_service_account_without_default_service_account_permission=pool-001-2-sa-2@compute-image-test-pool-001-2.iam.gserviceaccount.com,\
           project_id_without_default_service_account=compute-image-test-pool-001-1,\
           project_id_without_default_service_account_permission=compute-image-test-pool-001-2"
-      env:
-      - name: ARTIFACTS
-        value: /artifacts
 - name: ci-ovf-export-e2e-tests-daily
   cluster: gcp-guest
   decorate: true
@@ -131,13 +132,12 @@ periodics:
   spec:
     containers:
     - image: gcr.io/compute-image-tools-test/gce-ovf-export-tests:latest
+      command:
+      - "/gce_ovf_export_test_runner"
       args:
-      - "-out_dir=/artifacts"
+      - "-out_dir=$(ARTIFACTS)"
       - "-test_project_id=compute-image-test-pool-001"
       - "-test_zone=us-central1-c"
-      env:
-      - name: ARTIFACTS
-        value: /artifacts
 - name: ci-windows-upgrade-e2e-tests
   cluster: gcp-guest
   decorate: true
@@ -149,13 +149,12 @@ periodics:
   spec:
     containers:
     - image: gcr.io/compute-image-tools-test/gce-windows-upgrade-tests:latest
+      command:
+      - "/gce_windows_upgrade_test_runner"
       args:
-      - "-out_dir=/artifacts"
+      - "-out_dir=$(ARTIFACTS)"
       - "-test_project_id=compute-image-test-pool-001"
       - "-test_zone=us-central1-c"
-      env:
-      - name: ARTIFACTS
-        value: /artifacts
 - name: ci-images-import-export-cli-e2e-tests
   cluster: gcp-guest
   decorate: true
@@ -167,8 +166,10 @@ periodics:
   spec:
     containers:
     - image: gcr.io/compute-image-tools-test/gce-image-import-export-tests:latest
+      command:
+      - "/gce_image_import_export_test_runner"
       args:
-      - "-out_dir=/artifacts"
+      - "-out_dir=$(ARTIFACTS)"
       - "-test_project_id=compute-image-test-pool-001"
       - "-test_zone=us-central1-b"
       - "-variables=aws_region=us-east-2,aws_bucket=s3://onestep-test,\
@@ -180,9 +181,6 @@ periodics:
           compute_service_account_without_default_service_account_permission=pool-001-2-sa@compute-image-test-pool-001-2.iam.gserviceaccount.com,\
           project_id_without_default_service_account=compute-image-test-pool-001-1,\
           project_id_without_default_service_account_permission=compute-image-test-pool-001-2"
-      env:
-      - name: ARTIFACTS
-        value: /artifacts
 - name: ci-v2v-adapt-e2e
   cluster: gcp-guest
   decorate: true
@@ -194,8 +192,10 @@ periodics:
   spec:
     containers:
     - image: gcr.io/compute-image-tools-test/test-runner:latest
+      command:
+      - "/main.sh"
       args:
-      - "-out_path=/artifacts/junit.xml"
+      - "-out_path=$(ARTIFACTS)/junit.xml"
       # One project is enough for v2v tests, no test requires a write lock.
       - "-projects=compute-image-test-pool-001"
       - "-zone=us-central1-c"
@@ -205,8 +205,6 @@ periodics:
         value: GoogleCloudPlatform
       - name: REPO_NAME
         value: compute-image-tools
-      - name: ARTIFACTS
-        value: /artifacts
 - name: osconfig-head-images
   cluster: gcp-guest
   decorate: true
@@ -216,40 +214,39 @@ periodics:
   interval: 5h
   agent: kubernetes
   spec:
-   activeDeadlineSeconds: 7200
-   containers:
-   - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
-     args:
-     - "-test_case_filter=debian|centos|rhel|windows|cos|ubuntu"
-     - "-out_dir=/artifacts"
-     - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
-     - -test_zones={
-                     "us-central1-a":5,
-                     "us-central1-b":5,
-                     "us-central1-c":5,
-                     "us-central1-f":5,
-                     "us-west1-a":5,
-                     "us-west1-b":5,
-                     "us-west1-c":5,
-                     "us-east1-b":5,
-                     "us-east1-c":5,
-                     "us-east1-d":5,
-                     "us-east4-a":5,
-                     "us-east4-b":5,
-                     "us-east4-c":5,
-                     "europe-west4-a":5,
-                     "europe-west4-b":5,
-                     "europe-west4-c":5,
-                     "europe-west1-d":5,
-                     "europe-west1-b":5,
-                     "europe-west1-c":5,
-                     "asia-east1-a":5,
-                     "asia-east1-b":5,
-                     "asia-east1-c":5
-                   }
-     env:
-     - name: ARTIFACTS
-       value: /artifacts
+    activeDeadlineSeconds: 7200
+    containers:
+    - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
+      command:
+      - "/e2e_tests"
+      args:
+      - "-test_case_filter=debian|centos|rhel|windows|cos|ubuntu"
+      - "-out_dir=$(ARTIFACTS)"
+      - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
+      - -test_zones={
+                      "us-central1-a":5,
+                      "us-central1-b":5,
+                      "us-central1-c":5,
+                      "us-central1-f":5,
+                      "us-west1-a":5,
+                      "us-west1-b":5,
+                      "us-west1-c":5,
+                      "us-east1-b":5,
+                      "us-east1-c":5,
+                      "us-east1-d":5,
+                      "us-east4-a":5,
+                      "us-east4-b":5,
+                      "us-east4-c":5,
+                      "europe-west4-a":5,
+                      "europe-west4-b":5,
+                      "europe-west4-c":5,
+                      "europe-west1-d":5,
+                      "europe-west1-b":5,
+                      "europe-west1-c":5,
+                      "asia-east1-a":5,
+                      "asia-east1-b":5,
+                      "asia-east1-c":5
+                    }
 - name: osconfig-unstable
   cluster: gcp-guest
   decorate: true
@@ -259,42 +256,41 @@ periodics:
   interval: 1h
   agent: kubernetes
   spec:
-   activeDeadlineSeconds: 7200
-   containers:
-   - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
-     args:
-     - "-out_dir=/artifacts"
-     - "-agent_repo=unstable"
-     - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
-     - "-agent_endpoint={zone}-staging-osconfig.sandbox.googleapis.com:443"
-     - "-endpoint=staging-osconfig.sandbox.googleapis.com:443"
-     - -test_zones={
-                     "us-central1-a":15,
-                     "us-central1-b":15,
-                     "us-central1-c":15,
-                     "us-central1-f":15,
-                     "us-west1-a":15,
-                     "us-west1-b":15,
-                     "us-west1-c":15,
-                     "us-east1-b":15,
-                     "us-east1-c":15,
-                     "us-east1-d":15,
-                     "asia-northeast1-a":15,
-                     "asia-northeast1-b":15,
-                     "asia-northeast1-c":15,
-                     "europe-north1-a":15,
-                     "europe-north1-b":15,
-                     "europe-north1-c":15,
-                     "europe-west1-d":15,
-                     "europe-west1-b":15,
-                     "europe-west1-c":15,
-                     "asia-east1-a":15,
-                     "asia-east1-b":15,
-                     "asia-east1-c":15
-                   }
-     env:
-     - name: ARTIFACTS
-       value: /artifacts
+    activeDeadlineSeconds: 7200
+    containers:
+    - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
+      command:
+      - "/e2e_tests"
+      args:
+      - "-out_dir=$(ARTIFACTS)"
+      - "-agent_repo=unstable"
+      - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
+      - "-agent_endpoint={zone}-staging-osconfig.sandbox.googleapis.com:443"
+      - "-endpoint=staging-osconfig.sandbox.googleapis.com:443"
+      - -test_zones={
+                      "us-central1-a":15,
+                      "us-central1-b":15,
+                      "us-central1-c":15,
+                      "us-central1-f":15,
+                      "us-west1-a":15,
+                      "us-west1-b":15,
+                      "us-west1-c":15,
+                      "us-east1-b":15,
+                      "us-east1-c":15,
+                      "us-east1-d":15,
+                      "asia-northeast1-a":15,
+                      "asia-northeast1-b":15,
+                      "asia-northeast1-c":15,
+                      "europe-north1-a":15,
+                      "europe-north1-b":15,
+                      "europe-north1-c":15,
+                      "europe-west1-d":15,
+                      "europe-west1-b":15,
+                      "europe-west1-c":15,
+                      "asia-east1-a":15,
+                      "asia-east1-b":15,
+                      "asia-east1-c":15
+                    }
 - name: osconfig-staging
   cluster: gcp-guest
   decorate: true
@@ -304,40 +300,39 @@ periodics:
   interval: 3h
   agent: kubernetes
   spec:
-   activeDeadlineSeconds: 10000
-   containers:
-   - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
-     args:
-     - "-out_dir=/artifacts"
-     - "-agent_repo=staging"
-     - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
-     - -test_zones={
-                     "us-central1-a":10,
-                     "us-central1-b":10,
-                     "us-central1-c":10,
-                     "us-central1-f":10,
-                     "us-west1-a":10,
-                     "us-west1-b":10,
-                     "us-west1-c":10,
-                     "us-east1-b":10,
-                     "us-east1-c":10,
-                     "us-east1-d":10,
-                     "us-east4-a":10,
-                     "us-east4-b":10,
-                     "us-east4-c":10,
-                     "europe-west4-a":10,
-                     "europe-west4-b":10,
-                     "europe-west4-c":10,
-                     "europe-west1-d":10,
-                     "europe-west1-b":10,
-                     "europe-west1-c":10,
-                     "asia-east1-a":10,
-                     "asia-east1-b":10,
-                     "asia-east1-c":10
-                   }
-     env:
-     - name: ARTIFACTS
-       value: /artifacts
+    activeDeadlineSeconds: 10000
+    containers:
+    - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
+      command:
+      - "/e2e_tests"
+      args:
+      - "-out_dir=$(ARTIFACTS)"
+      - "-agent_repo=staging"
+      - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
+      - -test_zones={
+                      "us-central1-a":10,
+                      "us-central1-b":10,
+                      "us-central1-c":10,
+                      "us-central1-f":10,
+                      "us-west1-a":10,
+                      "us-west1-b":10,
+                      "us-west1-c":10,
+                      "us-east1-b":10,
+                      "us-east1-c":10,
+                      "us-east1-d":10,
+                      "us-east4-a":10,
+                      "us-east4-b":10,
+                      "us-east4-c":10,
+                      "europe-west4-a":10,
+                      "europe-west4-b":10,
+                      "europe-west4-c":10,
+                      "europe-west1-d":10,
+                      "europe-west1-b":10,
+                      "europe-west1-c":10,
+                      "asia-east1-a":10,
+                      "asia-east1-b":10,
+                      "asia-east1-c":10
+                    }
 - name: osconfig-stable
   cluster: gcp-guest
   decorate: true
@@ -347,37 +342,36 @@ periodics:
   interval: 5h
   agent: kubernetes
   spec:
-   activeDeadlineSeconds: 14400
-   containers:
-   - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
-     args:
-     - "-out_dir=/artifacts"
-     - "-agent_repo=stable"
-     - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
-     - -test_zones={
-                     "us-central1-a":5,
-                     "us-central1-b":5,
-                     "us-central1-c":5,
-                     "us-central1-f":5,
-                     "us-west1-a":5,
-                     "us-west1-b":5,
-                     "us-west1-c":5,
-                     "us-east1-b":5,
-                     "us-east1-c":5,
-                     "us-east1-d":5,
-                     "us-east4-a":5,
-                     "us-east4-b":5,
-                     "us-east4-c":5,
-                     "europe-west4-a":5,
-                     "europe-west4-b":5,
-                     "europe-west4-c":5,
-                     "europe-west1-d":5,
-                     "europe-west1-b":5,
-                     "europe-west1-c":5,
-                     "asia-east1-a":5,
-                     "asia-east1-b":5,
-                     "asia-east1-c":5
-                   }
-     env:
-     - name: ARTIFACTS
-       value: /artifacts
+    activeDeadlineSeconds: 14400
+    containers:
+    - image: gcr.io/compute-image-tools-test/osconfig-tests:latest
+      command:
+      - "/main.sh"
+      args:
+      - "-out_dir=$(ARTIFACTS)"
+      - "-agent_repo=stable"
+      - "-test_project_ids=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
+      - -test_zones={
+                      "us-central1-a":5,
+                      "us-central1-b":5,
+                      "us-central1-c":5,
+                      "us-central1-f":5,
+                      "us-west1-a":5,
+                      "us-west1-b":5,
+                      "us-west1-c":5,
+                      "us-east1-b":5,
+                      "us-east1-c":5,
+                      "us-east1-d":5,
+                      "us-east4-a":5,
+                      "us-east4-b":5,
+                      "us-east4-c":5,
+                      "europe-west4-a":5,
+                      "europe-west4-b":5,
+                      "europe-west4-c":5,
+                      "europe-west1-d":5,
+                      "europe-west1-b":5,
+                      "europe-west1-c":5,
+                      "asia-east1-a":5,
+                      "asia-east1-b":5,
+                      "asia-east1-c":5
+                    }


### PR DESCRIPTION
* fix one-space indentations
* remove ARTIFACTS environment variable
* specify command for each periodic job - bypassing wrapper!