### PR TITLE
Updates rerun auth to use slugs instead of ids

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -120,9 +120,15 @@ deck:
   tide_update_period: 1s
   rerun_auth_configs:
     '*':
-      github_team_ids:
-        - 3996822 # Knative Release Team
-        - 3288907 # Knative TOC
+      github_team_slugs:
+        - org: 'knative'
+          slug: 'technical-oversight-committee'
+        - org: 'knative'
+          slug: 'knative-release-leads'
+        - org: 'knative-sandbox'
+          slug: 'technical-oversight-committee'
+        - org: 'knative-sandbox'
+          slug: 'knative-release-leads'
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

xref: https://github.com/knative/test-infra/pull/3140

Previously, only the knative org IDs were being used. This caused an
error when trying to rerun jobs in the knative-sandbox org (the team ID
was invalid, because the ID in knative did not match the ID in sandbox).

This PR updates the rerun_auth-configs to use the team slugs instead.
The teams are now identified by a combo of org and slug (which should
alleviate the problem above) and has the added benefit of being more
explicit on which team is being used (don't have to double check that
the ID is the right ID for the team).

See Slack discussion here: https://knative.slack.com/archives/C03545VN9KK/p1646761295715509