### PR TITLE
Fix the rerun_auth_configs for Knative

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -119,17 +119,11 @@ deck:
       - podinfo.json
   tide_update_period: 1s
   rerun_auth_configs:
-    'knative':
+    '*':
       github_team_slugs:
         - org: 'knative'
           slug: 'technical-oversight-committee'
         - org: 'knative'
-          slug: 'knative-release-leads'
-    'knative-sandbox':
-      github_team_slugs:
-        - org: 'knative-sandbox'
-          slug: 'technical-oversight-committee'
-        - org: 'knative-sandbox'
           slug: 'knative-release-leads'
 
 prowjob_namespace: default


### PR DESCRIPTION
The current Prow has a bug for checking the rerun auth permissions for the periodic Prow jobs, when configured with `org` name as the key. For Knative, we don't really need that since we should allow the team members to rerun **all** Prow jobs, so this PR changes it back to `*`.

/cc @chaodaiG 