### PR TITLE
Add 2 external secrets for knative build cluster

### DIFF
--- a/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
+++ b/prow/knative/cluster/build/600-kubernetes_external_secrets.yaml
@@ -22,3 +22,9 @@ spec:
   - key: docker-config
     name: config.json
     version: latest
+  - key: server-list
+    name: server-list
+    version: latest
+  - key: ci-script
+    name: ci-script
+    version: latest


### PR DESCRIPTION
This PR is to add 2 additional external secrets named `server-list` and `ci-script` for the knative e2e test against the s390x test machine.

We are currently refactoring the CI structure. Another PR will come for the deletion of the existing 2 secrets after the improvement is finished.