### PR TITLE
Update Knative max_prowjob_age from 24h to 240h

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -132,7 +132,7 @@ log_level: debug
 
 sinker:
   resync_period: 1m
-  max_prowjob_age: 24h
+  max_prowjob_age: 240h
   max_pod_age: 30m
   terminated_pod_ttl: 30m
 


### PR DESCRIPTION
Knative has dot-release jobs that are scheduled every week, so with the current setting, most of the time the developers won't be able to find the jobs from prow.knative.dev and use Prow UI to retrigger them.

This PR updates Knative max_prowjob_age from 24h to 240h, which'll allow release managers to see more job history from Deck and retrigger the dot-release jobs. According to https://prow.knative.dev/ there are 1500+ jobs everyday, so x10 should not overload Prow since there were some recent performance improvements here.

I'm not aware of any other side effects, so please let us know if there are any especially those that can potentially increase the resource usage, since reducing the infra cost is our P0 task for CNCF infra migration initiatives. 

/cc @chaodaiG 

FYI @kvmware @carlisia @vsameer @dprotaso 