### PR TITLE
disable ci-images-import-export-cli-e2e-tests

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -173,35 +173,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''
-- name: ci-images-import-export-cli-e2e-tests
-  cluster: gcp-guest
-  decorate: true
-  annotations:
-    testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: ci-images-import-export-cli-e2e-tests
-  interval: 6h
-  agent: kubernetes
-  spec:
-    containers:
-    - image: gcr.io/compute-image-tools-test/gce-image-import-export-tests:latest
-      command:
-      - "/gce_image_import_export_test_runner"
-      args:
-      - "-out_dir=$(ARTIFACTS)"
-      - "-test_project_id=compute-image-test-pool-001"
-      - "-test_zone=us-central1-b"
-      - "-variables=aws_region=us-east-2,aws_bucket=s3://onestep-test,\
-          ubuntu_ami_id=ami-04d75010218164863,windows_ami_id=ami-0c91f2e838828598d,\
-          ubuntu_vmdk=s3://onestep-test/ubuntu1804.vmdk,\
-          windows_vmdk=s3://onestep-test/windows2019.vmdk,\
-          aws_cred_file_path=gs://compute-image-tools-test-resources/onestep-test-user,\
-          compute_service_account_without_default_service_account=pool-001-1-sa@compute-image-test-pool-001-1.iam.gserviceaccount.com,\
-          compute_service_account_without_default_service_account_permission=pool-001-2-sa@compute-image-test-pool-001-2.iam.gserviceaccount.com,\
-          project_id_without_default_service_account=compute-image-test-pool-001-1,\
-          project_id_without_default_service_account_permission=compute-image-test-pool-001-2"
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: ''
 - name: ci-v2v-adapt-e2e
   cluster: gcp-guest
   decorate: true


### PR DESCRIPTION
Our build cluster is running out of memory when running this suite, which is causing a cascade of retries that's causing other suites to fail. While we update the build cluster, I'd like to disable this suite.

More info: https://github.com/GoogleCloudPlatform/oss-test-infra/issues/1533