### PR TITLE
Re-enable import/export tests

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -58,6 +58,8 @@ periodics:
 - name: ci-daisy-e2e-daily
   cluster: gcp-guest
   decorate: true
+  decoration_config:
+    timeout: 23h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: ci-daisy-e2e-daily
@@ -84,6 +86,8 @@ periodics:
 - name: ci-daisy-e2e-weekly
   cluster: gcp-guest
   decorate: true
+  decoration_config:
+    timeout: 23h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: ci-daisy-e2e-weekly
@@ -136,6 +140,8 @@ periodics:
 - name: ci-ovf-export-e2e-tests-daily
   cluster: gcp-guest
   decorate: true
+  decoration_config:
+    timeout: 11h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: ci-ovf-export-e2e-tests-daily
@@ -156,6 +162,8 @@ periodics:
 - name: ci-windows-upgrade-e2e-tests
   cluster: gcp-guest
   decorate: true
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: ci-windows-upgrade-e2e-tests
@@ -173,9 +181,42 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''
+- name: ci-images-import-export-cli-e2e-tests
+  cluster: gcp-guest
+  decorate: true
+  decoration_config:
+    timeout: 11h
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: ci-images-import-export-cli-e2e-tests
+  interval: 12h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/compute-image-tools-test/gce-image-import-export-tests:latest
+      command:
+      - "/gce_image_import_export_test_runner"
+      args:
+      - "-out_dir=$(ARTIFACTS)"
+      - "-test_project_id=compute-image-test-pool-001"
+      - "-test_zone=us-central1-b"
+      - "-variables=aws_region=us-east-2,aws_bucket=s3://onestep-test,\
+          ubuntu_ami_id=ami-04d75010218164863,windows_ami_id=ami-0c91f2e838828598d,\
+          ubuntu_vmdk=s3://onestep-test/ubuntu1804.vmdk,\
+          windows_vmdk=s3://onestep-test/windows2019.vmdk,\
+          aws_cred_file_path=gs://compute-image-tools-test-resources/onestep-test-user,\
+          compute_service_account_without_default_service_account=pool-001-1-sa@compute-image-test-pool-001-1.iam.gserviceaccount.com,\
+          compute_service_account_without_default_service_account_permission=pool-001-2-sa@compute-image-test-pool-001-2.iam.gserviceaccount.com,\
+          project_id_without_default_service_account=compute-image-test-pool-001-1,\
+          project_id_without_default_service_account_permission=compute-image-test-pool-001-2"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
 - name: ci-v2v-adapt-e2e
   cluster: gcp-guest
   decorate: true
+  decoration_config:
+    timeout: 11h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: ci-v2v-adapt-e2e


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1536, we disabled the `ci-images-import-export-cli-e2e-tests` test suite while we upgraded our k8s build node pool. We finished the upgrade, so this re-enables the suite.

Additionally, this tunes the timeout period for long-running suites. The values are from historically successful runs on the old prow cluster, which did not enforce a timeout. Here's an example failure message that we're seeing:

```
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:165","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 2h0m0s timeout","severity":"error","time":"2022-03-21T00:09:35Z"}
```

Source: https://oss-prow.knative.dev/view/gs/oss-prow/logs/ci-daisy-e2e-daily/1505667879410864128