### PR TITLE
use gcr.io/gcp-guest for cleanerupper

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -11,7 +11,7 @@ periodics:
   spec:
     activeDeadlineSeconds: 1800
     containers:
-    - image: gcr.io/compute-image-tools-test/cleanerupper:latest
+    - image: gcr.io/gcp-guest/cleanerupper:latest
       command:
       - "/cleanerupper"
       args:


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/guest-test-infra/pull/422 we started publishing cleanerupper to `gcr.io/gcp-guest`.