### PR TITLE
Migrate Knative Prow to a GitHub app

### DIFF
--- a/prow/knative/cluster/400-crier.yaml
+++ b/prow/knative/cluster/400-crier.yaml
@@ -41,10 +41,11 @@ spec:
         - --kubeconfig=/etc/kubeconfig/config
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
-        - --github-token-path=/etc/github/oauth
         - --github-workers=5
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --slack-workers=1
         - --slack-token-file=/etc/slack/token
         ports:
@@ -60,12 +61,18 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
-        - name: oauth
+        - name: github-token
           mountPath: /etc/github
           readOnly: true
         - name: slack
           mountPath: /etc/slack
           readOnly: true
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: github-token
+              key: appid
       volumes:
       - name: config
         configMap:
@@ -73,9 +80,9 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      - name: oauth
+      - name: github-token
         secret:
-          secretName: oauth-token
+          secretName: github-token
       - name: kubeconfig
         secret:
           defaultMode: 420

--- a/prow/knative/cluster/400-hook.yaml
+++ b/prow/knative/cluster/400-hook.yaml
@@ -43,11 +43,19 @@ spec:
         imagePullPolicy: Always
         args:
         - --dry-run=false
+        - --webhook-path=/ghapp-hook
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
-        - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: github-token
+              key: appid
         ports:
         - name: http
           containerPort: 8888
@@ -57,7 +65,7 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: oauth
+        - name: github-token
           mountPath: /etc/github
           readOnly: true
         - name: config
@@ -86,9 +94,9 @@ spec:
       - name: hmac
         secret:
           secretName: hmac-token
-      - name: oauth
+      - name: github-token
         secret:
-          secretName: oauth-token
+          secretName: github-token
       - name: config
         configMap:
           name: config

--- a/prow/knative/cluster/400-ingress.yaml
+++ b/prow/knative/cluster/400-ingress.yaml
@@ -34,7 +34,7 @@ spec:
             name: deck
             port:
               number: 80
-      - path: /hook
+      - path: /ghapp-hook
         pathType: ImplementationSpecific
         backend:
           service:


### PR DESCRIPTION
The GitHub app is at https://github.com/apps/knative-prow, and has already been installed for `knative` and `knative-sandbox` org.

Please note I'm using a brutal way to do the migration during the off-hours to make the migration easier and less disruptive. The config changes have already been applied on the Knative Prow cluster and have been tested at https://github.com/knative/test-infra/pull/3197.

Sorry if the migration triggered false alerts.