### PR TITLE
Remove Prow config for google/knative-gcp

### DIFF
--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -156,7 +156,6 @@ tide:
     - do-not-merge/invalid-owners-file
     - needs-rebase
   - repos:
-    - "google/knative-gcp"
     - "knative-prow-robot/test-infra"
     labels:
     - lgtm
@@ -173,7 +172,6 @@ tide:
   merge_method:
     knative: squash
     knative-sandbox: squash
-    google/knative-gcp: squash
   target_url: https://prow.knative.dev/tide
   pr_status_base_urls:
     '*': https://prow.knative.dev/pr
@@ -223,15 +221,3 @@ branch-protection:
       repos:
         .github:
           protect: false
-
-    google:
-      repos:
-        # Protect all branches in google/knative-gcp
-        knative-gcp:
-          protect: true
-          required_status_checks:
-            contexts:
-            - cla/google
-            - tide
-          # Enforce all configured restrictions above for administrators.
-          enforce_admins: true

--- a/prow/knative/plugins.yaml
+++ b/prow/knative/plugins.yaml
@@ -17,7 +17,6 @@ approve:
 - repos:
   - "knative"
   - "knative-sandbox"
-  - "google/knative-gcp"
   - "knative-prow-robot/test-infra"
   ignore_review_state: false
 
@@ -26,7 +25,6 @@ lgtm:
 - repos:
   - "knative-sandbox"
   - "knative"
-  - "google/knative-gcp"
   review_acts_as_lgtm: true
 
 # Settings for the "heart" plugin.
@@ -156,33 +154,6 @@ plugins:
     - welcome
     - wip
     - yuks
-  google/knative-gcp:
-    plugins:
-    - approve
-    - assign
-    - blunderbuss
-    - buildifier
-    - cat
-    - dog
-    - golint
-    - heart
-    - help
-    - hold
-    - label
-    - lgtm
-    - lifecycle
-    - milestone
-    - override
-    - owners-label
-    - project
-    - shrug
-    - size
-    - skip
-    - trigger
-    - verify-owners
-    - welcome
-    - wip
-    - yuks
   knative-prow-robot/test-infra:
     plugins:
     - approve
@@ -224,15 +195,6 @@ external_plugins:
       - issue_comment
       - pull_request
   knative-sandbox:
-  - name: needs-rebase
-    events:
-      - issue_comment
-      - pull_request
-  - name: cherrypicker
-    events:
-      - issue_comment
-      - pull_request
-  google/knative-gcp:
   - name: needs-rebase
     events:
       - issue_comment


### PR DESCRIPTION
https://github.com/google/knative-gcp has been in maintenance mode and hasn't received new commits for more than 6 months. With Knative migrated to GitHub app, the CI/CD flows get broken and do not have strong incentives to get fixed.

This PR removes all the Prow config for google/knative-gcp for now. If in the future it turns out the maintainers of this project still need them, they can add them back.