### PR TITLE
Move Knative Tide to authenticate as a GitHub app

### DIFF
--- a/prow/knative/cluster/400-tide.yaml
+++ b/prow/knative/cluster/400-tide.yaml
@@ -57,15 +57,22 @@ spec:
         - --job-config-path=/etc/job-config
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github/oauth
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --dry-run=false
+        env:
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: github-token
+              key: appid
         ports:
         - name: http
           containerPort: 8888
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - name: oauth
+        - name: github-token
           mountPath: /etc/github
           readOnly: true
         - name: config
@@ -75,9 +82,9 @@ spec:
           mountPath: /etc/job-config
           readOnly: true
       volumes:
-      - name: oauth
+      - name: github-token
         secret:
-          secretName: oauth-token
+          secretName: github-token
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
This was missed in my last PR to migrate Knative Prow to a GitHub app.

/cc