### PR TITLE
Add external secret from build cluster for compute-image-import

### DIFF
--- a/prow/oss/cluster/kubernetes_external_secrets.yaml
+++ b/prow/oss/cluster/kubernetes_external_secrets.yaml
@@ -205,3 +205,16 @@ spec:
   - key: prow_build_cluster_kubeconfig_build-bms-oracle-team
     name: kubeconfig
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-build-compute-image-import
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: compute-image-import-test
+  data:
+  - key: prow_build_cluster_kubeconfig_build-compute-image-import
+    name: kubeconfig
+    version: latest


### PR DESCRIPTION
Generated by running this script: https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/oss/create-build-cluster.sh