### PR TITLE
Add plank config for compute-image-import-prow

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -167,7 +167,12 @@ plank:
         bucket: "bmaas-testing-prow-bucket"
       default_service_account_name: "prowjob-default-sa" # Use workload identity
       gcs_credentials_secret: ""                         # rather than service account key secret
-
+  - cluster: build-compute-image-import
+    config:
+      gcs_configuration:
+        bucket: "compute-image-import-prow"
+      default_service_account_name: "prowjob-default-sa" # Use workload identity
+      gcs_credentials_secret: ""                         # rather than service account key secret
 
 sinker:
   resync_period: 1m


### PR DESCRIPTION
The `create_build_cluster.sh` script from the [onboarding guide](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/oss/onboarding.md) prompted me to update this file.