### PR TITLE
Compute image import: Use main branch

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/compute-image-import/compute-image-import.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/compute-image-import/compute-image-import.yaml
@@ -209,9 +209,7 @@ postsubmits:
       testgrid-tab-name: module-tests
       description: Postsubmit tests; executes cli_tools_tests/module/
     branches:
-    - ^master$
-    labels:
-      preset-daisy: "true"
+    - ^main$
     spec:
       containers:
       - image: gcr.io/gcp-guest/cli-tools-module-tests:latest


### PR DESCRIPTION
The job `compute-image-import-postsubmit-module-tests` currently isn't running: https://testgrid.k8s.io/googleoss-compute-image-import#module-tests . After debugging with pj-on-kind, I found that it was incorrectly configured: the repo `GoogleCloudPlatform/compute-image-import` uses the branch `main` instead of `master`.

Additionally, this removes a label which we aren't using for this cluster.