### PR TITLE
Remove kubeflow-pipelines-v2-go-test from kubeflow-pipelines-presubmits.yaml

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -180,16 +180,6 @@ presubmits:
         command:
         - ./backend/src/v2/test/integration-test.sh
 
-  - name: kubeflow-pipelines-v2-go-test
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^backend/src/v2/.*$"
-    spec:
-      containers:
-        - image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
-          command:
-            - ./backend/src/v2/test/presubmit-v2-go-test.sh
-
   - name: kubeflow-pipelines-manifests
     cluster: build-kubeflow
     decorate: true


### PR DESCRIPTION
The test is already covered by `kubeflow-pipeline-backend-test` which runs go unit tests for the entire `backend/src` folder.