### PR TITLE
Adjust oauth config for new gprow.dev domains.

### DIFF
--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -31,7 +31,7 @@ spec:
         - --spyglass=true
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
-        - --redirect-http-to=oss-prow.knative.dev
+        - --redirect-http-to=oss.gprow.dev
         - --rerun-creates-job
         - --oauth-url=/github-login
         - --github-token-path=/etc/github/oauth
@@ -118,7 +118,7 @@ spec:
           secretName: kubeconfig-build-elcarro
       - name: oauth-config
         secret:
-          secretName: github-oauth-config-20200326-oss-prow-knative-dev
+          secretName: github-oauth-config-oss-gprow-dev
       - name: oauth-token
         secret:
           secretName: oauth-token-2

--- a/prow/oss/cluster/deck_private_deployment.yaml
+++ b/prow/oss/cluster/deck_private_deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/
         - --job-config-path=/etc/job-config
-        - --redirect-http-to=oss-prow-private.knative.dev
+        - --redirect-http-to=oss-private.gprow.dev
         - --spyglass=true
         - --tenant-id=looker
         - --rerun-creates-job
@@ -118,8 +118,8 @@ spec:
         - --github-team=eng
         - --http-address=0.0.0.0:4180
         - --upstream=http://localhost:8080
-        - --cookie-domain=oss-prow-private.knative.dev
-        - --cookie-name=oss-prow-private-knative-dev-oauth2-proxy
+        - --cookie-domain=oss-private.gprow.dev
+        - --cookie-name=oss-private-gprow-dev-oauth2-proxy
         - --cookie-samesite=none
         - --cookie-expire=23h
         - --email-domain=*


### PR DESCRIPTION
When this merges I'll also complete the following:
- [ ] Update the oauth redirect settings in GitHub to use the new domain for the __private__ front end's oauth app.
- [ ] Update the oauth redirect settings in GitHub to use the new domain for the __public__ front end's oauth app.
- [ ] Update the oauth redirect URL in the oauth config K8s secret for the __private__ front end
- [ ] [later] Delete the old oauth config K8s secret for the __public__ front end. (Since we're using a more generally named secret.)

/assign @chaodaiG 
/hold