### PR TITLE
Configure deck to display pod link from trusted cluster

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -251,8 +251,14 @@ deck:
           - artifacts/junit.*\.xml
       - lens:
           name: podinfo
+          config:
+            runner_configs:
+              "test-infra-trusted":
+                pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-west1-a/prow/test-pods/{{ .Name }}/details?project=oss-prow"
         required_files:
           - podinfo.json
+        optional_files:
+          - prowjob.json
       - lens:
           name: html
         required_files:


### PR DESCRIPTION
This feature was added as of https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1594 and already deployed on oss prow. configure this for trusted cluster for testing purpose, will do this for other clusters if proved to work

/cc @cjwagner @mpherman2 @listx 