### PR TITLE
Add pod link template for default cluster

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -253,6 +253,8 @@ deck:
           name: podinfo
           config:
             runner_configs:
+              "default":
+                pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-west1-a/prow/test-pods/{{ .Name }}/details?project=oss-prow-builds"
               "test-infra-trusted":
                 pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-west1-a/prow/test-pods/{{ .Name }}/details?project=oss-prow"
         required_files:


### PR DESCRIPTION
This the the last remaining build cluster that we know which project it's from.

/cc @cjwagner @mpherman2 