### PR TITLE
(kubeflow): Add pod link template for kf-ci-v1 cluster

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -257,6 +257,8 @@ deck:
                 pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-west1-a/prow/test-pods/{{ .Name }}/details?project=oss-prow-builds"
               "test-infra-trusted":
                 pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-west1-a/prow/test-pods/{{ .Name }}/details?project=oss-prow"
+              "kf-ci-v1":
+                pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-east1-d/kf-ci-v1/test-pods/{{ .Name }}/details?project=kubeflow-ci"
         required_files:
           - podinfo.json
         optional_files:


### PR DESCRIPTION
Related: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1600

Following recommendation to enable pod detail link in the Prowjob UI. Here is an example of link:

`https://console.cloud.google.com/kubernetes/pod/us-east1-d/kf-ci-v1/test-pods/070adbfe-ccc7-11ec-b4ba-3ae2d8058ce3/details?project=kubeflow-ci`

We are using kubeflow-ci project, and the cluster name is kf-ci-v1, location is us-east1-d. 

We need to validate this change.