### PR TITLE
(pipelines): Fix cluster name to `build-kubeflow` for pod link

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -257,7 +257,7 @@ deck:
                 pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-west1-a/prow/test-pods/{{ .Name }}/details?project=oss-prow-builds"
               "test-infra-trusted":
                 pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-west1-a/prow/test-pods/{{ .Name }}/details?project=oss-prow"
-              "kf-ci-v1":
+              "build-kubeflow":
                 pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-east1-d/kf-ci-v1/test-pods/{{ .Name }}/details?project=kubeflow-ci"
         required_files:
           - podinfo.json


### PR DESCRIPTION
Fix comment in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1604

/assign @chaodaiG 