### PR TITLE
predicted-gh-rate-limit-exhaustion: set duration to 60s

### DIFF
--- a/prow/oss/terraform/modules/alerts/main.tf
+++ b/prow/oss/terraform/modules/alerts/main.tf
@@ -79,7 +79,7 @@ resource "google_monitoring_alert_policy" "predicted-gh-rate-limit-exhaustion" {
       # end of the current rate limit reset window based on rate of consumption
       # over the last 10 minutes. The alert fires if we predict that we will
       # come within 250 tokens of the limit (which is 5% of the 5000 limit).
-      duration = "0s"
+      duration = "60s"
       query    = <<-EOT
       {t_0: # The remaining tokens in the rate limit reset window
           fetch k8s_container::workload.googleapis.com/github_token_usage


### PR DESCRIPTION
On about May 11 1AM PDT, we got 3 sub-1-minute alerts for istio-testing
for this metric:

- May 11, 2022 at 8:00AM UTC (28 sec ago)
       Alert firing lasted
       27 secs
- May 11, 2022 at 8:01AM UTC (29 sec ago)
       Alert firing lasted
       28 secs
- May 11, 2022 at 8:02AM UTC (32 sec ago)
       Alert firing lasted
       31 secs

This was due to a sudden drop in tokens over this time period, which was
quickly recovered. It's not clear why istio-testing experiences sudden
drops for this metric, triggering this alert, but from an administrative
point of view it probably doesn't help that we have multiple alerts fire
for less than a minute.

This change sets the duration field to 60s (it can only be in multiples
of 60s [1]), which is still a conservative figure.

[1]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy#duration

/cc @cjwagner 