### PR TITLE
Onboarding build cluster also sets up gencred refreshing

### DIFF
--- a/prow/oss/create-build-cluster.sh
+++ b/prow/oss/create-build-cluster.sh
@@ -14,7 +14,8 @@ set -o pipefail
 # Specific to Prow instance, don't change these.
 export PROW_INSTANCE_NAME="${PROW_INSTANCE_NAME:-oss-prow}"
 export ADMIN_IAM_MEMBER="${ADMIN_IAM_MEMBER:-group:mdb.cloud-kubernetes-engprod-oncall@google.com}"
-export PROW_SECRET_ACCESSOR_SA="kubernetes-external-secrets-sa@oss-prow.iam.gserviceaccount.com"
+export PROW_SERVICE_PROJECT="oss-prow"
+export PROW_SECRET_ACCESSOR_SA="gencred-refresher@oss-prow.iam.gserviceaccount.com"
 export PROW_DEPLOYMENT_DIR="./prow/oss/cluster" # From root of repo
 export CONTROL_PLANE_SA="oss-prow-public-deck@oss-prow.iam.gserviceaccount.com,oss-prow@oss-prow.iam.gserviceaccount.com"
 

--- a/prow/oss/gencred-refresher/gencred-refresher.yaml
+++ b/prow/oss/gencred-refresher/gencred-refresher.yaml
@@ -1,0 +1,1 @@
+clusters:

--- a/prow/oss/serviceaccounts/GoogleCloudPlatform_oss-test-infra_serviceaccounts.yaml
+++ b/prow/oss/serviceaccounts/GoogleCloudPlatform_oss-test-infra_serviceaccounts.yaml
@@ -22,3 +22,11 @@ metadata:
   name: prowjob-default-sa
   namespace: test-pods
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gencred-refresher@oss-prow.iam.gserviceaccount.com
+  name: gencred-refresher
+  namespace: test-pods
+---

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -55,7 +55,27 @@ postsubmits:
         resources:
           requests:
             memory: "1Gi"
-
+  - name: post-test-infra-gencred-refresh-kubeconfig
+    cluster: test-infra-trusted
+    run_if_changed: '^(prow/oss/gencred-config/|prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config\.yaml)'
+    decorate: true
+    branches:
+    - ^master$
+    spec:
+      serviceAccountName: gencred-refresher
+      containers:
+      - name: gencred
+        image: gcr.io/k8s-prow/gencred:v20220512-991c32830b
+        command:
+        - gencred
+        args:
+        - --config=./prow/oss/gencred-config/gencred-config.yaml
+    annotations:
+      testgrid-num-failures-to-alert: '1'
+      testgrid-dashboards: googleoss-test-infra
+      testgrid-tab-name: postsubmit-gencred-refresh-kubeconfig
+      testgrid-alert-email: k8s-infra-oncall@google.com
+      description: Runs gencred to refresh generated kubeconfigs.
 
 periodics:
 - cron: "30 * * * 1-5"  # Bump don't label `skip-review`. Run at :30 past every hour Mon-Fri
@@ -155,3 +175,23 @@ periodics:
         requests:
           cpu: 100m
           memory: 1Gi
+- cron: "17 */6 * * *"  # Every 6 hours at 17 minutes past the hour
+  name: ci-test-infra-gencred-refresh-kubeconfig
+  cluster: test-infra-trusted
+  decorate: true
+  spec:
+    serviceAccountName: gencred-refresher
+    containers:
+    - name: gencred
+      image: gcr.io/k8s-prow/gencred:v20220512-991c32830b
+      command:
+      - gencred
+      args:
+      - --config=./prow/oss/gencred-config/gencred-config.yaml
+  annotations:
+    testgrid-num-failures-to-alert: '3'
+    testgrid-alert-stale-results-hours: '12'
+    testgrid-dashboards: googleoss-test-infra
+    testgrid-tab-name: ci-gencred-refresh-kubeconfig
+    testgrid-alert-email: k8s-infra-oncall@google.com
+    description: Runs gencred to refresh generated kubeconfigs.


### PR DESCRIPTION
This is part of https://github.com/kubernetes/test-infra/issues/25993. TLDR: gencred generated token lasts at most 2 days, and after 2 days prow will lose access to build cluster unless someone manually run gencred again. This PR automates the rotating

/cc @cjwagner @listx 