### PR TITLE
Prow metrics collected with managed promethues

### DIFF
--- a/prow/oss/cluster/monitoring/prow_podmonitors_for_gmp.yaml
+++ b/prow/oss/cluster/monitoring/prow_podmonitors_for_gmp.yaml
@@ -1,0 +1,165 @@
+# These will be consumed by GKE Managed Prometheus(GMP) services in the cluster.
+# (Not related to prometheus-operator).
+# Ref:
+# https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring.
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: deck
+  name: deck
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: deck
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: ghproxy
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: hook
+  name: hook
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: hook
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: plank
+  name: plank
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: prow-controller-manager
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: sinker
+  name: sinker
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: sinker
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: tide
+  name: tide
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: tide
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: horologium
+  name: horologium
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: horologium
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: crier
+  name: crier
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: crier
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: sub
+  name: sub
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  selector:
+    matchLabels:
+      app: sub
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    app: kubernetes-external-secrets
+  name: kubernetes-external-secrets
+  namespace: default
+spec:
+  endpoints:
+  - interval: 30s
+    port: prometheus
+    scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-external-secrets


### PR DESCRIPTION
This is a new offering from GCP, which is managed prometheus services for collecting prometheus metrics. The configuration was pretty much copy/pasted from prow_podmonitors.yaml, with the following changes based on https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring:

- Removed namespaceSelector section, which is not supported any more. The namespace is added on the PodMonitor CR itself.
- Renamed podMetricsEndpoints to endpoints.
- Use new apiVersion.