### PR TITLE
ignore v2 sample tests on 1.x branches

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -169,6 +169,8 @@ presubmits:
       - image: python:3.7
         command:
         - ./backend/src/v2/test/sample-test.sh
+    skip_branches:
+    - ^sdk\/release-1.*$
   
   - name: kubeflow-pipelines-integration-v2
     run_if_changed: "^(samples/core/(parameterized_tfx_oss|dataflow)/.*)$"


### PR DESCRIPTION
v2 sample tests are failing on `sdk/release-1.x` branches (example: https://github.com/kubeflow/pipelines/pull/7786#issuecomment-1137584977) because the required script does not exist on those branches. 
We do not need to run the v2 sample tests on the v1 branches.

This PR instructs prow to not run tests on those branches.
