### PR TITLE
External secret for build-kpt-config-sync is in oss-prow project

### DIFF
--- a/prow/oss/cluster/kubernetes_external_secrets.yaml
+++ b/prow/oss/cluster/kubernetes_external_secrets.yaml
@@ -174,7 +174,7 @@ metadata:
   namespace: default
 spec:
   backendType: gcpSecretsManager
-  projectId: oss-prow-build-kpt-config-sync
+  projectId: oss-prow
   data:
   - key: prow_build_cluster_kubeconfig_build-kpt-config-sync
     name: kubeconfig


### PR DESCRIPTION
This fixes #1666, which was an auto-generated PR from onboarding, which very likely was caused by a bug in the onboarding script, I will fix it separately