### PR TITLE
Add external secret from build cluster for cloud-kubernetes-node-management-team

### DIFF
--- a/prow/oss/cluster/kubernetes_external_secrets.yaml
+++ b/prow/oss/cluster/kubernetes_external_secrets.yaml
@@ -179,3 +179,16 @@ spec:
   - key: prow_build_cluster_kubeconfig_build-kpt-config-sync
     name: kubeconfig
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-build-cloud-kubernetes-node-management-team
+  namespace: default
+spec:
+  backendType: gcpSecretsManager
+  projectId: oss-prow
+  data:
+  - key: prow_build_cluster_kubeconfig_build-cloud-kubernetes-node-management-team
+    name: kubeconfig
+    version: latest

--- a/prow/oss/gencred-config/gencred-config.yaml
+++ b/prow/oss/gencred-config/gencred-config.yaml
@@ -1,4 +1,10 @@
 clusters:
+- gke: projects/gke-accel-cntnr-ng-tests/locations/us-west1-b/clusters/gke-accel-cntnr-ng-tests
+  name: build-cloud-kubernetes-node-management-team
+  duration: 48h
+  gsm:
+    name: prow_build_cluster_kubeconfig_build-cloud-kubernetes-node-management-team
+    project: oss-prow
 - gke: projects/oss-prow-build-kpt-config-sync/locations/us-central1-b/clusters/oss-prow-build-kpt-config-sync
   name: build-kpt-config-sync
   duration: 48h


### PR DESCRIPTION
Generated by running this script: https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/oss/create-build-cluster.sh