### PR TITLE
increase CS e2e memory request to 80Gi

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -71,8 +71,8 @@ presubmits:
           readOnly: true
         resources:
           requests:
-            # When running at parallel=15, we use 20Gi. So request 40Gi to be safe.
-            memory: "40Gi"
+            # When running at parallel=15, we use 20Gi. So request 80Gi to be safe.
+            memory: "80Gi"
             # This value is experimentally determined.
             # We know to increase this when CPU usage is reported as above 1.0
             # and we observe randomly flaky tests. Check the nodes in our Prow CI
@@ -128,8 +128,8 @@ presubmits:
           readOnly: true
         resources:
           requests:
-            # When running at parallel=15, we use 20Gi. So request 40Gi to be safe.
-            memory: "40Gi"
+            # When running at parallel=15, we use 20Gi. So request 80Gi to be safe.
+            memory: "80Gi"
             # This value is experimentally determined.
             # We know to increase this when CPU usage is reported as above 1.0
             # and we observe randomly flaky tests. Check the nodes in our Prow CI


### PR DESCRIPTION
The large-job-pool on our prow build cluster uses c2-standard-30 nodes,
which come with 30 vCPUs and 120GB memory. These jobs request 29 vCPUs
and 40Gi memory, meaning each job can only run on a single node but
underutilizes the memory on that node. This increases the memory request
to improve memory utilization on the node. This will hopefully reduce
test flakiness.