### PR TITLE
Reduce frequency of Guest Policy and OS Policy Assignments cleanup

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -23,6 +23,27 @@ periodics:
       - "-machine_images=true"
       - "-networks=true"
       - "-snapshots=true"
+      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2,guestos-metadata-scanner"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-osconfig
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper
+  interval: 5h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 3600
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
       - "-guest_policies=true"
       - "-ospolicy_assignments=true"
       - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2,guestos-metadata-scanner"

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -32,7 +32,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cleanerupper
+    testgrid-tab-name: cleanerupper-osconfig
   interval: 5h
   agent: kubernetes
   spec:


### PR DESCRIPTION
Currently cleanerupper is run hourly and cleans all of the resources the legacy periodic tests utilize including Guest Policy and OS Policy Assignments. Cleaning Guest Policy and OS Policy Assignments regularly pushes the cleanerupper job past its 30 minute limit due to sending a request to read policies in every zone offered in GCP, for OS Policy Assignments.

Guest Policy and OS Policy Assignments cleanup has been split in a separate job
* An hour limit has been configured to give the cleanerupper job ample time to finish.
* Frequency of this cleanup has been reduced to every five hours since I've noticed there's often [no policies to clean up](https://oss.gprow.dev/view/gs/oss-prow/logs/cleanerupper/1561776787086643200).