### PR TITLE
Fix skip_storage_path_validation error in presubmit

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -246,6 +246,7 @@ deck:
     '*':
       github_orgs:
       - GoogleCloudPlatform
+  skip_storage_path_validation: false
   additional_allowed_buckets:
     - compute-image-tools-test
     - gcp-guest-testgrid


### PR DESCRIPTION
This will fix the Prow bump presubmit error