### PR TITLE
Increase the memory request for e2e submit job

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -71,8 +71,7 @@ presubmits:
           readOnly: true
         resources:
           requests:
-            # When running at parallel=15, we use 20Gi. So request 80Gi to be safe.
-            memory: "80Gi"
+            memory: "105Gi"
             # This value is experimentally determined.
             # We know to increase this when CPU usage is reported as above 1.0
             # and we observe randomly flaky tests. Check the nodes in our Prow CI
@@ -128,8 +127,7 @@ presubmits:
           readOnly: true
         resources:
           requests:
-            # When running at parallel=15, we use 20Gi. So request 80Gi to be safe.
-            memory: "80Gi"
+            memory: "105Gi"
             # This value is experimentally determined.
             # We know to increase this when CPU usage is reported as above 1.0
             # and we observe randomly flaky tests. Check the nodes in our Prow CI


### PR DESCRIPTION
While testing the parallel setting of the CS presubmit mono/multi jobs, the test pod got deleted due to memory pressure. 
This node used for the presubmit jobs has 112GiB memory. This PR increases the memory request from 80GiB to 105GiB to see whether it helps relieve the memory pressure.