### PR TITLE
Adjust the CPU/mem resources

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -71,12 +71,12 @@ presubmits:
           readOnly: true
         resources:
           requests:
-            memory: "100Gi"
+            memory: "30Gi"
             # This value is experimentally determined.
             # We know to increase this when CPU usage is reported as above 1.0
             # and we observe randomly flaky tests. Check the nodes in our Prow CI
             # cluster.
-            cpu: "52000m"
+            cpu: "17000m"
       volumes:
       - name: prober-cred
         secret:
@@ -127,12 +127,12 @@ presubmits:
           readOnly: true
         resources:
           requests:
-            memory: "100Gi"
+            memory: "30Gi"
             # This value is experimentally determined.
             # We know to increase this when CPU usage is reported as above 1.0
             # and we observe randomly flaky tests. Check the nodes in our Prow CI
             # cluster.
-            cpu: "52000m"
+            cpu: "17000m"
       volumes:
       - name: prober-cred
         secret:


### PR DESCRIPTION
The peak CPU usage of the presubmit mono/multi jobs is about 10 CPUs; The peak mem usage of the presubmit mono/multi jobs is about 16 GiBs.

This PR sets the CPU/mem requests to 17CPUs/30GiBs, so that we can support running three presubmit jobs on a single node concurrently.