### PR TITLE
Split the large presubmit job into multiple smaller ones

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       nodeSelector:
         # This job requires 8vCPUs or less, so it is "small".
         cloud.google.com/gke-nodepool: small-job-pool
-  - name: kpt-config-sync-presubmit-e2e-mono-repo
+  - name: kpt-config-sync-presubmit-e2e-mono-repo-test-group1
     cluster: build-kpt-config-sync
     # branches: ["master"]
     always_run: false
@@ -55,7 +55,7 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test-e2e-go-ephemeral-mono-repo
+        - test-e2e-kind-mono-repo-test-group1
         env:
         # This is only used to tell the job where to store the images.
         # It can be any non-empty value that is a valid gcr.io folder name.
@@ -81,7 +81,119 @@ presubmits:
       - name: prober-cred
         secret:
           secretName: nomos-prober-runner-gcp-client-key
-  - name: kpt-config-sync-presubmit-e2e-multi-repo
+  - name: kpt-config-sync-presubmit-e2e-mono-repo-test-group2
+    cluster: build-kpt-config-sync
+    # branches: ["master"]
+    always_run: false
+    skip_if_only_changed: "^(docs|dashboard)/|\\.md$|^(LICENSE|OWNERS)$"
+    # Ensure that we don't try to schedule more than 5 jobs at a time. This means
+    # we won't automatically get "Pods Unschedulable", but Prow will wait patiently
+    # for other jobs to complete before running.
+    max_concurrency: 5
+    decorate: true
+    labels:
+      # We think this label is required to use kind. Copied from presubmit job above.
+      preset-kind-volume-mounts: "true"
+      # These labels are on the other jobs, so they're here.
+      preset-service-account: "true"
+      # Enable docker-in-docker, and use memory for etcd instead of disk-backed.
+      preset-dind-enabled-memory: "true"
+    decoration_config:
+      # Tests usually finish in ~15 minutes, but this ensures we don't fail on the
+      # odd test that takes much longer than normal.
+      timeout: 60m
+    spec:
+      containers:
+      # Use the special version of the kubekins 1.22 image with Kind
+      # v0.14.0 installed.
+      - image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind-mono-repo-test-group2
+        env:
+        # This is only used to tell the job where to store the images.
+        # It can be any non-empty value that is a valid gcr.io folder name.
+        - name: USER
+          value: "kpt-config-sync-e2e-go-ci"
+        securityContext:
+          privileged: true
+        # This volume mount for prober creds may be superfluous. We don't really
+        # have a way to know.
+        volumeMounts:
+        - name: prober-cred
+          mountPath: /etc/prober-gcp-service-account
+          readOnly: true
+        resources:
+          requests:
+            memory: "30Gi"
+            # This value is experimentally determined.
+            # We know to increase this when CPU usage is reported as above 1.0
+            # and we observe randomly flaky tests. Check the nodes in our Prow CI
+            # cluster.
+            cpu: "17000m"
+      volumes:
+      - name: prober-cred
+        secret:
+          secretName: nomos-prober-runner-gcp-client-key
+  - name: kpt-config-sync-presubmit-e2e-mono-repo-test-group3
+    cluster: build-kpt-config-sync
+    # branches: ["master"]
+    always_run: false
+    skip_if_only_changed: "^(docs|dashboard)/|\\.md$|^(LICENSE|OWNERS)$"
+    # Ensure that we don't try to schedule more than 5 jobs at a time. This means
+    # we won't automatically get "Pods Unschedulable", but Prow will wait patiently
+    # for other jobs to complete before running.
+    max_concurrency: 5
+    decorate: true
+    labels:
+      # We think this label is required to use kind. Copied from presubmit job above.
+      preset-kind-volume-mounts: "true"
+      # These labels are on the other jobs, so they're here.
+      preset-service-account: "true"
+      # Enable docker-in-docker, and use memory for etcd instead of disk-backed.
+      preset-dind-enabled-memory: "true"
+    decoration_config:
+      # Tests usually finish in ~15 minutes, but this ensures we don't fail on the
+      # odd test that takes much longer than normal.
+      timeout: 60m
+    spec:
+      containers:
+      # Use the special version of the kubekins 1.22 image with Kind
+      # v0.14.0 installed.
+      - image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind-mono-repo-test-group3
+        env:
+        # This is only used to tell the job where to store the images.
+        # It can be any non-empty value that is a valid gcr.io folder name.
+        - name: USER
+          value: "kpt-config-sync-e2e-go-ci"
+        securityContext:
+          privileged: true
+        # This volume mount for prober creds may be superfluous. We don't really
+        # have a way to know.
+        volumeMounts:
+        - name: prober-cred
+          mountPath: /etc/prober-gcp-service-account
+          readOnly: true
+        resources:
+          requests:
+            memory: "30Gi"
+            # This value is experimentally determined.
+            # We know to increase this when CPU usage is reported as above 1.0
+            # and we observe randomly flaky tests. Check the nodes in our Prow CI
+            # cluster.
+            cpu: "17000m"
+      volumes:
+      - name: prober-cred
+        secret:
+          secretName: nomos-prober-runner-gcp-client-key
+  - name: kpt-config-sync-presubmit-e2e-multi-repo-test-group1
     # branches: ["master"]
     cluster: build-kpt-config-sync
     always_run: false
@@ -111,7 +223,119 @@ presubmits:
         - runner.sh
         args:
         - make
-        - test-e2e-go-ephemeral-multi-repo
+        - test-e2e-kind-multi-repo-test-group1
+        env:
+        # This is only used to tell the job where to store the images.
+        # It can be any non-empty value that is a valid gcr.io folder name.
+        - name: USER
+          value: "kpt-config-sync-e2e-go-ci"
+        securityContext:
+          privileged: true
+        # This volume mount for prober creds may be superfluous. We don't really
+        # have a way to know.
+        volumeMounts:
+        - name: prober-cred
+          mountPath: /etc/prober-gcp-service-account
+          readOnly: true
+        resources:
+          requests:
+            memory: "30Gi"
+            # This value is experimentally determined.
+            # We know to increase this when CPU usage is reported as above 1.0
+            # and we observe randomly flaky tests. Check the nodes in our Prow CI
+            # cluster.
+            cpu: "17000m"
+      volumes:
+      - name: prober-cred
+        secret:
+          secretName: nomos-prober-runner-gcp-client-key
+  - name: kpt-config-sync-presubmit-e2e-multi-repo-test-group2
+    # branches: ["master"]
+    cluster: build-kpt-config-sync
+    always_run: false
+    skip_if_only_changed: "^(docs|dashboard)/|\\.md$|^(LICENSE|OWNERS)$"
+    # Ensure that we don't try to schedule more than 5 jobs at a time. This means
+    # we won't automatically get "Pods Unschedulable", but Prow will wait patiently
+    # for other jobs to complete before running.
+    max_concurrency: 5
+    decorate: true
+    labels:
+      # We think this label is required to use kind. Copied from presubmit job above.
+      preset-kind-volume-mounts: "true"
+      # These labels are on the other jobs, so they're here.
+      preset-service-account: "true"
+      # Enable docker-in-docker, and use memory for etcd instead of disk-backed.
+      preset-dind-enabled-memory: "true"
+    decoration_config:
+      # Tests usually finish in ~15 minutes, but this ensures we don't fail on the
+      # odd test that takes much longer than normal.
+      timeout: 60m
+    spec:
+      containers:
+      # Use the special version of the kubekins 1.22 image with Kind
+      # v0.14.0 installed.
+      - image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind-multi-repo-test-group2
+        env:
+        # This is only used to tell the job where to store the images.
+        # It can be any non-empty value that is a valid gcr.io folder name.
+        - name: USER
+          value: "kpt-config-sync-e2e-go-ci"
+        securityContext:
+          privileged: true
+        # This volume mount for prober creds may be superfluous. We don't really
+        # have a way to know.
+        volumeMounts:
+        - name: prober-cred
+          mountPath: /etc/prober-gcp-service-account
+          readOnly: true
+        resources:
+          requests:
+            memory: "30Gi"
+            # This value is experimentally determined.
+            # We know to increase this when CPU usage is reported as above 1.0
+            # and we observe randomly flaky tests. Check the nodes in our Prow CI
+            # cluster.
+            cpu: "17000m"
+      volumes:
+      - name: prober-cred
+        secret:
+          secretName: nomos-prober-runner-gcp-client-key
+  - name: kpt-config-sync-presubmit-e2e-multi-repo-test-group3
+    # branches: ["master"]
+    cluster: build-kpt-config-sync
+    always_run: false
+    skip_if_only_changed: "^(docs|dashboard)/|\\.md$|^(LICENSE|OWNERS)$"
+    # Ensure that we don't try to schedule more than 5 jobs at a time. This means
+    # we won't automatically get "Pods Unschedulable", but Prow will wait patiently
+    # for other jobs to complete before running.
+    max_concurrency: 5
+    decorate: true
+    labels:
+      # We think this label is required to use kind. Copied from presubmit job above.
+      preset-kind-volume-mounts: "true"
+      # These labels are on the other jobs, so they're here.
+      preset-service-account: "true"
+      # Enable docker-in-docker, and use memory for etcd instead of disk-backed.
+      preset-dind-enabled-memory: "true"
+    decoration_config:
+      # Tests usually finish in ~15 minutes, but this ensures we don't fail on the
+      # odd test that takes much longer than normal.
+      timeout: 60m
+    spec:
+      containers:
+      # Use the special version of the kubekins 1.22 image with Kind
+      # v0.14.0 installed.
+      - image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+        command:
+        - runner.sh
+        args:
+        - make
+        - test-e2e-kind-multi-repo-test-group3
         env:
         # This is only used to tell the job where to store the images.
         # It can be any non-empty value that is a valid gcr.io folder name.


### PR DESCRIPTION
This PR should be submitted before https://github.com/GoogleContainerTools/kpt-config-sync/pull/116.