### PR TITLE
update config sync plugins

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -29,13 +29,13 @@ config_updater:
 approve:
 - repos:
   - GoogleCloudPlatform
-  - GoogleContainerTools
   - google
   - googleforgames
   - grpc-ecosystem
   - chaotoppicks
   require_self_approval: false
 - repos:
+  - GoogleContainerTools
   - kubeflow/caffe2-operator
   - kubeflow/chainer-operator
   - kubeflow/common
@@ -251,6 +251,7 @@ plugins:
     - trigger
     - verify-owners
     - yuks
+    - wip
 
   googleforgames/agones:
     plugins:


### PR DESCRIPTION
- Add wip plugin to support draft/wip PRs
- Switch approve plugin to require_self_approval since most members of the team are approvers. This allows reviewers to differentiate between lgtm and approve.