### PR TITLE
fix commandHelpLink for approve plugin

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -34,6 +34,7 @@ approve:
   - grpc-ecosystem
   - chaotoppicks
   require_self_approval: false
+  commandHelpLink: https://oss.gprow.dev/command-help
 - repos:
   - GoogleContainerTools
   - kubeflow/caffe2-operator
@@ -48,6 +49,7 @@ approve:
   - kubeflow/tf-operator
   - kubeflow/xgboost-operator
   require_self_approval: true
+  commandHelpLink: https://oss.gprow.dev/command-help
 
 blunderbuss:
   use_status_availability: true


### PR DESCRIPTION
The approve plugin by default links to go.k8s.io/bot-commands, which takes the user to https://prow.k8s.io/command-help rather then the oss prow deck. This updates the plugin configuration to direct the user to the command help page for oss.gprow.dev.