### PR TITLE
Add job spec for kpt-config-sync periodic jobs

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -1,0 +1,76 @@
+# YAML anchors for reference elsewhere.
+# to view expanded yaml, run: `yq eval 'explode(.)' [file]`
+prow_ignored:
+- &config-sync-ci-job
+  interval: 1h
+  cluster: build-kpt-config-sync
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled-memory: "true"
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  extra_refs:
+  - org: GoogleContainerTools
+    repo: kpt-config-sync
+    base_ref: main
+  spec: &config-sync-ci-job-spec
+    containers:
+    - &config-sync-ci-container
+      image: gcr.io/gke-test-infra/kubekins-e2e:v20220204-29ea0e1be-1.23
+      command:
+      - runner.sh
+      env:
+      - name: UID
+        value: "10333"
+      - name: GID
+        value: "10333"
+      - name: GKE_E2E_TIMEOUT
+        value: 2h
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: prober-cred
+        mountPath: /etc/prober-gcp-service-account
+        readOnly: true
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "2000m"
+    nodeSelector:
+      # This job requires 8vCPUs or less, so it is "small".
+      cloud.google.com/gke-nodepool: small-job-pool
+    volumes:
+    - name: prober-cred
+      secret:
+        secretName: nomos-prober-runner-gcp-client-key
+
+periodics:
+- <<: *config-sync-ci-job
+  name: multi-repo-gke-test-group-1-std-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-test-group1
+    testgrid-tab-name: multi-repo-gke-test-group-1-std-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-gke-test-group-1-std-stable'
+
+
+- <<: *config-sync-ci-job
+  name: multi-repo-gke-test-group-2-std-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-test-group2
+    testgrid-tab-name: multi-repo-gke-test-group-2-std-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-gke-test-group-2-std-stable'

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-utils.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-utils.yaml
@@ -3,8 +3,8 @@ periodics:
   interval: 3h
   cluster: build-kpt-config-sync
   annotations:
-    testgrid-dashboards: googleoss-kpt-config-sync
-    testgrid-tab-name: periodic
+    testgrid-dashboards: googleoss-kpt-config-sync-misc
+    testgrid-tab-name: prober-runner-sa-key-rotate
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -11,7 +11,9 @@ dashboards:
 - name: googleoss-kubeflow-gcp-blueprints
 - name: googleoss-grpc-transcoder
 - name: googleoss-http-pattern-matcher
-- name: googleoss-kpt-config-sync
+- name: googleoss-kpt-config-sync-multi-repo-test-group1
+- name: googleoss-kpt-config-sync-multi-repo-test-group2
+- name: googleoss-kpt-config-sync-misc
 
 dashboard_groups:
   - name: googleoss
@@ -24,8 +26,12 @@ dashboard_groups:
     - googleoss-esp-v2-periodic
     - googleoss-grpc-transcoder
     - googleoss-http-pattern-matcher
-    - googleoss-kpt-config-sync
   - name: googleoss-kubeflow
     dashboard_names:
     - googleoss-kubeflow-pipelines
     - googleoss-kubeflow-gcp-blueprints
+  - name: googleoss-kpt-config-sync
+    dashboard_names:
+    - googleoss-kpt-config-sync-multi-repo-test-group1
+    - googleoss-kpt-config-sync-multi-repo-test-group2
+    - googleoss-kpt-config-sync-misc


### PR DESCRIPTION
It also moves the kpt-config-sync jobs to its own tab, which allows nested dashboard groups.