### PR TITLE
Gerrit repos defined globally instead of as command line args

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -25,8 +25,6 @@ spec:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml
         - --cookiefile=/etc/cookies/cookies
-        - --gerrit-projects=https://kunit-review.googlesource.com=linux
-        - --gerrit-projects=https://linux-review.googlesource.com=linux/kernel/git/torvalds/linux
         - --gerrit-workers=1
         - --pubsub-workers=1
         - --github-endpoint=http://ghproxy

--- a/prow/oss/cluster/gerrit.yaml
+++ b/prow/oss/cluster/gerrit.yaml
@@ -25,8 +25,6 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --cookiefile=/etc/cookies/cookies
-        - --gerrit-projects=https://kunit-review.googlesource.com=linux
-        - --gerrit-projects=https://linux-review.googlesource.com=linux/kernel/git/torvalds/linux
         - --last-sync-fallback=gs://oss-prow/last-gerrit-sync
         volumeMounts:
         - name: config

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -251,6 +251,17 @@ deck:
     - compute-image-tools-test
     - gcp-guest-testgrid
 
+gerrit:
+  deck_url: https://oss.gprow.dev/
+  tick_interval: 30s
+  org_repos_config:
+  - org: https://kunit-review.googlesource.com
+    repos:
+    - linux
+  - org: https://linux-review.googlesource.com
+    repos:
+    - linux/kernel/git/torvalds/linux
+
 in_repo_config:
   enabled:
     chaotoppicks: true


### PR DESCRIPTION
This was announced deprecated in March 2022, and officially deprecated since yesterday.