### PR TITLE
Increase the periodic job running time from 2h to 3h

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -9,7 +9,7 @@ prow_ignored:
     preset-dind-enabled-memory: "true"
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 3h
   extra_refs:
   - org: GoogleContainerTools
     repo: kpt-config-sync
@@ -26,7 +26,7 @@ prow_ignored:
       - name: GID
         value: "10333"
       - name: GKE_E2E_TIMEOUT
-        value: 2h
+        value: 3h
       - name: GCP_PROJECT
         value: oss-prow-build-kpt-config-sync
       securityContext:


### PR DESCRIPTION
It takes more time to run the config sync e2e tests on the autopilot clouster, so increasing it from 2h to 3h.