### PR TITLE
set GCP_PROJECT to stolos-dev in presubmits

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -34,6 +34,9 @@ prow_ignored:
       # It can be any non-empty value that is a valid gcr.io folder name.
       - name: USER
         value: "kpt-config-sync-e2e-go-ci"
+      # TODO: unset GCP_PROJECT once jobs can rely on resources in oss prow project
+      - name: GCP_PROJECT
+        value: "stolos-dev"
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
the prow project has not yet been set up with all of the resources needed to run the tests