### PR TITLE
experimental: use workload identity for periodic

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -56,12 +56,16 @@ periodics:
     testgrid-tab-name: standard-stable
   spec:
     <<: *config-sync-ci-job-spec
+    serviceAccountName: e2e-test-runner
     containers:
     - <<: *config-sync-ci-container
       args:
       - make
       - test-e2e-gke-multi-repo-test-group1
       - 'GCP_CLUSTER=multi-repo-1-standard-stable'
+      - 'PROBER_DOCKER_ARGS=""'
+      volumeMounts: []
+    volumes: []
 
 - <<: *config-sync-ci-job
   name: multi-repo-1-standard-regular


### PR DESCRIPTION
This change updates the job spec for one job to use workload identity. Only one job is changed so this can be tested without impacting the entire test grid.