### PR TITLE
use empty string for PROBER_DOCKER_ARGS

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -63,7 +63,7 @@ periodics:
       - make
       - test-e2e-gke-multi-repo-test-group1
       - 'GCP_CLUSTER=multi-repo-1-standard-stable'
-      - 'PROBER_DOCKER_ARGS=""'
+      - 'PROBER_DOCKER_ARGS='
       volumeMounts: []
     volumes: []
 


### PR DESCRIPTION
the quotes were being expanded to the docker call, causing the execution to fail with invalid reference format error.