### PR TITLE
Decrease the memory request for config sync Kind prow jobs

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -1271,7 +1271,7 @@ periodics:
       - test-e2e-kind-multi-repo
       resources:
         requests:
-          memory: "60Gi"
+          memory: "50Gi"
           cpu: "30000m"
     nodeSelector:
       cloud.google.com/gke-nodepool: large-job-pool-periodic
@@ -1338,7 +1338,7 @@ periodics:
       - test-e2e-kind-mono-repo
       resources:
         requests:
-          memory: "60Gi"
+          memory: "50Gi"
           cpu: "30000m"
     nodeSelector:
       cloud.google.com/gke-nodepool: large-job-pool-periodic


### PR DESCRIPTION
The current machine type of the nodepool for config sync Kind prow jobs is n2-custom-32-65536, which has 32 vCPU and 64GB memory.

Requesting for 60GB for the docker container that runs the e2e test hits an insufficient memory issue. This commit decreases the memory request to 50GB.