### PR TITLE
set env USE_TEST_INFRA_LOG_DUMPING

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -196,7 +196,7 @@ presubmits:
         - name: USER
           value: prow
         - name: USE_TEST_INFRA_LOG_DUMPING
-          value: true
+          value: "true"
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -257,7 +257,7 @@ presubmits:
         - name: USER
           value: prow
         - name: USE_TEST_INFRA_LOG_DUMPING
-          value: true
+          value: "true"
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -318,7 +318,7 @@ presubmits:
         - name: USER
           value: prow
         - name: USE_TEST_INFRA_LOG_DUMPING
-          value: true
+          value: "true"
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -379,7 +379,7 @@ presubmits:
         - name: USER
           value: prow
         - name: USE_TEST_INFRA_LOG_DUMPING
-          value: true
+          value: "true"
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -440,7 +440,7 @@ presubmits:
         - name: USER
           value: prow
         - name: USE_TEST_INFRA_LOG_DUMPING
-          value: true
+          value: "true"
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -814,7 +814,7 @@ periodics:
             - name: USER
               value: prow
             - name: USE_TEST_INFRA_LOG_DUMPING
-              value: true
+              value: "true"
           volumeMounts:
             - name: service
               mountPath: /etc/service-account
@@ -880,7 +880,7 @@ periodics:
         - name: USER
           value: prow
         - name: USE_TEST_INFRA_LOG_DUMPING
-          value: true
+          value: "true"
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -946,7 +946,7 @@ periodics:
             - name: USER
               value: prow
             - name: USE_TEST_INFRA_LOG_DUMPING
-              value: true
+              value: "true"
           volumeMounts:
             - name: service
               mountPath: /etc/service-account
@@ -1012,7 +1012,7 @@ periodics:
             - name: USER
               value: prow
             - name: USE_TEST_INFRA_LOG_DUMPING
-              value: true
+              value: "true"
           volumeMounts:
             - name: service
               mountPath: /etc/service-account
@@ -1078,7 +1078,7 @@ periodics:
             - name: USER
               value: prow
             - name: USE_TEST_INFRA_LOG_DUMPING
-              value: true
+              value: "true"
           volumeMounts:
             - name: service
               mountPath: /etc/service-account

--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -195,6 +195,8 @@ presubmits:
           value: /etc/cloudesf-ssh-key-secret/ssh-public
         - name: USER
           value: prow
+        - name: USE_TEST_INFRA_LOG_DUMPING
+          value: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -254,6 +256,8 @@ presubmits:
           value: /etc/cloudesf-ssh-key-secret/ssh-public
         - name: USER
           value: prow
+        - name: USE_TEST_INFRA_LOG_DUMPING
+          value: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -313,6 +317,8 @@ presubmits:
           value: /etc/cloudesf-ssh-key-secret/ssh-public
         - name: USER
           value: prow
+        - name: USE_TEST_INFRA_LOG_DUMPING
+          value: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -372,6 +378,8 @@ presubmits:
           value: /etc/cloudesf-ssh-key-secret/ssh-public
         - name: USER
           value: prow
+        - name: USE_TEST_INFRA_LOG_DUMPING
+          value: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -431,6 +439,8 @@ presubmits:
           value: /etc/cloudesf-ssh-key-secret/ssh-public
         - name: USER
           value: prow
+        - name: USE_TEST_INFRA_LOG_DUMPING
+          value: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -803,6 +813,8 @@ periodics:
               value: /etc/cloudesf-ssh-key-secret/ssh-public
             - name: USER
               value: prow
+            - name: USE_TEST_INFRA_LOG_DUMPING
+              value: true
           volumeMounts:
             - name: service
               mountPath: /etc/service-account
@@ -867,6 +879,8 @@ periodics:
           value: /etc/cloudesf-ssh-key-secret/ssh-public
         - name: USER
           value: prow
+        - name: USE_TEST_INFRA_LOG_DUMPING
+          value: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -931,6 +945,8 @@ periodics:
               value: /etc/cloudesf-ssh-key-secret/ssh-public
             - name: USER
               value: prow
+            - name: USE_TEST_INFRA_LOG_DUMPING
+              value: true
           volumeMounts:
             - name: service
               mountPath: /etc/service-account
@@ -995,6 +1011,8 @@ periodics:
               value: /etc/cloudesf-ssh-key-secret/ssh-public
             - name: USER
               value: prow
+            - name: USE_TEST_INFRA_LOG_DUMPING
+              value: true
           volumeMounts:
             - name: service
               mountPath: /etc/service-account
@@ -1059,6 +1077,8 @@ periodics:
               value: /etc/cloudesf-ssh-key-secret/ssh-public
             - name: USER
               value: prow
+            - name: USE_TEST_INFRA_LOG_DUMPING
+              value: true
           volumeMounts:
             - name: service
               mountPath: /etc/service-account


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To work around the deprecated log_dump script
https://github.com/kubernetes/kubernetes/tree/master/cluster/log-dump

