### PR TITLE
use custom labels for presubmit nodeSelector

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -48,7 +48,8 @@ prow_ignored:
           # cluster.
           cpu: "26000m"
     nodeSelector:
-      cloud.google.com/gke-nodepool: large-job-pool
+      kpt-config-sync/type: presubmit
+      kpt-config-sync/size: large
 
 
 presubmits:


### PR DESCRIPTION
Using the node pool label makes it difficult to recreate the node pool or incorporate more machine types into the node pool. This change uses a custom label selector to enable using multiple node pools for the kind presubmit jobs.