### PR TITLE
Update gcloud-in-go version to latest

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -14,7 +14,7 @@ postsubmits:
     spec:
       serviceAccountName: prow-deployer
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20200824-5d057db
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20210913-fc7c4e8
         command:
         - make
         args:


### PR DESCRIPTION
Potential fix for https://oss.gprow.dev/view/gs/oss-prow/logs/post-oss-test-infra-deploy-prow/1585738959382646784

Job History: https://testgrid.k8s.io/googleoss-test-infra#prow-deploy
