### PR TITLE
Use k8s-staging-test-infra version of gcloud-in-go

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -14,7 +14,7 @@ postsubmits:
     spec:
       serviceAccountName: prow-deployer
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20210913-fc7c4e8
+      - image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20220607-33951ed1ed
         command:
         - make
         args:


### PR DESCRIPTION
The old repository's image is no longer being updated.

issue https://github.com/GoogleCloudPlatform/oss-test-infra/issues/1818