### PR TITLE
test kfp sdk on python 3.11

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -110,6 +110,18 @@ presubmits:
         command:
         - ./test/presubmit-tests-sdk.sh
 
+  - name: kubeflow-pipelines-sdk-python311
+    cluster: build-kubeflow
+    decorate: true
+    run_if_changed: "^(sdk/.*)|(test/presubmit-tests-sdk.sh)$"
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - image: python:3.11
+        command:
+        - ./test/presubmit-tests-sdk.sh
+
   - name: kubeflow-pipelines-tfx-python37
     cluster: build-kubeflow
     decorate: true


### PR DESCRIPTION
Given the recent release of Python 3.11, this PR tests the KFP SDK on Python 3.11.