### PR TITLE
Add Prow setup for jwt_verify_lib

### DIFF
--- a/prow/prowjobs/google/jwt_verify_lib/OWNERS
+++ b/prow/prowjobs/google/jwt_verify_lib/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- qiwzhang
+- nareddyt
+- orionHong

--- a/prow/prowjobs/google/jwt_verify_lib/jwt-verify-lib-presubmit.yaml
+++ b/prow/prowjobs/google/jwt_verify_lib/jwt-verify-lib-presubmit.yaml
@@ -13,19 +13,6 @@ presubmits:
       - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
         command:
         - ./script/ci.sh
-  - name: jwt-verify-lib-checkstyle
-    cluster: espv2
-    always_run: true
-    decorate: true
-    annotations:
-      testgrid-dashboards: googleoss-jwt-verify-lib
-      testgrid-tab-name: checkstyle
-      description: "Runs checkstyle against the entire codebase per PR"
-    spec:
-      containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
-        command:
-        - ./script/check-style
 
 periodics:
 - name: jwt-verify-lib-periodic

--- a/prow/prowjobs/google/jwt_verify_lib/jwt-verify-lib-presubmit.yaml
+++ b/prow/prowjobs/google/jwt_verify_lib/jwt-verify-lib-presubmit.yaml
@@ -1,0 +1,47 @@
+presubmits:
+  google/jwt_verify_lib:
+  - name: jwt-verify-lib-presubmit
+    cluster: espv2
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-dashboards: googleoss-jwt-verify-lib
+      testgrid-tab-name: presubmit
+      description: "Runs all unit tests per PR."
+    spec:
+      containers:
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
+        command:
+        - ./script/ci.sh
+  - name: jwt-verify-lib-checkstyle
+    cluster: espv2
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-dashboards: googleoss-jwt-verify-lib
+      testgrid-tab-name: checkstyle
+      description: "Runs checkstyle against the entire codebase per PR"
+    spec:
+      containers:
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
+        command:
+        - ./script/check-style
+
+periodics:
+- name: jwt-verify-lib-periodic
+  cluster: espv2
+  cron: '0 0,12 * * *' # Run every 12 hours, starting at midnight.
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-jwt-verify-lib
+    testgrid-tab-name: periodic
+    description: "Runs all unit tests on the master branch continuously."
+  extra_refs:
+  - org: google
+    repo: jwt_verify_lib
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20201230-v2.20.0-26-ge16dc8bc-master
+      command:
+      - ./script/ci.sh

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -20,6 +20,7 @@ dashboards:
 - name: googleoss-kpt-config-sync-multi-repo-7
 - name: googleoss-kpt-config-sync-multi-repo-8
 - name: googleoss-kpt-config-sync-misc
+- name: googleoss-jwt-verify-lib
 
 dashboard_groups:
   - name: googleoss
@@ -32,6 +33,7 @@ dashboard_groups:
     - googleoss-esp-v2-periodic
     - googleoss-grpc-transcoder
     - googleoss-http-pattern-matcher
+    - googleoss-jwt-verify-lib
   - name: googleoss-kubeflow
     dashboard_names:
     - googleoss-kubeflow-pipelines


### PR DESCRIPTION
Add configurations to use Prow as CI for https://github.com/google/jwt_verify_lib.

Changes added:
- Add a presubmit and a periodic job. This is re-using the docker container configured in other jobs managerd by our team ([GoogleCloudPlatform/esp-v2](https://github.com/GoogleCloudPlatform/oss-test-infra/tree/master/prow/prowjobs/GoogleCloudPlatform/esp-v2), [grpc-ecosystem/grpc-httpjson-transcoding](https://github.com/GoogleCloudPlatform/oss-test-infra/tree/master/prow/prowjobs/grpc-ecosystem/grpc-httpjson-transcoding), [google/http_pattern_matcher](https://github.com/GoogleCloudPlatform/oss-test-infra/tree/master/prow/prowjobs/google/http_pattern_matcher)).
- Re-use the `esp-v2` Prow cluster that our team self-hosts on GCP.
- Create a new testgrid dashboard for this job.

Signed-off-by: Hongru Xiang [hongrux@google.com](mailto:hongrux@google.com)