### PR TITLE
remove monorepo presubmits

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -80,33 +80,6 @@ presubmits:
         # This job requires 8vCPUs or less, so it is "small".
         cloud.google.com/gke-nodepool: small-job-pool
   - <<: *config-sync-e2e-job
-    name: kpt-config-sync-presubmit-e2e-mono-repo-test-group1
-    spec:
-      <<: *config-sync-e2e-job-spec
-      containers:
-      - <<: *config-sync-e2e-container
-        args:
-        - make
-        - test-e2e-kind-mono-repo-test-group1
-  - <<: *config-sync-e2e-job
-    name: kpt-config-sync-presubmit-e2e-mono-repo-test-group2
-    spec:
-      <<: *config-sync-e2e-job-spec
-      containers:
-      - <<: *config-sync-e2e-container
-        args:
-        - make
-        - test-e2e-kind-mono-repo-test-group2
-  - <<: *config-sync-e2e-job
-    name: kpt-config-sync-presubmit-e2e-mono-repo-test-group3
-    spec:
-      <<: *config-sync-e2e-job-spec
-      containers:
-      - <<: *config-sync-e2e-container
-        args:
-        - make
-        - test-e2e-kind-mono-repo-test-group3
-  - <<: *config-sync-e2e-job
     name: kpt-config-sync-presubmit-e2e-multi-repo-test-group1
     spec:
       <<: *config-sync-e2e-job-spec


### PR DESCRIPTION
With the monorepo code migrated to a separate repo, we no longer need to run the monorepo presubmits on kpt-config-sync. Note that with the reduction in prowjobs per presubmit we require fewer resources in a presubmit run. We could potentially increase the job concurrency accordingly, but for now I intend to scale down the node pool instead. We can scale the node pool back up later if we desire a higher job concurrency.