### PR TITLE
remove PROBER_DOCKER_ARGS

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -31,9 +31,6 @@ prow_ignored:
         value: 4h
       - name: GCP_PROJECT
         value: oss-prow-build-kpt-config-sync
-      # Set PROBER_DOCKER_ARGS to empty to disable mounting prober creds
-      - name: PROBER_DOCKER_ARGS
-        value:
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
This env var is no longer used and WI is supported by default