### PR TITLE
chore: Increase timeout for kpt-config-sync autopilot periodics

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -1007,6 +1007,8 @@ periodics:
 
 - <<: *config-sync-ci-job
   name: multi-repo-7-autopilot-stable
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-7
     testgrid-tab-name: autopilot-stable
@@ -1020,9 +1022,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-7-autopilot-stable'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-7-autopilot-regular
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-7
     testgrid-tab-name: autopilot-regular
@@ -1036,9 +1041,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-7-autopilot-regular'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-7-autopilot-rapid
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-7
     testgrid-tab-name: autopilot-rapid
@@ -1052,9 +1060,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-7-autopilot-rapid'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-7-autopilot-rapid-latest
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-7
     testgrid-tab-name: autopilot-rapid-latest
@@ -1068,6 +1079,7 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-7-autopilot-rapid-latest'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-7-standard-regular-bitbucket


### PR DESCRIPTION
The current periodics can take up to 4 hours to compelete which gets interrupted by the current 4 hour timeout. This change increases the timeout to reduce test flakiness.