### PR TITLE
Run `kubeflow-pipelines-tfx-python37` tests only on `sdk/release-1.8` branch.

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -126,6 +126,8 @@ presubmits:
     cluster: build-kubeflow
     decorate: true
     run_if_changed: "^(sdk/.*)|(test/presubmit-tests-tfx.sh)$"
+    branches:
+    - ^sdk\/release-1.*$
     spec:
       containers:
       - image: python:3.7

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -127,7 +127,7 @@ presubmits:
     decorate: true
     run_if_changed: "^(sdk/.*)|(test/presubmit-tests-tfx.sh)$"
     branches:
-    - ^sdk\/release-1.*$
+    - sdk/release-1.8
     spec:
       containers:
       - image: python:3.7


### PR DESCRIPTION
TFX is not compatible with KFP SDK 2.0: https://github.com/tensorflow/tfx/blob/2450843564f4bc9297f01d1c8fd69c01c7dba4d8/tfx/dependencies.py#L133-L136

Installing KFP SDK from master head [[ref](https://github.com/kubeflow/pipelines/blob/4bb57e6723b7a5c2eb685536e5a293aea87bd3a1/test/presubmit-tests-tfx.sh#L33-L34)] only would be reverted later when installing tfx [[ref](https://github.com/kubeflow/pipelines/blob/4bb57e6723b7a5c2eb685536e5a293aea87bd3a1/test/presubmit-tests-tfx.sh#L48-L49)]. So we're not testing against master branch anyway. 