### PR TITLE
[ESPv2] Update prow env to image with LLVM 14

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/esp-v2/esp-v2.yaml
@@ -10,7 +10,7 @@ presubmits:
       description: "Generates docker images to deploy in e2e tests."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-build.sh
         env:
@@ -35,7 +35,7 @@ presubmits:
       description: "Runs all unit and integration tests."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-presubmit.sh
         env:
@@ -60,7 +60,7 @@ presubmits:
       description: "Runs all integration tests with latest envoy and old configmanager for api backward compatibility"
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-api-regression.sh
         env:
@@ -85,7 +85,7 @@ presubmits:
       description: "Runs all unit and integration tests with ASan."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/presubmit-asan.sh
         env:
@@ -110,7 +110,7 @@ presubmits:
       description: "Runs all unit and integration tests with TSan."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/presubmit-tsan.sh
         env:
@@ -135,7 +135,7 @@ presubmits:
       description: "Generates coverage report for a subset of presubmit tests."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-coverage.sh
         env:
@@ -465,7 +465,7 @@ presubmits:
       description: "Runs e2e tests for Cloud Run."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-e2e.sh
         env:
@@ -492,7 +492,7 @@ presubmits:
       description: "Runs e2e tests for Cloud Functions."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-e2e.sh
         env:
@@ -519,7 +519,7 @@ presubmits:
       description: "Runs e2e tests for App Engine."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-e2e.sh
         env:
@@ -546,7 +546,7 @@ presubmits:
       description: "Runs e2e tests for Cloud Run."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-e2e.sh
         env:
@@ -573,7 +573,7 @@ presubmits:
       description: "Runs e2e test for gcloud_build_image script."
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/e2e-gcloud-build-image.sh
         env:
@@ -601,7 +601,7 @@ postsubmits:
       description: "Generates docker images for potential release"
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-build.sh
         env:
@@ -632,7 +632,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/continuous-build.sh
           env:
@@ -661,7 +661,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/gcpproxy-presubmit.sh
           env:
@@ -690,7 +690,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/presubmit-asan.sh
           env:
@@ -719,7 +719,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/presubmit-tsan.sh
           env:
@@ -748,7 +748,7 @@ periodics:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/gcpproxy-coverage.sh
         env:
@@ -1109,7 +1109,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/e2e-cloud-run-cloud-run-http-bookstore.sh
           env:
@@ -1140,7 +1140,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/e2e-cloud-run-cloud-function-http-bookstore.sh
           env:
@@ -1171,7 +1171,7 @@ periodics:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/e2e-cloud-run-app-engine-http-bookstore.sh
         env:
@@ -1202,7 +1202,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/e2e-cloud-run-cloud-run-grpc-echo.sh
           env:
@@ -1231,7 +1231,7 @@ periodics:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+      - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
         command:
         - ./prow/e2e-gcloud-build-image.sh
         env:
@@ -1301,7 +1301,7 @@ periodics:
         base_ref: master
     spec:
       containers:
-        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20220829-v2.38.0-5-gc746373d-master
+        - image: gcr.io/cloudesf-testing/gcpproxy-prow:v20221128-v2.39.0-3-g66e00dec-master
           command:
             - ./prow/janitor.sh
           env:


### PR DESCRIPTION
Latest envoy only builds with clang-14

Dockerfile changes in https://github.com/GoogleCloudPlatform/esp-v2/pull/755

Signed-off-by: Teju Nareddy <nareddyt@google.com>