### PR TITLE
no el9 for ar-plugin

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -13,7 +13,7 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/main.sh"
-        args: ["gcp-guest", "us-west1-a", "el7,el8,el9"]
+        args: ["gcp-guest", "us-west1-a", "el7,el8"]
   GoogleCloudPlatform/artifact-registry-apt-transport:
   - name: apt-transport-presubmit-build
     cluster: gcp-guest


### PR DESCRIPTION
Mistakenly introduced in #1687 but not yet released for EL9. Will restore when ready.