### PR TITLE
Add sbom presubmit for disk export workflow modification

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -3,8 +3,8 @@ presubmits:
   - name: compute-image-tools-export-sbom
     cluster: gcp-guest
     run_if_changed: 'daisy_workflows/export/export_disk.sh'
-    trigger: "(?m)^/flake8$"
-    rerun_command: "/flake8"
+    trigger: "(?m)^/sbom$"
+    rerun_command: "/sbom"
     context: prow/presubmit/sbom
     decorate: true
     spec:

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -16,7 +16,7 @@ presubmits:
         args:
         - "-project=compute-image-test-pool-001"
         - "-var:syft_source=gs://gce-image-build-resources/linux/syft_0.59.0_linux_amd64.tar.gz"
-        - image_test/sbom/enterprise_sbom_test.wf.json"
+        - daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json"
   - name: compute-image-tools-flake8
     cluster: gcp-guest
     run_if_changed: '.*\.py$'

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -2,7 +2,7 @@ presubmits:
   GoogleCloudPlatform/compute-image-tools:
   - name: compute-image-tools-export-sbom
     cluster: gcp-guest
-    run_if_changed: 'daisy_workflows/export/disk_export.wf.json'
+    run_if_changed: 'daisy_workflows/export/export_disk.sh'
     trigger: "(?m)^/flake8$"
     rerun_command: "/flake8"
     context: prow/presubmit/sbom

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -1,5 +1,22 @@
 presubmits:
   GoogleCloudPlatform/compute-image-tools:
+  - name: compute-image-tools-export-sbom
+    cluster: gcp-guest
+    run_if_changed: 'daisy_workflows/export/disk_export.wf.json'
+    trigger: "(?m)^/flake8$"
+    rerun_command: "/flake8"
+    context: prow/presubmit/sbom
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/compute-image-tools/daisy:latest
+        imagePullPolicy: Always
+        command:
+        - "/daisy"
+        args:
+        - "-project=compute-image-test-pool-001"
+        - "-var:syft_source=gs://gce-image-build-resources/linux/syft_0.59.0_linux_amd64.tar.gz"
+        - image_test/sbom/enterprise_sbom_test.wf.json"
   - name: compute-image-tools-flake8
     cluster: gcp-guest
     run_if_changed: '.*\.py$'


### PR DESCRIPTION
When disk_export.wf.json is modified, this presubmit should run to ensure that sbom generation still works. The presubmit should take around 7 minutes to complete.