### PR TITLE
freeze prow deployments

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -112,45 +112,6 @@ periodics:
       secret:
         secretName: google-oss-robot-ssh-keys
         defaultMode: 0400
-- cron: "01 21 * * 1-5"  # Bump with label `skip-review`. Run at 13:01 PST (21:01 UTC, fall) Mon-Fri
-  # Save for daylight saving:
-  # (Could consider not to switch, since running at 14:01 PST is an acceptable time)
-  # cron: "01 20 * * 1-5"  # Bump with label `skip-review`. Run at 13:01 PST (20:01 UTC, spring) Mon-Fri
-  name: ci-oss-test-infra-autobump-prow-for-auto-deploy
-  cluster: test-infra-trusted
-  decorate: true
-  extra_refs:
-  - org: GoogleCloudPlatform
-    repo: oss-test-infra
-    base_ref: master
-  annotations:
-    testgrid-dashboards: googleoss-test-infra
-    testgrid-tab-name: autobump-prow-for-auto-deploy
-    testgrid-alert-email: k8s-infra-oncall@google.com
-    testgrid-num-failures-to-alert: '1'
-  spec:
-    containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20221220-5c7fbe528a
-      command:
-      - generic-autobumper
-      args:
-      - --config=prow/oss/oss-autobump-config.yaml
-      - --labels-override=skip-review # This label is used by tide for identifying trusted PR
-      - --skip-if-no-oncall # Only apply `skip-review` label when oncall is active
-      volumeMounts:
-      - name: github
-        mountPath: /etc/github-token
-        readOnly: true
-      - name: ssh
-        mountPath: /root/.ssh
-    volumes:
-    - name: github
-      secret:
-        secretName: oauth-token-2
-    - name: ssh
-      secret:
-        secretName: google-oss-robot-ssh-keys
-        defaultMode: 0400
 # ci-oss-test-infra-heartbeat is used for prometheus, alert(s) will be sent
 # if this job hadn't been succeeded for some time
 - cron: "*/3 * * * *" # Every 3 minutes


### PR DESCRIPTION
The `ci-oss-test-infra-autobump-prow` job creates the bump PR. Here we delete the job (`ci-oss-test-infra-autobump-prow-for-auto-deploy`) that votes on these PRs to skip review, making them merge automatically. When we are back from holidays we can restore this job so that Prow (oss.gprow.dev) is updated automatically again.

For examples of autobump PRs, see
https://github.com/GoogleCloudPlatform/oss-test-infra/pulls?q=is%3Apr+author%3Agoogle-oss-robot+is%3Aclosed.

/cc @cjwagner @chases2 