### PR TITLE
add Config Sync release periodics

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -1,0 +1,1080 @@
+# YAML anchors for reference elsewhere.
+# to view expanded yaml, run: `yq eval 'explode(.)' [file]`
+prow_ignored:
+- &config-sync-ci-job
+  interval: 1h
+  cluster: build-kpt-config-sync
+  labels:
+    &config-sync-ci-labels
+    preset-service-account: "true"
+    preset-dind-enabled-memory: "true"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  extra_refs:
+  - org: GoogleContainerTools
+    repo: kpt-config-sync
+    base_ref: v1.14
+  spec: &config-sync-ci-job-spec
+    serviceAccountName: e2e-test-runner
+    containers:
+    - &config-sync-ci-container
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220708-6b0cfd300e-1.23
+      command:
+      - runner.sh
+      env:
+      - name: UID
+        value: "10333"
+      - name: GID
+        value: "10333"
+      - name: GKE_E2E_TIMEOUT
+        value: 4h
+      - name: GCP_PROJECT
+        value: kpt-config-sync-release-ci
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "2Gi"
+          cpu: "2000m"
+    nodeSelector:
+      # This job requires 8vCPUs or less, so it is "small".
+      cloud.google.com/gke-nodepool: small-job-pool
+
+periodics:
+### multi-repo test group 1 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-1-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-1
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group1
+      - 'GCP_CLUSTER=multi-repo-1-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### multi-repo test group 2 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-2-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-2
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group2
+      - 'GCP_CLUSTER=multi-repo-2-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### multi-repo test group 3 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-3-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-3
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group3
+      - 'GCP_CLUSTER=multi-repo-3-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### multi-repo test group 4 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-4-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group4
+      - 'GCP_CLUSTER=multi-repo-4-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### multi-repo test group 5 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-5-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-5
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group5
+      - 'GCP_CLUSTER=multi-repo-5-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### multi-repo test group 6 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-6-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-6
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group6
+      - 'GCP_CLUSTER=multi-repo-6-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### multi-repo test group 7 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-7-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group7
+      - 'GCP_CLUSTER=multi-repo-7-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### multi-repo test group 8 jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-standard-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: standard-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-standard-stable'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-standard-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: standard-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-standard-regular'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-standard-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: standard-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-standard-rapid'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-standard-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: standard-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-standard-rapid-latest'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-autopilot-stable
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: autopilot-stable
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-autopilot-stable'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-autopilot-regular
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: autopilot-regular
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-autopilot-regular'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-autopilot-rapid
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: autopilot-rapid
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-autopilot-rapid'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-8-autopilot-rapid-latest
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-8
+    testgrid-tab-name: autopilot-rapid-latest
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-gke-multi-repo-test-group8
+      - 'GCP_CLUSTER=multi-repo-8-autopilot-rapid-latest'
+      - 'GCP_REGION=us-central1'
+      - 'GCP_ZONE=""'
+
+### miscellaneous jobs ###
+- <<: *config-sync-ci-job
+  name: release-multi-repo-kind
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-misc
+    testgrid-tab-name: release-multi-repo-kind
+  labels:
+    preset-kind-volume-mounts: "true"
+    <<: *config-sync-ci-labels
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      image: gcr.io/kpt-config-sync-ci-release/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+      args:
+      - make
+      - test-e2e-kind-multi-repo
+      resources:
+        requests:
+          memory: "50Gi"
+          cpu: "30000m"
+    nodeSelector:
+      cloud.google.com/gke-nodepool: large-job-pool-periodic
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-kcc
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-misc
+    testgrid-tab-name: release-multi-repo-kcc
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-go-gke-ci
+      - 'E2E_ARGS=--share-test-env --kcc -run=TestKCC*'
+      - 'GCP_CLUSTER=multi-repo-kcc'
+
+- <<: *config-sync-ci-job
+  name: release-multi-repo-gcenode
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-misc
+    testgrid-tab-name: release-multi-repo-gcenode
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-go-gke-ci
+      - 'E2E_ARGS=--share-test-env --gcenode -run=TestGCENode'
+      - 'GCP_CLUSTER=multi-repo-gcenode'
+
+- <<: *config-sync-ci-job
+  name: release-stress-test
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-release-misc
+    testgrid-tab-name: stress-test
+  spec:
+    <<: *config-sync-ci-job-spec
+    containers:
+    - <<: *config-sync-ci-container
+      args:
+      - make
+      - test-e2e-go-gke-ci
+      - 'E2E_ARGS=--stress -run=TestStress*'
+      - 'GCP_CLUSTER=stress-test'

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -20,6 +20,15 @@ dashboards:
 - name: googleoss-kpt-config-sync-multi-repo-7
 - name: googleoss-kpt-config-sync-multi-repo-8
 - name: googleoss-kpt-config-sync-misc
+- name: googleoss-kpt-config-sync-release-multi-repo-1
+- name: googleoss-kpt-config-sync-release-multi-repo-2
+- name: googleoss-kpt-config-sync-release-multi-repo-3
+- name: googleoss-kpt-config-sync-release-multi-repo-4
+- name: googleoss-kpt-config-sync-release-multi-repo-5
+- name: googleoss-kpt-config-sync-release-multi-repo-6
+- name: googleoss-kpt-config-sync-release-multi-repo-7
+- name: googleoss-kpt-config-sync-release-multi-repo-8
+- name: googleoss-kpt-config-sync-release-misc
 - name: googleoss-jwt-verify-lib
 
 dashboard_groups:
@@ -49,3 +58,14 @@ dashboard_groups:
     - googleoss-kpt-config-sync-multi-repo-7
     - googleoss-kpt-config-sync-multi-repo-8
     - googleoss-kpt-config-sync-misc
+  - name: googleoss-kpt-config-sync-release
+    dashboard_names:
+    - googleoss-kpt-config-sync-release-multi-repo-1
+    - googleoss-kpt-config-sync-release-multi-repo-2
+    - googleoss-kpt-config-sync-release-multi-repo-3
+    - googleoss-kpt-config-sync-release-multi-repo-4
+    - googleoss-kpt-config-sync-release-multi-repo-5
+    - googleoss-kpt-config-sync-release-multi-repo-6
+    - googleoss-kpt-config-sync-release-multi-repo-7
+    - googleoss-kpt-config-sync-release-multi-repo-8
+    - googleoss-kpt-config-sync-release-misc


### PR DESCRIPTION
This is a similar set of periodic jobs that we run on the main branch. This set of periodics is intended to verify the current/latest release branch.