### PR TITLE
use e2e-prow image from build cluster project

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -1023,7 +1023,7 @@ periodics:
     <<: *config-sync-ci-job-spec
     containers:
     - <<: *config-sync-ci-container
-      image: gcr.io/kpt-config-sync-ci-release/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
       args:
       - make
       - test-e2e-kind-multi-repo


### PR DESCRIPTION
The kind jobs run directly in the build cluster rather than in a GKE cluster in the target project. There is currently a permission issue reading from GCR in the other project, so this pulls the image from the build cluster project instead.