### PR TITLE
Increase the timeout for release CI jobs on autopilot clusters

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -827,6 +827,8 @@ periodics:
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-7-autopilot-stable
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
     testgrid-tab-name: autopilot-stable
@@ -840,9 +842,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-7-autopilot-stable'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-7-autopilot-regular
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
     testgrid-tab-name: autopilot-regular
@@ -856,9 +861,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-7-autopilot-regular'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-7-autopilot-rapid
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-7
     testgrid-tab-name: autopilot-rapid
@@ -872,6 +880,7 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-7-autopilot-rapid'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-7-autopilot-rapid-latest
@@ -884,21 +893,13 @@ periodics:
     <<: *config-sync-ci-job-spec
     containers:
     - <<: *config-sync-ci-container
-      env:
-      - name: UID
-        value: "10333"
-      - name: GID
-        value: "10333"
-      - name: GKE_E2E_TIMEOUT
-        value: 5h
-      - name: GCP_PROJECT
-        value: kpt-config-sync-ci-release
       args:
       - make
       - test-e2e-gke-multi-repo-test-group7
       - 'GCP_CLUSTER=multi-repo-7-autopilot-rapid-latest'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 ### multi-repo test group 8 jobs ###
 - <<: *config-sync-ci-job


### PR DESCRIPTION
Config Sync test group 7 includes testcases that switch source configs, which triggers the reconciler Pod to restart. It takes much longer time to restart a Pod on an autopilot cluster. Hence, this commit increases the timeout from 4h to 5h.