### PR TITLE
Increase the timeout for config sync test-group 4 CI jobs on autopilot clusters

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -464,6 +464,8 @@ periodics:
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-4-autopilot-stable
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
     testgrid-tab-name: autopilot-stable
@@ -477,9 +479,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-stable'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-4-autopilot-regular
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
     testgrid-tab-name: autopilot-regular
@@ -493,9 +498,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-regular'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-4-autopilot-rapid
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
     testgrid-tab-name: autopilot-rapid
@@ -509,9 +517,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-rapid'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: release-multi-repo-4-autopilot-rapid-latest
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-release-multi-repo-4
     testgrid-tab-name: autopilot-rapid-latest
@@ -525,6 +536,7 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-rapid-latest'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 ### multi-repo test group 5 jobs ###
 - <<: *config-sync-ci-job

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -554,6 +554,8 @@ periodics:
 
 - <<: *config-sync-ci-job
   name: multi-repo-4-autopilot-stable
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-4
     testgrid-tab-name: autopilot-stable
@@ -567,9 +569,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-stable'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-4-autopilot-regular
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-4
     testgrid-tab-name: autopilot-regular
@@ -583,9 +588,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-regular'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-4-autopilot-rapid
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-4
     testgrid-tab-name: autopilot-rapid
@@ -599,9 +607,12 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-rapid'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-4-autopilot-rapid-latest
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-multi-repo-4
     testgrid-tab-name: autopilot-rapid-latest
@@ -615,6 +626,7 @@ periodics:
       - 'GCP_CLUSTER=multi-repo-4-autopilot-rapid-latest'
       - 'GCP_REGION=us-central1'
       - 'GCP_ZONE=""'
+      - 'GKE_E2E_TIMEOUT=5h'
 
 - <<: *config-sync-ci-job
   name: multi-repo-4-standard-regular-bitbucket


### PR DESCRIPTION
Some test-group-4 CI jobs on the autopilot clusters are close to 4 hours, e.g.,
https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/multi-repo-4-autopilot-regular/1615720761786372096.

The job will fail if it runs over 4h. This commit increases the time out for test-group-4 on autopilot clusters from 4h to 5h.