### PR TITLE
kunit: Require manual trigger of the kunit presubmit

### DIFF
--- a/prow/prowjobs/linux-review.googlesource.com/linux/kernel/git/torvalds/linux.yaml
+++ b/prow/prowjobs/linux-review.googlesource.com/linux/kernel/git/torvalds/linux.yaml
@@ -4,7 +4,9 @@ presubmits:
     branches:
     - master
     decorate: true
-    always_run: true
+    always_run: false
+    trigger: "run kunit tests"
+    rerun_command: "run kunit tests"
     spec:
       volumes:
       - name: shared-mem


### PR DESCRIPTION
This is currently triggering automatically _way_ too often, so hopefully this will fix that.

Instead, manually trigger kunit tests by commenting "run kunit tests".

Note that this affects the linux-review repository (with its branch pulled in from torvalds), not the kunit-review repository, which sees less use (and less spam).