### PR TITLE
ci: bump kubekins-e2e image

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -19,7 +19,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-ci-container
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220708-6b0cfd300e-1.23
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
       command:
       - runner.sh
       env:
@@ -1047,7 +1047,7 @@ periodics:
     <<: *config-sync-ci-job-spec
     containers:
     - <<: *config-sync-ci-container
-      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20230309-9a6b1b3121-1.23-kind-v0.14.0
       args:
       - make
       - test-e2e-kind-multi-repo

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -19,7 +19,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-ci-container
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220708-6b0cfd300e-1.23
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
       command:
       - runner.sh
       env:
@@ -1287,7 +1287,7 @@ periodics:
     <<: *config-sync-ci-job-spec
     containers:
     - <<: *config-sync-ci-container
-      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20230309-9a6b1b3121-1.23-kind-v0.14.0
       args:
       - make
       - test-e2e-kind-multi-repo

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -26,7 +26,7 @@ prow_ignored:
     # Use the special version of the kubekins 1.22 image with Kind
     # v0.14.0 installed.
     - &config-sync-e2e-container
-      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20220708-6b0cfd300e-1.23-kind-v0.14.0
+      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20230309-9a6b1b3121-1.23-kind-v0.14.0
       command:
       - runner.sh
       env:
@@ -63,7 +63,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220708-6b0cfd300e-1.23
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
         command:
         - runner.sh
         args:


### PR DESCRIPTION
This uses an upgraded kubekins-e2e base image which contains Go 1.19.

Uses the image defined in https://github.com/GoogleContainerTools/kpt-config-sync/pull/466