### PR TITLE
Update kubekins-e2e image to v20230324-c487e233e1-master

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/k8s-cloud-provider/k8s-cloud-provider-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/k8s-cloud-provider/k8s-cloud-provider-config.yaml
@@ -9,7 +9,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230324-c487e233e1-master
         command:
         - make
         - --


### PR DESCRIPTION
Needed to fix failing tests due to older golang version (the tests seem to be running with golang < 1.16 which is pretty old)

Related PR: https://github.com/GoogleCloudPlatform/k8s-cloud-provider/pull/89
Failing tests: https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/GoogleCloudPlatform_k8s-cloud-provider/89/pull-k8s-cloud-provider-test/1640409285739417600

/cc @aojea