### PR TITLE
run python 3.11 tests only on `master` branch

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -114,6 +114,8 @@ presubmits:
     cluster: build-kubeflow
     decorate: true
     run_if_changed: "^(sdk/.*)|(test/presubmit-tests-sdk.sh)$"
+    branches:
+      - master
     spec:
       containers:
       - image: python:3.11


### PR DESCRIPTION
To fix test failure on `sdk/release-1.8` PR: https://github.com/kubeflow/pipelines/pull/9060#issuecomment-1489238473