### PR TITLE
chore: Update golang used in kubeflow-pipelines-presubmits.yaml

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: golang:1.18-bullseye
+      - image: golang:1.20-bullseye
         command:
         - ./test/presubmit-backend-test.sh
   - name: kubeflow-pipeline-e2e-test


### PR DESCRIPTION
Some modules used by KFP requires golang 1.20:

```
../../../../pkg/mod/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f/pkg/cached/cache.go:242:16: undefined: atomic.Pointer
note: module requires Go 1.19
# k8s.io/client-go/tools/cache/synctrack
../../../../pkg/mod/k8s.io/client-go@v0.27.1/tools/cache/synctrack/lazy.go:29:15: undefined: atomic.Pointer
note: module requires Go 1.20
FAIL	github.com/kubeflow/pipelines/backend/src/agent/persistence/worker [build failed]
FAIL	github.com/kubeflow/pipelines/backend/src/apiserver/archive [build failed]
FAIL	github.com/kubeflow/pipelines/backend/src/apiserver/auth [build failed]
FAIL	github.com/kubeflow/pipelines/backend/src/apiserver/client [build failed]
```