### PR TITLE
add vulnerability scanning periodic job

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -1342,3 +1342,31 @@ periodics:
       - test-e2e-go-gke-ci
       - 'E2E_ARGS=--stress -run=TestStress*'
       - 'GCP_CLUSTER=stress-test'
+
+- name: vulnerability-scan
+  interval: 1h
+  annotations:
+    testgrid-dashboards: googleoss-kpt-config-sync-misc
+    testgrid-tab-name: vulnerability-scan
+  cluster: build-kpt-config-sync
+  decorate: true
+  decoration_config:
+    timeout: 30m
+  extra_refs:
+  - org: GoogleContainerTools
+    repo: kpt-config-sync
+    base_ref: main
+  spec:
+    serviceAccountName: vulnerability-scanner
+    containers:
+    - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/vulnerability-scanner:v1.0.0-60ad07344
+      command:
+      - make
+      - vulnerability-scan-postsubmit
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+    nodeSelector:
+      # This job requires 8vCPUs or less, so it is "small".
+      cloud.google.com/gke-nodepool: small-job-pool


### PR DESCRIPTION
This job checks the container analysis results in GCP for vulnerabilities on the postsubmit artifacts for the checked out commit.