### PR TITLE
increase frequency of vuln scan job

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -1344,7 +1344,7 @@ periodics:
       - 'GCP_CLUSTER=stress-test'
 
 - name: vulnerability-scan
-  interval: 1h
+  interval: 30m
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-misc
     testgrid-tab-name: vulnerability-scan


### PR DESCRIPTION
This job is relatively lightweight, so we can afford to run it more frequently. This will enable faster feedback on changes/fixes.