### PR TITLE
Use sbom util instead of syft source for presubmit

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -15,7 +15,7 @@ presubmits:
         - "/daisy"
         args:
         - "-project=compute-image-test-pool-001"
-        - "-var:syft_source=gs://gce-image-build-resources/linux/syft_0.59.0_linux_amd64.tar.gz"
+        - "-var:sbom_util_gcs_root=gs://gce-image-sbom-util"
         - "daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json"
   - name: compute-image-tools-flake8
     cluster: gcp-guest


### PR DESCRIPTION
Now that the sbom util path for linux image sbom generation is enabled, use that path for the presubmit instead of the syft-source path.