### PR TITLE
explicitly unset GCP_ZONE for autopilot

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -1421,6 +1421,9 @@ periodics:
         value: prow-e2e-network-1
       - name: GCP_SUBNETWORK
         value: prow-e2e-subnetwork-2
+      # only one of GCP_ZONE and GCP_REGION can be provided
+      - name: GCP_ZONE
+        value: ""
       - name: GCP_REGION
         value: us-central1
       - name: GKE_RELEASE_CHANNEL


### PR DESCRIPTION
Only one of GCP_ZONE or GCP_REGION can be specified for creating a cluster. The makefile by default supplies a GCP_ZONE and must be unset.