### PR TITLE
increase interval for new cs e2e jobs

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -44,7 +44,7 @@ prow_ignored:
 # Experimental anchor to verify the new create-clusters flow.
 # If stable, this is intended to replace the above anchor.
 - &config-sync-ci-job-v2
-  interval: 1h
+  interval: 30m
   cluster: build-kpt-config-sync
   decorate: true
   decoration_config:


### PR DESCRIPTION
The new job types run faster than the old ones, the e2e tests on standard now can often complete in ~45 minutes. Decreasing the interval will improve the turnaround time on the new periodics.