### PR TITLE
move new CS periodics to main dashboard

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -1392,7 +1392,7 @@ periodics:
 - <<: *config-sync-ci-job-v2
   name: kpt-config-sync-standard-regular
   annotations:
-    testgrid-dashboards: googleoss-kpt-config-sync-misc
+    testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: standard-regular
   spec:
     <<: *config-sync-ci-job-spec-v2
@@ -1411,7 +1411,7 @@ periodics:
 - <<: *config-sync-ci-job-v2
   name: kpt-config-sync-standard-rapid
   annotations:
-    testgrid-dashboards: googleoss-kpt-config-sync-misc
+    testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: standard-rapid
   spec:
     <<: *config-sync-ci-job-spec-v2
@@ -1433,7 +1433,7 @@ periodics:
 - <<: *config-sync-ci-job-v2
   name: kpt-config-sync-standard-rapid-latest
   annotations:
-    testgrid-dashboards: googleoss-kpt-config-sync-misc
+    testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: standard-rapid-latest
   spec:
     <<: *config-sync-ci-job-spec-v2
@@ -1455,7 +1455,7 @@ periodics:
 - <<: *config-sync-ci-job-v2
   name: kpt-config-sync-autopilot-regular
   annotations:
-    testgrid-dashboards: googleoss-kpt-config-sync-misc
+    testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: autopilot-regular
   spec:
     <<: *config-sync-ci-job-spec-v2

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -19,6 +19,7 @@ dashboards:
 - name: googleoss-kpt-config-sync-multi-repo-6
 - name: googleoss-kpt-config-sync-multi-repo-7
 - name: googleoss-kpt-config-sync-multi-repo-8
+- name: googleoss-kpt-config-sync-main
 - name: googleoss-kpt-config-sync-misc
 - name: googleoss-kpt-config-sync-release-multi-repo-1
 - name: googleoss-kpt-config-sync-release-multi-repo-2
@@ -49,6 +50,7 @@ dashboard_groups:
     - googleoss-kubeflow-gcp-blueprints
   - name: googleoss-kpt-config-sync
     dashboard_names:
+    # TODO: remove these legacy dashboards once migration is complete
     - googleoss-kpt-config-sync-multi-repo-1
     - googleoss-kpt-config-sync-multi-repo-2
     - googleoss-kpt-config-sync-multi-repo-3
@@ -57,6 +59,8 @@ dashboard_groups:
     - googleoss-kpt-config-sync-multi-repo-6
     - googleoss-kpt-config-sync-multi-repo-7
     - googleoss-kpt-config-sync-multi-repo-8
+    # end legacy dashboards
+    - googleoss-kpt-config-sync-main
     - googleoss-kpt-config-sync-misc
   - name: googleoss-kpt-config-sync-release
     dashboard_names:


### PR DESCRIPTION
This is the intended dashboard format, where the periodics against the main branch will be consolidated into a single dashboard. The legacy testgroup based prowjobs and associated dashboards will be cleaned up once all of the new jobs are set up.