### PR TITLE
chore: bump CS kubekins-e2e image

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -20,7 +20,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-ci-container
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
       command:
       - runner.sh
       env:
@@ -1048,7 +1048,7 @@ periodics:
     <<: *config-sync-ci-job-spec
     containers:
     - <<: *config-sync-ci-container
-      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20230309-9a6b1b3121-1.23-kind-v0.14.0
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
       args:
       - make
       - test-e2e-kind-multi-repo

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -19,7 +19,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-ci-container
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
       command:
       - runner.sh
       env:
@@ -1339,7 +1339,7 @@ periodics:
     <<: *config-sync-ci-job-spec
     containers:
     - <<: *config-sync-ci-container
-      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20230309-9a6b1b3121-1.23-kind-v0.14.0
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
       args:
       - make
       - test-e2e-kind-multi-repo

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
     spec:
       serviceAccountName: postsubmit-runner
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
+      - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
         command:
         - runner.sh
         args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -26,7 +26,7 @@ prow_ignored:
     # Use the special version of the kubekins 1.22 image with Kind
     # v0.14.0 installed.
     - &config-sync-e2e-container
-      image: gcr.io/oss-prow-build-kpt-config-sync/e2e-prow:kubekins-e2e-v20230309-9a6b1b3121-1.23-kind-v0.14.0
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
       command:
       - runner.sh
       env:
@@ -63,7 +63,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230309-9a6b1b3121-1.23
+      - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
         command:
         - runner.sh
         args:


### PR DESCRIPTION
The image has been redefined for the new test-infra registry, but is essentially the same image.