### PR TITLE
load shell variable before daisy command for presubmit

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -12,11 +12,9 @@ presubmits:
       - image: gcr.io/compute-image-tools/daisy:latest
         imagePullPolicy: Always
         command:
-        - "/daisy"
+        - "sh"
         args:
-        - "-project=compute-image-test-pool-001"
-        - "-var:sbom_util_gcs_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest)"
-        - "daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json"
+        - "sbom_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest) && daisy -project=compute-image-test-pool-001 -var:sbom_util_gcs_root=$sbom_root daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json"
   - name: compute-image-tools-export-sbom-windows
     cluster: gcp-guest
     run_if_changed: 'daisy_workflows/image_build/windows/bootstrap_install.ps1'


### PR DESCRIPTION
If the command is set to "/daisy", the shell variable within $(command) is not run. 

The command needs to be set to sh to get the gcloud secret successfully.