### PR TITLE
Use bash instead of sh

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -12,7 +12,7 @@ presubmits:
       - image: gcr.io/gcp-guest/gointegtest:latest
         imagePullPolicy: Always
         command:
-        - "sh"
+        - "/bin/bash"
         args:
         - "sbom_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest); "
         - "/daisy"

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -12,7 +12,7 @@ presubmits:
       - image: gcr.io/gcp-guest/gointegtest:latest
         imagePullPolicy: Always
         command:
-        - "/bin/bash"
+        - "bash"
         args:
         - "sbom_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest); "
         - "/daisy"


### PR DESCRIPTION
sh seems to interpret the first argument as a file, even if we are just trying to run the command.

Use /bin/bash instead