### PR TITLE
Run bash as a command

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -14,6 +14,7 @@ presubmits:
         command:
         - "bash"
         args:
+        - "-c"
         - "sbom_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest); "
         - "/daisy"
         - "project=compute-image-test-pool-001" 


### PR DESCRIPTION
Explicitly run bash as a command, so the first argument isn't interpreted as a filename