### PR TITLE
Use secrets for windows sbom presubmit

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-image-tools.yaml
@@ -15,7 +15,7 @@ presubmits:
         - "bash"
         args:
         - "-c"
-        - "sbom_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest); /daisy -project=compute-image-test-pool-001 -var:sbom_util_gcs_root=$sbom_root daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json"
+        - "sbom_util_gcs_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest); /daisy -project=compute-image-test-pool-001 -var:sbom_util_gcs_root=$sbom_util_gcs_root daisy_workflows/sbom_validation/enterprise_sbom_test.wf.json"
   - name: compute-image-tools-export-sbom-windows
     cluster: gcp-guest
     run_if_changed: 'daisy_workflows/image_build/windows/bootstrap_install.ps1'
@@ -25,18 +25,13 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/compute-image-tools/daisy:latest
+      - image: gcr.io/gcp-guest/gointegtest:latest
         imagePullPolicy: Always
         command:
-        - "/daisy"
+        - "bash"
         args:
-        - "-project=compute-image-test-pool-001"
-        - "-var:sbom_util_gcs_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest)"
-        - "-var:media=$(gcloud secrets versions access latest --secret=win2019-64 --project=gcp-guest)"
-        - "-var:pwsh=$(gcloud secrets versions access latest --secret=windows_gcs_pwsh --project=gcp-guest)"
-        - "-var:cloudsdk=$(gcloud secrets versions access latest --secret=windows_gcs_cloud_sdk --project=gcp-guest)"
-        - "-var:dotnet48=$(gcloud secrets versions access latest --secret=windows_gcs_dotnet48 --project=gcp-guest)"
-        - "daisy_workflows/sbom_validation/windows_sbom_validation.wf.json"      
+        - "-c"
+        - "sbom_util_gcs_root=$(gcloud secrets versions access latest --secret=sbom-util-secret --project=gcp-guest); media=$(gcloud secrets versions access latest --secret=win2019-64 --project=gcp-guest); pwsh=$(gcloud secrets versions access latest --secret=windows_gcs_pwsh --project=gcp-guest); cloudsdk=$(gcloud secrets versions access latest --secret=windows_gcs_cloud_sdk --project=gcp-guest); dotnet48=$(gcloud secrets versions access latest --secret=windows_gcs_dotnet48 --project=gcp-guest); /daisy -project=compute-image-test-pool-001 -var:sbom_util_gcs_root=$sbom_util_gcs_root -var:media=$media -var:pwsh=$pwsh -var:cloudsdk=$cloudsdk -var:dotnet48=$dotnet48 daisy_workflows/sbom_validation/windows_sbom_validation.wf.json"      
   - name: compute-image-tools-flake8
     cluster: gcp-guest
     run_if_changed: '.*\.py$'


### PR DESCRIPTION
Following the template for the disk_export presubmit, use secrets for the windows presubmit.