### PR TITLE
Update the vulnerability-scanner image

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -1118,7 +1118,7 @@ periodics:
   spec:
     serviceAccountName: vulnerability-scanner
     containers:
-    - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/vulnerability-scanner:v1.0.0-60ad07344
+    - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/vulnerability-scanner:v1.0.0-ff545b40
       command:
       - make
       - vulnerability-scan-postsubmit

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -343,7 +343,7 @@ periodics:
   spec:
     serviceAccountName: vulnerability-scanner
     containers:
-    - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/vulnerability-scanner:v1.0.0-60ad07344
+    - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/vulnerability-scanner:v1.0.0-ff545b40
       command:
       - make
       - vulnerability-scan-postsubmit


### PR DESCRIPTION
This is to pick up the change in
https://github.com/GoogleContainerTools/kpt-config-sync/pull/753/files.

A new docker image was pushed with the command:
`make build-vulnerability-scanner && make push-vulnerability-scanner`