### PR TITLE
increase cluster size for stress tests

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -322,6 +322,7 @@ periodics:
       - 'GKE_RELEASE_CHANNEL=regular'
       - 'E2E_CLUSTER_PREFIX=standard-regular-stress'
       - 'E2E_NUM_CLUSTERS=1'
+      - 'GKE_NUM_NODES=3' # stress test needs a bigger cluster to handle finalizing
       - 'E2E_ARGS=--stress -run=TestStress*'
 
 #### End one-off jobs


### PR DESCRIPTION
The stress tests manage and then delete a large number of resources. The reset code currently times out with the given cluster shape. Increasing the number of nodes enables the stress test to complete within the default timeout (experimentally).