### PR TITLE
bump release CI from pinned tag to branch

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -11,7 +11,7 @@ prow_ignored:
   - &config-sync-ci-ref
     org: GoogleContainerTools
     repo: kpt-config-sync
-    base_ref: v1.16.0-rc.2 # TODO: update this to v1.16 once the branch is created
+    base_ref: v1.16
   spec: &config-sync-ci-job-spec
     serviceAccountName: e2e-test-runner
     containers:


### PR DESCRIPTION
The job was pinned to a tag because the release branch was not yet ready when we wanted to update the job definitions. Under normal circumstances we will upgrade from branch->branch once the new release branch is ready.