### PR TITLE
Add build cluster kubeconfig for bms-oracle-team

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -37,7 +37,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -47,6 +47,9 @@ spec:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-bms-oracle-team
+          name: build-bms-oracle-team
+          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -87,6 +90,10 @@ spec:
           mountPath: /etc/github
           readOnly: true
       volumes:
+      - name: build-bms-oracle-team
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -43,13 +43,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8080
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-bms-oracle-team
+          name: build-bms-oracle-team
+          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -109,6 +112,10 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       volumes:
+      - name: build-bms-oracle-team
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck_blueprints_deployment.yaml
+++ b/prow/oss/cluster/deck_blueprints_deployment.yaml
@@ -44,13 +44,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8080
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-bms-oracle-team
+          name: build-bms-oracle-team
+          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -154,6 +157,10 @@ spec:
               name: blueprints-github-oauth
               key: cookieSecret
       volumes:
+      - name: build-bms-oracle-team
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -51,6 +51,9 @@ spec:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-bms-oracle-team
+          name: build-bms-oracle-team
+          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -111,6 +114,10 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       volumes:
+      - name: build-bms-oracle-team
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -28,11 +28,14 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-bms-oracle-team
+          name: build-bms-oracle-team
+          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -67,6 +70,10 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
+      - name: build-bms-oracle-team
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -27,11 +27,14 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
+        - mountPath: /etc/build-bms-oracle-team
+          name: build-bms-oracle-team
+          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -66,6 +69,10 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
+      - name: build-bms-oracle-team
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420


### PR DESCRIPTION
Please submit this change after the previous PR was submitted and postsubmit job succeeded. Prow oncall: please don't submit this change until the secret is created successfully, which will be indicated by prow alerts in 2 minutes after the postsubmit job.

IIUC, pls wait for https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2050 to be merged and then approve/merge this PR.

Thanks

P.S.: More background copied from the other PR is reproduced below:

More details (internal references) on this:
* YAQS:  https://yaqs.corp.google.com/eng/q/144582480517660672?ved=0CAAQ0qAKahcKEwiY97rp_YSBAxUAAAAAHQAAAAAQHA
* TDD: [go/bmx-ci:pr-triggered-test-automation](http://go/bmx-ci:pr-triggered-test-automation)
* The full run of `create-build-cluster.sh` is at https://b.corp.google.com/issues/290186907#comment17

