### PR TITLE
Revert incorrect onboarding in PRs 2051 and 2050

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -37,7 +37,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -47,9 +47,6 @@ spec:
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
-          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -87,10 +84,6 @@ spec:
           mountPath: /etc/github
           readOnly: true
       volumes:
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -43,16 +43,13 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8080
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
-          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -109,10 +106,6 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       volumes:
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck_blueprints_deployment.yaml
+++ b/prow/oss/cluster/deck_blueprints_deployment.yaml
@@ -44,16 +44,13 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: http
           containerPort: 8080
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
-          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -154,10 +151,6 @@ spec:
               name: blueprints-github-oauth
               key: cookieSecret
       volumes:
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -51,9 +51,6 @@ spec:
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
-          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -111,10 +108,6 @@ spec:
           periodSeconds: 3
           timeoutSeconds: 600
       volumes:
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/kubernetes_external_secrets.yaml
+++ b/prow/oss/cluster/kubernetes_external_secrets.yaml
@@ -192,16 +192,3 @@ spec:
   - key: prow_build_cluster_kubeconfig_build-gcsfuse
     name: kubeconfig
     version: latest
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
-  name: kubeconfig-build-bms-oracle-team
-  namespace: default
-spec:
-  backendType: gcpSecretsManager
-  projectId: oss-prow
-  data:
-  - key: prow_build_cluster_kubeconfig_build-bms-oracle-team
-    name: kubeconfig
-    version: latest

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -28,14 +28,11 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
-          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -67,10 +64,6 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -27,14 +27,11 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
-          readOnly: true
         - mountPath: /etc/build-gcsfuse
           name: build-gcsfuse
           readOnly: true
@@ -66,10 +63,6 @@ spec:
           mountPath: /etc/build-kubeflow
           readOnly: true
       volumes:
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-gcsfuse
         secret:
           defaultMode: 420

--- a/prow/oss/gencred-config/gencred-config.yaml
+++ b/prow/oss/gencred-config/gencred-config.yaml
@@ -1,10 +1,4 @@
 clusters:
-- gke: projects/bmaas-testing/locations/southamerica-east1-b/clusters/bmaas-testing-prow-sydrp
-  name: build-bms-oracle-team
-  duration: 48h
-  gsm:
-    name: prow_build_cluster_kubeconfig_build-bms-oracle-team
-    project: oss-prow
 - gke: projects/gcs-fuse-test-ml/locations/us-central1-c/clusters/gcsfuse-prow-test
   name: build-gcsfuse
   duration: 48h


### PR DESCRIPTION
Reverting changes to recreate cluster due to incorrect service account while onboarding via:
* https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2050
* https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2051