### PR TITLE
Use a separate large job pool for the release CI

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -80,7 +80,7 @@ periodics:
           memory: "50Gi"
           cpu: "30000m"
     nodeSelector:
-      cloud.google.com/gke-nodepool: large-job-pool-periodic
+      cloud.google.com/gke-nodepool: large-job-pool-periodic-release
 
 #### Begin GKE standard jobs
 - <<: *config-sync-ci-job


### PR DESCRIPTION
The kind job on both the main branch and the release branch failed because of api timeout.
After checking the node status, we are seeing MemoryPressure, DiskPressure, and PIDPressure issues on the node.

Hence, this commit moves the kind job on the release branch to a separate large job pool.

b/299570441