### PR TITLE
fix kubeconfig for test-infra-trusted cluster

### DIFF
--- a/prow/Makefile.gcloud.mk
+++ b/prow/Makefile.gcloud.mk
@@ -39,7 +39,3 @@ get-cluster-credentials: save-kubeconfig activate-serviceaccount
 .PHONY: get-build-cluster-credentials
 get-build-cluster-credentials: save-kubeconfig activate-serviceaccount
 	gcloud container clusters get-credentials "$(CLUSTER_BUILD)" --project="$(PROJECT_BUILD)" --zone="$(ZONE)"
-
-.PHONY: update-kubeconfigs
-update-kubeconfigs:
-	kubectl create configmap kubeconfigs --from-file=kubeconfigs.yaml=kubeconfigs.yaml --dry-run=client -o yaml | kubectl replace configmap kubeconfigs -f -

--- a/prow/oss/Makefile
+++ b/prow/oss/Makefile
@@ -30,8 +30,12 @@ update-config: get-cluster-credentials
 update-plugins: get-cluster-credentials
 	kubectl create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
 
+.PHONY: update-kubeconfigs
+update-kubeconfigs:
+	kubectl create configmap kubeconfigs --from-file=kubeconfigs.yaml=cluster/kubeconfigs/kubeconfigs.yaml --dry-run=client -o yaml | kubectl apply -f -
+
 .PHONY: deploy
-deploy: get-cluster-credentials
+deploy: get-cluster-credentials update-kubeconfigs
 # Apply the ProwJob CRD with --server-side=true due to its size.
 	kubectl apply --server-side=true -f ./cluster/prowjob-crd/
 	kubectl apply -f ./cluster/

--- a/prow/oss/cluster/kubeconfigs/kubeconfigs.yaml
+++ b/prow/oss/cluster/kubeconfigs/kubeconfigs.yaml
@@ -8,8 +8,8 @@ contexts:
 - context:
     cluster: gke_oss-prow_us-west1-a_prow
     user: gke_oss-prow_us-west1-a_prow
-  name: gke_oss-prow_us-west1-a_prow
-current-context: gke_oss-prow_us-west1-a_prow
+  name: test-infra-trusted
+current-context: test-infra-trusted
 kind: Config
 preferences: {}
 users:
@@ -17,7 +17,8 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
-      args: null
+      args:
+      - --use_application_default_credentials
       command: gke-gcloud-auth-plugin
       env: null
       installHint: Install gke-gcloud-auth-plugin for use with kubectl by following

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -28,7 +28,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs/kubeconfigs.yaml"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: metrics
           containerPort: 9090


### PR DESCRIPTION
The update to the kubeconfigs.yaml file has already been applied to the oss-prow cluster, and is a NOP.

/cc @michelle192837 @cjwagner @airbornepony @timwangmusic