### PR TITLE
mount kubeconfigs configmap into other prow components

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -37,7 +37,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -85,6 +85,9 @@ spec:
           readOnly: true
         - name: ghapp-token
           mountPath: /etc/github
+          readOnly: true
+        - mountPath: /etc/gke-gcloud-auth-plugin-based
+          name: kubeconfigs
           readOnly: true
       volumes:
       - name: build-bms-oracle-team
@@ -136,6 +139,9 @@ spec:
       - name: ghapp-token
         secret:
           secretName: ghapp-token
+      - name: kubeconfigs
+        configMap:
+          name: kubeconfigs
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: http
           containerPort: 8080
@@ -94,6 +94,9 @@ spec:
           readOnly: true
         - name: build-kubeflow
           mountPath: /etc/build-kubeflow
+          readOnly: true
+        - mountPath: /etc/gke-gcloud-auth-plugin-based
+          name: kubeconfigs
           readOnly: true
         livenessProbe:
           httpGet:
@@ -163,6 +166,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-kubeflow
+      - name: kubeconfigs
+        configMap:
+          name: kubeconfigs
 ---
 apiVersion: v1
 kind: Service

--- a/prow/oss/cluster/deck_blueprints_deployment.yaml
+++ b/prow/oss/cluster/deck_blueprints_deployment.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: http
           containerPort: 8080
@@ -95,6 +95,9 @@ spec:
           readOnly: true
         - name: build-kubeflow
           mountPath: /etc/build-kubeflow
+          readOnly: true
+        - mountPath: /etc/gke-gcloud-auth-plugin-based
+          name: kubeconfigs
           readOnly: true
         livenessProbe:
           httpGet:
@@ -208,6 +211,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-kubeflow
+      - name: kubeconfigs
+        configMap:
+          name: kubeconfigs
 ---
 apiVersion: v1
 kind: Service

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -92,6 +92,9 @@ spec:
           readOnly: true
         - name: build-kubeflow
           mountPath: /etc/build-kubeflow
+          readOnly: true
+        - mountPath: /etc/gke-gcloud-auth-plugin-based
+          name: kubeconfigs
           readOnly: true
         resources:
           requests: # peak usage sampled by most recent usages of hook
@@ -162,6 +165,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-kubeflow
+      - name: kubeconfigs
+        configMap:
+          name: kubeconfigs
 ---
 apiVersion: v1
 kind: Service

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -27,7 +27,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig"
+          value: "/etc/kubeconfig/config-20211108:/etc/build-bms-oracle-team/kubeconfig:/etc/build-gcsfuse/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: metrics
           containerPort: 9090
@@ -64,6 +64,9 @@ spec:
           readOnly: true
         - name: build-kubeflow
           mountPath: /etc/build-kubeflow
+          readOnly: true
+        - mountPath: /etc/gke-gcloud-auth-plugin-based
+          name: kubeconfigs
           readOnly: true
       volumes:
       - name: build-bms-oracle-team
@@ -108,6 +111,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-kubeflow
+      - name: kubeconfigs
+        configMap:
+          name: kubeconfigs
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
We've already tested that the settings in
https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2065 work for prow-controller-manager.

Mount the kubeconfig into crier, deck, deck-blueprints (for consistency with deck), hook, and sinker.

/cc @michelle192837 @cjwagner @airbornepony @timwangmusic