### PR TITLE
Update the kubekins-e2e and gke-e2e image for kpt-config-sync

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -16,7 +16,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-ci-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v1.0.0-590be013d
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v1.0.0-f11bb971
       command:
       - make
       - test-e2e-gke-ci
@@ -67,7 +67,7 @@ periodics:
     preset-dind-enabled-memory: "true"
   spec:
     containers:
-    - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
       command:
       - runner.sh
       args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -15,7 +15,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-ci-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v1.0.0-590be013d
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v1.0.0-f11bb971
       command:
       - make
       - test-e2e-gke-ci
@@ -66,7 +66,7 @@ periodics:
     preset-dind-enabled-memory: "true"
   spec:
     containers:
-    - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
       command:
       - runner.sh
       args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
     spec:
       serviceAccountName: postsubmit-runner
       containers:
-      - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
         command:
         - runner.sh
         args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -23,10 +23,8 @@ prow_ignored:
     timeout: 60m
   spec: &config-sync-e2e-job-spec
     containers:
-    # Use the special version of the kubekins 1.22 image with Kind
-    # v0.14.0 installed.
     - &config-sync-e2e-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
       command:
       - runner.sh
       env:
@@ -63,7 +61,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/kubekins-e2e:v1.0.0-612a3a80d
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
         command:
         - runner.sh
         args:


### PR DESCRIPTION
The kpt-config-sync project uses go version 1.20, so this commit updates
the kubekins-e2e and gke-e2e image to ensure it is compatible with the go
version.

The gke-e2e image was built based on the commit in kpt-config-sync:
https://github.com/GoogleContainerTools/kpt-config-sync/commit/f11bb971f413a6c9ee0e11378568b841c717b23e.