### PR TITLE
Bump cit-performance-peridiocs timeout to 5h to accomodate windows images

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -413,6 +413,8 @@ periodics:
 - name: cit-periodics-performance
   cluster: gcp-guest
   decorate: true
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-performance


### PR DESCRIPTION
Latest run is timing out: https://oss.gprow.dev/view/gs/oss-prow/logs/cit-periodics-performance/1704783248854355968