### PR TITLE
chore(kfp): bump to python 3.9

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-periodics.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-periodics.yaml
@@ -13,7 +13,7 @@ periodics:
       workdir: true
   spec:
     containers:
-      - image: python:3.7-slim
+      - image: python:3.9-slim
         imagePullPolicy: Always
         command:
           - "./test/kfp-functional-test/kfp-functional-test.sh"

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-postsubmits.yaml
@@ -7,7 +7,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./backend/src/v2/test/integration-test.sh
     annotations:

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
         args:
         # We cannot call the shell script directly because the shebang in script is /bin/bash,
         # but the bash:alpine3.14 image has its bash in /usr/local/bin/bash.
-        - ./manifests/gcp_marketplace/test/presubmit.sh 
+        - ./manifests/gcp_marketplace/test/presubmit.sh
   - name: kubeflow-pipeline-upgrade-test
     run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
     cluster: build-kubeflow
@@ -156,7 +156,7 @@ presubmits:
     run_if_changed: "^(components/.*\\.yaml)|(test/presubmit-component-yaml.sh)|(sdk/python/.*)$"
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./test/presubmit-component-yaml.sh
 
@@ -176,10 +176,10 @@ presubmits:
     run_if_changed: "^(backend/src/apiserver/visualization/.*)|(test/presubmit-backend-visualization.sh)$"
     spec:
       containers:
-      - image: python:3.8
+      - image: python:3.9
         command:
         - ./test/presubmit-backend-visualization.sh
-  
+
   - name: kubeflow-pipelines-samples-v2
     cluster: build-kubeflow
     decorate: true
@@ -188,19 +188,19 @@ presubmits:
     optional: true
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./backend/src/v2/test/sample-test.sh
     skip_branches:
     - ^sdk\/release-1.*$
-  
+
   - name: kubeflow-pipelines-integration-v2
     run_if_changed: "^(samples/core/(parameterized_tfx_oss|dataflow)/.*)$"
     cluster: build-kubeflow
     decorate: true
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./backend/src/v2/test/integration-test.sh
 
@@ -221,7 +221,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./test/presubmit-isort-sdk.sh
   - name: kubeflow-pipelines-sdk-yapf
@@ -232,7 +232,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./test/presubmit-yapf-sdk.sh
   - name: kubeflow-pipelines-sdk-docformatter
@@ -243,7 +243,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./test/presubmit-docformatter-sdk.sh
   - name: kubeflow-pipelines-sdk-execution-tests
@@ -254,7 +254,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./test/presubmit-sdk-execution-tests.sh
 
@@ -298,7 +298,7 @@ presubmits:
       - image: python:3.10
         command:
         - ./test/presubmit-test-kfp-kubernetes-library.sh
-  
+
   - name: kfp-kubernetes-test-python311
     cluster: build-kubeflow
     decorate: true
@@ -317,7 +317,7 @@ presubmits:
     spec:
       containers:
       # run on the lowest version of Python (with the least features) for most aggressive testing
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./test/presubmit-test-run-all-gcpc-modules.sh
 
@@ -327,7 +327,7 @@ presubmits:
     run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-sdk-upgrade.sh)$"
     spec:
       containers:
-      - image: python:3.7
+      - image: python:3.9
         command:
         - ./test/presubmit-test-sdk-upgrade.sh
 


### PR DESCRIPTION
This PR updates the default python version used by Kubeflow Pipelines to 3.9 since 3.7 is now EOL and causing conflicts with dependencies (such as `ml-metadata`). This should solve the recent test failures on the master branch.

/cc @chensun @zijianjoy  @connor-mccarthy