### PR TITLE
Change CIT 2hr peridiocs to 3hr with same timeout

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -407,10 +407,12 @@ periodics:
 - name: cit-periodics
   cluster: gcp-guest
   decorate: true
+  decoration_config:
+    timeout: 3h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics
-  interval: 2h
+  interval: 3h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest


### PR DESCRIPTION
[Testgrid](https://testgrid.k8s.io/googleoss-gcp-guest#cit-periodics) is stale because everything is timing out from the new images. Not sure if 3hrs is enough, we'll see.