### PR TITLE
Update kpt-config-sync presubmit image

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -24,7 +24,9 @@ prow_ignored:
   spec: &config-sync-e2e-job-spec
     containers:
     - &config-sync-e2e-container
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
+      # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
+      # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
       command:
       - runner.sh
       env:
@@ -61,7 +63,9 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
+      # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
+      # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
         command:
         - runner.sh
         args:


### PR DESCRIPTION
Use the go-canary image variant, because it includes Go 1.21, which is required to run `go mod tidy` in presubmits, after we upgrade to Go 1.21, which is required in order to upgrade kpt. Previously we pinned to the 1.26 variant, to ensure a specific version of k8s was used. The go-canary variant is pinned to the `stable` version of k8s, which today is v1.28.2 (per https://cdn.dl.k8s.io/release/stable.txt).