### PR TITLE
Update kpt-config-sync test images

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -67,7 +67,9 @@ periodics:
     preset-dind-enabled-memory: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
+    # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
+    # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
       command:
       - runner.sh
       args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -66,7 +66,9 @@ periodics:
     preset-dind-enabled-memory: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
+    # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
+    # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
       command:
       - runner.sh
       args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
@@ -20,7 +20,9 @@ postsubmits:
     spec:
       serviceAccountName: postsubmit-runner
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230908-f87868ed63-1.26
+      # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
+      # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
         command:
         - runner.sh
         args:


### PR DESCRIPTION
Presumbists worked with this new image. So this updates the rest of the periodics and postsubmits.