### PR TITLE
use 2 cluster for autopilot stress tests

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -345,7 +345,7 @@ periodics:
       - 'GKE_CLUSTER_VERSION=latest'
       - 'E2E_CLUSTER_PREFIX=autopilot-rapid-latest-stress'
       - 'GKE_AUTOPILOT=true'
-      - 'E2E_NUM_CLUSTERS=1'
+      - 'E2E_NUM_CLUSTERS=2' # autopilot stress tests sometimes take greater than 2h to run on 1 cluster
       - 'E2E_ARGS=--stress -run=TestStress*'
 
 #### End one-off jobs


### PR DESCRIPTION
The autopilot stress tests sometimes take longer than 2 hours when running on a single cluster, causing them to timeout. This change adds another cluster to shorten the runtime.