### PR TITLE
Revamp guest-test-infra presubmit checks

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -350,11 +350,11 @@ presubmits:
         command:
         - "/main.sh"
         args: ["concourse/pipelines"]
-  - name: infra-presubmit-gocheck
+  - name: infra-presubmit-gocheck-root
     cluster: gcp-guest
     run_if_changed: '\.go$'
-    trigger: "(?m)^/gocheck$"
-    rerun_command: "/gocheck"
+    trigger: "(?m)^/gocheckroot$"
+    rerun_command: "/gocheckroot"
     context: prow/presubmit/gocheck
     decorate: true
     spec:
@@ -363,11 +363,56 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-  - name: infra-presubmit-gobuild
+  - name: infra-presubmit-gocheck-cit
+    cluster: gcp-guest
+    run_if_changed: 'imagetest.*\.go$'
+    trigger: "(?m)^/gocheckcit$"
+    rerun_command: "/gocheckcit"
+    context: prow/presubmit/gocheck
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gocheck:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- imagetest/
+  - name: infra-presubmit-gocheck-cleanerupper
+    cluster: gcp-guest
+    run_if_changed: 'container_images/cleanerupper.*\.go$'
+    trigger: "(?m)^/gocheckclean$"
+    rerun_command: "/gocheckclean"
+    context: prow/presubmit/gocheck
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gocheck:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- container_images/cleanerupper/
+  - name: infra-presubmit-gocheck-registryimage
+    cluster: gcp-guest
+    run_if_changed: 'container_images/registry-image-forked.*\.go$'
+    trigger: "(?m)^/gocheckregimage$"
+    rerun_command: "/gocheckregimage"
+    context: prow/presubmit/gocheck
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gocheck:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- container_images/registry-image-forked/
+  - name: infra-presubmit-gobuild-root
     cluster: gcp-guest
     run_if_changed: '\.go$'
-    trigger: "(?m)^/gobuild$"
-    rerun_command: "/gobuild"
+    trigger: "(?m)^/gobuildroot$"
+    rerun_command: "/gobuildroot"
     context: prow/presubmit/gobuild
     decorate: true
     spec:
@@ -376,11 +421,56 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-  - name: infra-presubmit-gotest
+  - name: infra-presubmit-gobuild-cit
+    cluster: gcp-guest
+    run_if_changed: 'imagetest/.*(\.go|go\.mod|go\.sum|Dockerfile|\.sh)$'
+    trigger: "(?m)^/gobuildcit$"
+    rerun_command: "/gobuildcit"
+    context: prow/presubmit/gobuild
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/citpresubmit:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- build
+  - name: infra-presubmit-gobuild-cleanerupper
+    cluster: gcp-guest
+    run_if_changed: 'container_images/cleanerupper.*\.go$'
+    trigger: "(?m)^/gobuildclean$"
+    rerun_command: "/gobuildclean"
+    context: prow/presubmit/gobuild
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gobuild:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- container_images/cleanerupper/
+  - name: infra-presubmit-gobuild-registryimage
+    cluster: gcp-guest
+    run_if_changed: 'container_images/registry-image-forked.*\.go$'
+    trigger: "(?m)^/gobuildregimage$"
+    rerun_command: "/gobuildregimage"
+    context: prow/presubmit/gobuild
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gobuild:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- container_images/registry-image-forked/
+  - name: infra-presubmit-gotest-root
     cluster: gcp-guest
     run_if_changed: '\.go$'
-    trigger: "(?m)^/gotest$"
-    rerun_command: "/gotest"
+    trigger: "(?m)^/gotestroot$"
+    rerun_command: "/gotestroot"
     context: prow/presubmit/gotest
     decorate: true
     spec:
@@ -389,12 +479,12 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-  - name: infra-presubmit-citpresubmit
+  - name: infra-presubmit-gotest-cit
     cluster: gcp-guest
-    run_if_changed: 'imagetest/.*(\.go|go\.mod|go\.sum|Dockerfile)$'
-    trigger: "(?m)^/citpresubmit$"
-    rerun_command: "/citpresubmit"
-    context: prow/presubmit/citpresubmit
+    run_if_changed: 'imagetest.*\.go$'
+    trigger: "(?m)^/gotestcit$"
+    rerun_command: "/gotestcit"
+    context: prow/presubmit/gotest
     decorate: true
     spec:
       containers:
@@ -402,6 +492,38 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
+	    args:
+		- test
+  - name: infra-presubmit-gotest-cleanerupper
+    cluster: gcp-guest
+    run_if_changed: 'container_images/cleanerupper.*\.go$'
+    trigger: "(?m)^/gotestclean$"
+    rerun_command: "/gotestclean"
+    context: prow/presubmit/gotest
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gotest:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- container_images/cleanerupper/
+  - name: infra-presubmit-gotest-registryimage
+    cluster: gcp-guest
+    run_if_changed: 'container_images/registry-image-forked.*\.go$'
+    trigger: "(?m)^/gotestregimage$"
+    rerun_command: "/gotestregimage"
+    context: prow/presubmit/gotest
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/gcp-guest/gotest:latest
+        imagePullPolicy: Always
+        command:
+        - "/go/main.sh"
+	    args:
+		- container_images/registry-image-forked/
 
 periodics:
 - name: cit-periodics

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -355,7 +355,7 @@ presubmits:
     run_if_changed: '\.go$'
     trigger: "(?m)^/gocheckroot$"
     rerun_command: "/gocheckroot"
-    context: prow/presubmit/gocheck
+    context: prow/presubmit/gocheck/root
     decorate: true
     spec:
       containers:
@@ -368,7 +368,7 @@ presubmits:
     run_if_changed: 'imagetest.*\.go$'
     trigger: "(?m)^/gocheckcit$"
     rerun_command: "/gocheckcit"
-    context: prow/presubmit/gocheck
+    context: prow/presubmit/gocheck/cit
     decorate: true
     spec:
       containers:
@@ -383,7 +383,7 @@ presubmits:
     run_if_changed: 'container_images/cleanerupper.*\.go$'
     trigger: "(?m)^/gocheckclean$"
     rerun_command: "/gocheckclean"
-    context: prow/presubmit/gocheck
+    context: prow/presubmit/gocheck/cleanerupper
     decorate: true
     spec:
       containers:
@@ -398,7 +398,7 @@ presubmits:
     run_if_changed: 'container_images/registry-image-forked.*\.go$'
     trigger: "(?m)^/gocheckregimage$"
     rerun_command: "/gocheckregimage"
-    context: prow/presubmit/gocheck
+    context: prow/presubmit/gocheck/registryimage
     decorate: true
     spec:
       containers:
@@ -413,7 +413,7 @@ presubmits:
     run_if_changed: '\.go$'
     trigger: "(?m)^/gobuildroot$"
     rerun_command: "/gobuildroot"
-    context: prow/presubmit/gobuild
+    context: prow/presubmit/gobuild/root
     decorate: true
     spec:
       containers:
@@ -426,7 +426,7 @@ presubmits:
     run_if_changed: 'imagetest/.*(\.go|go\.mod|go\.sum|Dockerfile|\.sh)$'
     trigger: "(?m)^/gobuildcit$"
     rerun_command: "/gobuildcit"
-    context: prow/presubmit/gobuild
+    context: prow/presubmit/gobuild/cit
     decorate: true
     spec:
       containers:
@@ -441,7 +441,7 @@ presubmits:
     run_if_changed: 'container_images/cleanerupper.*\.go$'
     trigger: "(?m)^/gobuildclean$"
     rerun_command: "/gobuildclean"
-    context: prow/presubmit/gobuild
+    context: prow/presubmit/gobuild/cleanerupper
     decorate: true
     spec:
       containers:
@@ -456,7 +456,7 @@ presubmits:
     run_if_changed: 'container_images/registry-image-forked.*\.go$'
     trigger: "(?m)^/gobuildregimage$"
     rerun_command: "/gobuildregimage"
-    context: prow/presubmit/gobuild
+    context: prow/presubmit/gobuild/registryimage
     decorate: true
     spec:
       containers:
@@ -471,7 +471,7 @@ presubmits:
     run_if_changed: '\.go$'
     trigger: "(?m)^/gotestroot$"
     rerun_command: "/gotestroot"
-    context: prow/presubmit/gotest
+    context: prow/presubmit/gotest/root
     decorate: true
     spec:
       containers:
@@ -484,7 +484,7 @@ presubmits:
     run_if_changed: 'imagetest.*\.go$'
     trigger: "(?m)^/gotestcit$"
     rerun_command: "/gotestcit"
-    context: prow/presubmit/gotest
+    context: prow/presubmit/gotest/cit
     decorate: true
     spec:
       containers:
@@ -499,7 +499,7 @@ presubmits:
     run_if_changed: 'container_images/cleanerupper.*\.go$'
     trigger: "(?m)^/gotestclean$"
     rerun_command: "/gotestclean"
-    context: prow/presubmit/gotest
+    context: prow/presubmit/gotest/cleanerupper
     decorate: true
     spec:
       containers:
@@ -514,7 +514,7 @@ presubmits:
     run_if_changed: 'container_images/registry-image-forked.*\.go$'
     trigger: "(?m)^/gotestregimage$"
     rerun_command: "/gotestregimage"
-    context: prow/presubmit/gotest
+    context: prow/presubmit/gotest/registryimage
     decorate: true
     spec:
       containers:

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -376,8 +376,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- imagetest/
+        args:
+        - imagetest/
   - name: infra-presubmit-gocheck-cleanerupper
     cluster: gcp-guest
     run_if_changed: 'container_images/cleanerupper.*\.go$'
@@ -391,8 +391,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- container_images/cleanerupper/
+        args:
+        - container_images/cleanerupper/
   - name: infra-presubmit-gocheck-registryimage
     cluster: gcp-guest
     run_if_changed: 'container_images/registry-image-forked.*\.go$'
@@ -406,8 +406,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- container_images/registry-image-forked/
+        args:
+        - container_images/registry-image-forked/
   - name: infra-presubmit-gobuild-root
     cluster: gcp-guest
     run_if_changed: '\.go$'
@@ -434,8 +434,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- build
+        args:
+        - build
   - name: infra-presubmit-gobuild-cleanerupper
     cluster: gcp-guest
     run_if_changed: 'container_images/cleanerupper.*\.go$'
@@ -449,8 +449,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- container_images/cleanerupper/
+        args:
+        - container_images/cleanerupper/
   - name: infra-presubmit-gobuild-registryimage
     cluster: gcp-guest
     run_if_changed: 'container_images/registry-image-forked.*\.go$'
@@ -464,8 +464,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- container_images/registry-image-forked/
+        args:
+        - container_images/registry-image-forked/
   - name: infra-presubmit-gotest-root
     cluster: gcp-guest
     run_if_changed: '\.go$'
@@ -492,8 +492,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- test
+        args:
+        - test
   - name: infra-presubmit-gotest-cleanerupper
     cluster: gcp-guest
     run_if_changed: 'container_images/cleanerupper.*\.go$'
@@ -507,8 +507,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- container_images/cleanerupper/
+        args:
+        - container_images/cleanerupper/
   - name: infra-presubmit-gotest-registryimage
     cluster: gcp-guest
     run_if_changed: 'container_images/registry-image-forked.*\.go$'
@@ -522,8 +522,8 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-	    args:
-		- container_images/registry-image-forked/
+        args:
+        - container_images/registry-image-forked/
 
 periodics:
 - name: cit-periodics


### PR DESCRIPTION
We are missing a lot of gobuild/gocheck/gotest coverage because these containers are scoped to only subdirectories which belong to the same module as the main directory. This change will add each module as its own presubmit directory to ensure coverage.

citpresubmit still handles building and testing because of the way we handle test code in those directories.