### PR TITLE
disable review_acts_as_lgtm for kpt-config-sync

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -64,6 +64,9 @@ lgtm:
   - grpc-ecosystem
   review_acts_as_lgtm: true
 - repos:
+  - GoogleContainerTools/kpt-config-sync
+  review_acts_as_lgtm: false
+- repos:
   - GoogleCloudPlatform/testgrid
   review_acts_as_lgtm: true
   trusted_team_for_sticky_lgtm: 'TestGrid Admins'


### PR DESCRIPTION
With the new request to require the Github UI approval button on our
repository, we've lost the ability to effectively approve a PR
without granting lgtm. Disabling review_acts_as_lgtm will enable an
approver to grant the approval state/label without granting lgtm.

Context:

https://github.com/GoogleContainerTools/kpt-config-sync/issues/1002 Requested for us to require the Approval UI button, despite our usage of prow to manage lgtm/approval. There is a bit of redundancy now with the approval mechanisms, but this should allow us to separate approve from lgtm again.