### PR TITLE
kes-kicker: target 'default' namespace

### DIFF
--- a/prow/oss/cluster/kes-kicker.yaml
+++ b/prow/oss/cluster/kes-kicker.yaml
@@ -2,11 +2,13 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: kes-kicker
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kes-kicker
+  namespace: default
 rules:
   - apiGroups: ["apps", "extensions"]
     resources: ["deployments"]
@@ -18,6 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kes-kicker
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -30,6 +33,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: kes-kicker
+  namespace: default
 spec:
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 2
@@ -48,6 +52,8 @@ spec:
               image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20220607-33951ed1ed
               command:
                 - "kubectl"
+                - "-n"
+                - "default" # the KES deployment lives in the default namespace
                 - "rollout"
                 - "restart"
                 - "deployment/kubernetes-external-secrets"


### PR DESCRIPTION
In #2125, we created various resources (ServiceAccount, Role,
RoleBinding, CronJob) all with the name "kes-kicker". Looking at the
cluster after these configurations have been applied, they all appear to
be in the "test-pods" namespace.

Consequently, we get an error like this in the logs from the kes-kicker
pod when it gets scheduled to satisfy the CronJob definition:

    Error from server (NotFound): deployments.apps "kubernetes-external-secrets" not found

This appears to be because the kubectl command inside kes-kicker is
operating inside the test-pods namespace.

Recreate the same resources in the default namespace. But also, give the
kubectl invocation an namespace because it's more strict that way and it
can't hurt.

/cc @cjwagner @airbornepony @timwangmusic 