### PR TITLE
improve component compile/load testing on pipelines library source code changes

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -165,7 +165,7 @@ presubmits:
   - name: kubeflow-pipelines-load-component-yaml
     cluster: build-kubeflow
     decorate: true
-    run_if_changed: "^(components/.*\\.yaml)|(test/presubmit-component-yaml.sh)|(sdk/python/.*)|(api/v2alpha1/.*)$"
+    run_if_changed: "^(components/.*\\.yaml)|(test/presubmit-component-yaml.sh)|(sdk/python/.*)$"
     spec:
       containers:
       - image: python:3.7


### PR DESCRIPTION
Tests that GCPC components can still compile when any of `google-cloud-pipeline-components`, `kfp`, and `kfp-pipeline-spec` change.