### PR TITLE
make `kfp-kubernetes` execution tests required

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -335,10 +335,6 @@ presubmits:
     cluster: build-kubeflow
     decorate: true
     run_if_changed: "^(sdk/python/.*)|(api/v2alpha1/.*)|(kubernetes_platform/.*)|(test/presubmit-kfp-kubernetes-execution-tests.sh)$"
-    # START TODO: remove when tests pass
-    optional: true
-    skip_report: false
-    # END TODO
     spec:
       containers:
       - image: python:3.7


### PR DESCRIPTION
Tests are implemented and [passing](https://github.com/kubeflow/pipelines/pull/10304) (see [logs](https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/kubeflow_pipelines/10304/kfp-kubernetes-execution-tests/1735056424230195200)).