### PR TITLE
Revert "make `kfp-kubernetes` execution tests required"

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -335,6 +335,10 @@ presubmits:
     cluster: build-kubeflow
     decorate: true
     run_if_changed: "^(sdk/python/.*)|(api/v2alpha1/.*)|(kubernetes_platform/.*)|(test/presubmit-kfp-kubernetes-execution-tests.sh)$"
+    # START TODO: remove when tests pass
+    optional: true
+    skip_report: false
+    # END TODO
     spec:
       containers:
       - image: python:3.7


### PR DESCRIPTION
Tests were passing, but are now failing. Pipelines are stuck in a "Running" state, despite inner tasks all succeeding.

![image](https://github.com/GoogleCloudPlatform/oss-test-infra/assets/55268212/aaff3765-1b12-4e77-aa63-87492c2c237c)

/assign @chensun 