### PR TITLE
build & test root, registry image, cleanerupper, and cit whenever go.mod or go.sum is changed

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -410,7 +410,7 @@ presubmits:
         - container_images/registry-image-forked/
   - name: infra-presubmit-gobuild-root
     cluster: gcp-guest
-    run_if_changed: '\.go$'
+    run_if_changed: '(\.go|go\.mod|go\.sum)$'
     trigger: "(?m)^/gobuildroot$"
     rerun_command: "/gobuildroot"
     context: prow/presubmit/gobuild/root
@@ -438,7 +438,7 @@ presubmits:
         - build
   - name: infra-presubmit-gobuild-cleanerupper
     cluster: gcp-guest
-    run_if_changed: 'container_images/cleanerupper.*\.go$'
+    run_if_changed: 'container_images/cleanerupper.*(\.go|go\.mod|go\.sum)$'
     trigger: "(?m)^/gobuildclean$"
     rerun_command: "/gobuildclean"
     context: prow/presubmit/gobuild/cleanerupper
@@ -453,7 +453,7 @@ presubmits:
         - container_images/cleanerupper/
   - name: infra-presubmit-gobuild-registryimage
     cluster: gcp-guest
-    run_if_changed: 'container_images/registry-image-forked.*\.go$'
+    run_if_changed: 'container_images/registry-image-forked.*(\.go|go\.mod|go\.sum)$'
     trigger: "(?m)^/gobuildregimage$"
     rerun_command: "/gobuildregimage"
     context: prow/presubmit/gobuild/registryimage
@@ -468,7 +468,7 @@ presubmits:
         - container_images/registry-image-forked/
   - name: infra-presubmit-gotest-root
     cluster: gcp-guest
-    run_if_changed: '\.go$'
+    run_if_changed: '(\.go|go\.mod|go\.sum)$'
     trigger: "(?m)^/gotestroot$"
     rerun_command: "/gotestroot"
     context: prow/presubmit/gotest/root
@@ -481,7 +481,7 @@ presubmits:
         - "/go/main.sh"
   - name: infra-presubmit-gotest-cit
     cluster: gcp-guest
-    run_if_changed: 'imagetest.*\.go$'
+    run_if_changed: 'imagetest.*(\.go|go\.mod|go\.sum)$'
     trigger: "(?m)^/gotestcit$"
     rerun_command: "/gotestcit"
     context: prow/presubmit/gotest/cit
@@ -496,7 +496,7 @@ presubmits:
         - test
   - name: infra-presubmit-gotest-cleanerupper
     cluster: gcp-guest
-    run_if_changed: 'container_images/cleanerupper.*\.go$'
+    run_if_changed: 'container_images/cleanerupper.*(\.go|go\.mod|go\.sum)$'
     trigger: "(?m)^/gotestclean$"
     rerun_command: "/gotestclean"
     context: prow/presubmit/gotest/cleanerupper
@@ -511,7 +511,7 @@ presubmits:
         - container_images/cleanerupper/
   - name: infra-presubmit-gotest-registryimage
     cluster: gcp-guest
-    run_if_changed: 'container_images/registry-image-forked.*\.go$'
+    run_if_changed: 'container_images/registry-image-forked.*(\.go|go\.mod|go\.sum)$'
     trigger: "(?m)^/gotestregimage$"
     rerun_command: "/gotestregimage"
     context: prow/presubmit/gotest/registryimage


### PR DESCRIPTION
/cc @elicriffield @zmarano 

the cit gobuild config already does this