### PR TITLE
Bump timeout to half of interval for oslogin periodics

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -574,7 +574,7 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 12h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: oslogin-periodics


### PR DESCRIPTION
Last two runs timed out:
https://storage.googleapis.com/oss-prow/logs/oslogin-periodics/1744072291597160448/build-log.txt
/cc @zmarano @drewhli 