### PR TITLE
Remove go-integ presubmit for Guest Agent

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -163,26 +163,6 @@ presubmits:
         - "/go/main.sh"
 
   GoogleCloudPlatform/guest-agent:
-  - name: guest-agent-integ
-    cluster: gcp-guest
-    run_if_changed: '\.go$'
-    trigger: "(?m)^/gointeg$"
-    rerun_command: "/gointeg"
-    context: prow/presubmit/gointeg
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/gcp-guest/gointegtest:latest
-        imagePullPolicy: Always
-        command:
-        - "/main.sh"
-        env:
-        - name: ZONE
-          value: us-west1-b
-        - name: PROJECT
-          value: gcp-guest
-        - name: GCS_BUCKET
-          value: gs://gcp-guest-test-outputs
   - name: guest-agent-presubmit-gocheck
     cluster: gcp-guest
     run_if_changed: '\.go$'


### PR DESCRIPTION
This is because all the integration tests have been removed due to them being broken.