### PR TITLE
k8s-config-connector: enable lifecycle commands

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -260,6 +260,7 @@ plugins:
     #- label
     - approve
     - lgtm
+    - lifecycle   # Close PRs with /close
     - verify-owners
     - wip
 


### PR DESCRIPTION
The /close command is notably missing!
