### PR TITLE
ci: add helm/oci provider options for CS e2e

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -45,6 +45,10 @@ prow_ignored:
         value: "pd-ssd"
       - name: GKE_DISK_SIZE
         value: "50Gb"
+      - name: E2E_OCI_PROVIDER
+        value: "gar"
+      - name: E2E_HELM_PROVIDER
+        value: "gar"
       resources:
         requests:
           memory: "8Gi"
@@ -75,6 +79,8 @@ periodics:
       args:
       - make
       - test-e2e-kind-multi-repo
+      - 'E2E_OCI_PROVIDER=local'
+      - 'E2E_HELM_PROVIDER=local'
       securityContext:
         privileged: true
       resources:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -44,6 +44,10 @@ prow_ignored:
         value: "pd-ssd"
       - name: GKE_DISK_SIZE
         value: "50Gb"
+      - name: E2E_OCI_PROVIDER
+        value: "gar"
+      - name: E2E_HELM_PROVIDER
+        value: "gar"
       resources:
         requests:
           memory: "8Gi"
@@ -74,6 +78,8 @@ periodics:
       args:
       - make
       - test-e2e-kind-multi-repo
+      - 'E2E_OCI_PROVIDER=local'
+      - 'E2E_HELM_PROVIDER=local'
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
This adds the new helm/oci provider flags for the periodic job configs. This sets the GKE tests to run with the artifact registry provider and the kind tests to run with the local provider.