### PR TITLE
k8s-config-connector: require self approval

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -47,6 +47,7 @@ approve:
   - kubeflow/pytorch-operator
   - kubeflow/tf-operator
   - kubeflow/xgboost-operator
+  - GoogleCloudPlatform/k8s-config-connector
   require_self_approval: true
   commandHelpLink: https://oss.gprow.dev/command-help
 


### PR DESCRIPTION
My understanding is that requiring self approval will make it such that PRs opened by OWNERS don't get the `approved` label.