### PR TITLE
Bump timeout for cit-periodics-performance

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -536,7 +536,7 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 5h
+    timeout: 7h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-performance


### PR DESCRIPTION
https://testgrid.k8s.io/googleoss-gcp-guest#cit-periodics-performance

Test times out due to adding more images, prow kills the CIT job, killing the job stops it from cleaning up resources, then new jobs either timeout in prow or timeout waiting for quota because the zombie resources are taking it all.

We need to both bump the timeout for this job, and clean up zombie resources. This PR will do the first, I'll do the second thing manually.

I don't think increasing job count will help since we're bumping up against the limits of our quota with 10 jobs.

/cc @koln67 @zmarano 