### PR TITLE
ci: further stagger each large GKE job

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -153,6 +153,7 @@ periodics:
 
 - <<: *config-sync-standard-job
   name: kpt-config-sync-standard-rapid
+  cron: 30 */2 * * *
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: standard-rapid
@@ -167,6 +168,7 @@ periodics:
 
 - <<: *config-sync-standard-job
   name: kpt-config-sync-standard-rapid-latest
+  cron: 45 */2 * * *
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: standard-rapid-latest
@@ -182,6 +184,7 @@ periodics:
 
 - <<: *config-sync-standard-job
   name: kpt-config-sync-standard-stable
+  cron: 15 */2 * * *
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: standard-stable
@@ -245,6 +248,7 @@ periodics:
 
 - <<: *config-sync-autopilot-job
   name: kpt-config-sync-autopilot-stable
+  cron: 15 1-23/2 * * *
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: autopilot-stable
@@ -259,6 +263,7 @@ periodics:
 
 - <<: *config-sync-autopilot-job
   name: kpt-config-sync-autopilot-rapid
+  cron: 30 1-23/2 * * *
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: autopilot-rapid
@@ -273,6 +278,7 @@ periodics:
 
 - <<: *config-sync-autopilot-job
   name: kpt-config-sync-autopilot-rapid-latest
+  cron: 45 1-23/2 * * *
   annotations:
     testgrid-dashboards: googleoss-kpt-config-sync-main
     testgrid-tab-name: autopilot-rapid-latest


### PR DESCRIPTION
This change gives a minute offset to each of the big jobs to further stagger them. This is primarily motivated by the autopilot jobs so that not all clusters are scaling from zero at the same time.