### PR TITLE
Bump individual workflow timeout to 60m for cit-periodics-performance

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -549,6 +549,7 @@ periodics:
       - "/manager"
       args:
       - "-parallel_count=10"
+      - "-timeout=60m"
       - "-project=gcp-guest"
       - "-zone=us-central1-b"
 # First group in the parentheses allows testing of any 3rd gen or lower machine


### PR DESCRIPTION
Still seeing some timeouts of individual workflows getting stuck. The fill disks step is adding a lot of runtime, going to bump timeout to 60m.
/cc @koln67 @zmarano 