### PR TITLE
Fix issues with cit alerting configuration

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -520,7 +520,7 @@ periodics:
     testgrid-alert-email: buganizer-system+117405@google.com
     testgrid-num-failures-to-alert: '3'
     testgrid-alert-stale-results-hours: '24'
-    testgrid-debug-url: http://go/cit-alert-runbook
+    testgrid-alert-mail-debug-url: http://go/cit-alert-runbook
   interval: 6h
   spec:
     containers:
@@ -579,7 +579,7 @@ periodics:
     testgrid-broken-column-threshold: '0.99'
     testgrid-num-failures-to-alert: '2'
     testgrid-alert-stale-results-hours: '24'
-    testgrid-debug-url: http://go/cit-alert-runbook
+    testgrid-alert-mail-debug-url: http://go/cit-alert-runbook
     testgrid-alert-email: buganizer-system+117405@google.com
   interval: 12h
   spec:

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -516,7 +516,7 @@ periodics:
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics
-    testgrid-broken-column-threshold: '0.015' # Allow 1.5% of tests to be failing and still mark column as passing
+    testgrid-broken-column-threshold: '0.985' # Allow 1.5% of tests to be failing and still mark column as passing
     testgrid-alert-email: buganizer-system+117405@google.com
     testgrid-num-failures-to-alert: '3'
     testgrid-alert-stale-results-hours: '24'
@@ -576,7 +576,7 @@ periodics:
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: oslogin-periodics
-    testgrid-broken-column-threshold: '0.01'
+    testgrid-broken-column-threshold: '0.99'
     testgrid-num-failures-to-alert: '2'
     testgrid-alert-stale-results-hours: '24'
     testgrid-debug-url: http://go/cit-alert-runbook


### PR DESCRIPTION
I misunderstood the threshold definition and have to use the deprecated debug-url field.