### PR TITLE
Update CIT alerting config

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -516,9 +516,6 @@ periodics:
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics
-    testgrid-broken-column-threshold: '0.015' # Allow 1.5% of tests to be failing and still mark column as passing
-    testgrid-num-failures-to-alert: '3'
-    testgrid-alert-stale-results-hours: '24'
   interval: 6h
   spec:
     containers:
@@ -527,7 +524,6 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-set_exit_status=false"
       - "-parallel_count=20"
       - "-project=gcp-guest"
       - "-zone=us-central1-b"
@@ -575,9 +571,6 @@ periodics:
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: oslogin-periodics
-    testgrid-broken-column-threshold: '0.01'
-    testgrid-num-failures-to-alert: '2'
-    testgrid-alert-stale-results-hours: '24'
   interval: 12h
   spec:
     containers:
@@ -586,7 +579,6 @@ periodics:
         command:
         - "/manager"
         args:
-        - "-set_exit_status=false"
         - "-project=oslogin-cit"
         - "-zone=us-central1-b"
 # Same as cit-periodics but without Windows


### PR DESCRIPTION
Moving all alerting configuration to the k8s testgrid repo, and removing `set_exit_status false` option (I think I can make broken_column_threshold work this time.
/hold