### PR TITLE
Run performance periodics on a longer, lower interval

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -540,11 +540,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 7h
+    timeout: 24h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-performance
-  interval: 12h
+  interval: 168h # 1 week
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -552,7 +552,7 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=10"
+      - "-parallel_count=2"
       - "-timeout=60m"
       - "-project=gcp-guest"
       - "-zone=us-central1-b"
@@ -596,11 +596,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 24h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: ubuntu-daily-cit-performance
-  interval: 12h
+  interval: 72h # 3 days
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -608,7 +608,7 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=10"
+      - "-parallel_count=2"
       - "-project=gcp-guest"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
       - "-zone=us-central1-b"


### PR DESCRIPTION
This should help with quota issues and be a more efficient use of resources. The images in cit-performance-periodics change very infrequently so the weekly interval should be fine for testing. The images in ubuntu-daily-cit-performance change more frequently so I lowered to half a week. I have more detailed math if you want to check yourself but based on historical data I'm expecting runtimes of 8.4 - 19.7 hours (with an average of 11.4 hours), which gives a four hour buffer before timeouts. parallel_count=1 is more efficient but doubles these runtimes and running a prow job for longer than 24 hours requires some extra configuration beyond just time IIUC so I've stuck with this for now.

/cc @bkatyl @elicriffield 