### PR TITLE
Tune E2E_NUM_CLUSTERS for kpt-config-sync CI to decrease parallism

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -67,7 +67,7 @@ prow_ignored:
       - name: E2E_HELM_PROVIDER
         value: "gar"
       - name: E2E_NUM_CLUSTERS
-        value: "10"
+        value: "8"
 # Base job definition for autopilot jobs
 - &config-sync-autopilot-job
   <<: *config-sync-base-job
@@ -102,7 +102,7 @@ prow_ignored:
       - name: E2E_HELM_PROVIDER
         value: "gar"
       - name: E2E_NUM_CLUSTERS
-        value: "15"
+        value: "12"
       - name: GKE_AUTOPILOT
         value: "true"
 


### PR DESCRIPTION
Most Config Sync CI uses Cloud Source Repository as the Git provider to run the e2e tests. We're currently hitting the write limit, and it requires updating the project portfolio to increase the quota.

```
ERROR: (gcloud.source.repos.create) ResponseError: status=[RESOURCE_EXHAUSTED], code=[429], message=[RESOURCE_EXHAUSTED: Quota exceeded for quota metric 'Number of write requests' and limit 'Number of write requests per minute' of service 'sourcerepo.googleapis.com' for consumer 'project_number:770236578952'.]
```

CI link: https://oss.gprow.dev/view/gs/oss-prow-build-kpt-config-sync/logs/kpt-config-sync-standard-rapid-latest/1773451412810764288

This commit decreases parallism by reducing the number of E2E test clusters, so there would be fewer concurrent write requests to CSR.

Another option is to further stagger the jobs so they don't run at the same time. However, it is already configured to run standard tests on even hours and run autopilot tests on odd hours. Both standard and autopilot tests take around 1 hour to finish, so it won't help if we further stagger these jobs.