### PR TITLE
Bump cit-performance-peridiocs parallel count

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -548,7 +548,7 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=2"
+      - "-parallel_count=3"
       - "-timeout=60m"
       - "-project=gcp-guest"
       - "-zone=us-central1-b"


### PR DESCRIPTION
My math was slightly off, last run timed out with 13 networkperf runs left to finish. For now I want to keep execution under 24hrs, to keep prow configuration simple. Bumping parallel count by 1 should easily get it there.

/cc @zmarano @elicriffield 