### PR TITLE
Change prow command for k8s-cloud-providers

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/k8s-cloud-provider/k8s-cloud-provider-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/k8s-cloud-provider/k8s-cloud-provider-config.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-k8s-cloud-provider-test
     branches:
     - master
-    - rgraph-unstable
     always_run: true         # Run for every PR, or only when requested.
     labels:
       preset-service-account: "true"
@@ -14,4 +13,4 @@ presubmits:
         command:
         - make
         - --
-        - test
+        - all


### PR DESCRIPTION
* change command to `make all` which covers build, running test and coverage.
* remove rgraph unstable branch from prow - this branch is deprecated
