### PR TITLE
Require self-approval for Kubeflow repos

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -39,19 +39,25 @@ approve:
   require_self_approval: false
   commandHelpLink: https://oss.gprow.dev/command-help
 - repos:
-  - GoogleContainerTools
-  - kubeflow/caffe2-operator
-  - kubeflow/chainer-operator
-  - kubeflow/common
-  - kubeflow/fate-operator
-  - kubeflow/kubeflow
-  - kubeflow/mpi-operator
-  - kubeflow/mxnet-operator
-  - kubeflow/pipelines
-  - kubeflow/pytorch-operator
-  - kubeflow/tf-operator
-  - kubeflow/xgboost-operator
   - GoogleCloudPlatform/k8s-config-connector
+  - GoogleContainerTools
+  - kubeflow/arena
+  - kubeflow/blog
+  - kubeflow/community
+  - kubeflow/examples
+  - kubeflow/internal-acls
+  - kubeflow/katib
+  - kubeflow/kfp-tekton
+  - kubeflow/kubeflow
+  - kubeflow/manifests
+  - kubeflow/model-registry
+  - kubeflow/mpi-operator
+  - kubeflow/notebooks
+  - kubeflow/pipelines
+  - kubeflow/spark-operator
+  - kubeflow/testing
+  - kubeflow/training-operator
+  - kubeflow/website
   require_self_approval: true
   commandHelpLink: https://oss.gprow.dev/command-help
 


### PR DESCRIPTION
As discussed in https://github.com/kubeflow/kubeflow/issues/7549#issuecomment-2091871635, and other places.

We need to ensure that approvers are explicitly approving their PRs in the Kubeflow org, as this prevents people from accidentally merging PRs with a single `/lgtm`.

This PR updates the prow configs so that all currently active Kubeflow repos require people who are approvers to explicitly `/approve` their own PRs, if that is their intention.

__NOTE:__ it might be possible to just enable this at the org level by including `kubeflow` as a list element, but I am not super familiar with how the config works.