### PR TITLE
Pin to a specific cluster version for Autopilot rapid and rapid-latest

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -280,6 +280,7 @@ periodics:
       args:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-9'
       - 'GKE_RELEASE_CHANNEL=rapid'
+      - 'GKE_CLUSTER_VERSION=1.29.4-gke.1670000'  # TODO(b/339056595#comment58): remove `GKE_CLUSTER_VERSION` when all versions in the rapid channel are newer than the pinned version
       - 'E2E_CLUSTER_PREFIX=autopilot-rapid'
 
 - <<: *config-sync-autopilot-job
@@ -295,7 +296,7 @@ periodics:
       args:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-10'
       - 'GKE_RELEASE_CHANNEL=rapid'
-      - 'GKE_CLUSTER_VERSION=latest'
+      - 'GKE_CLUSTER_VERSION=1.29.4-gke.1670000'  # TODO(b/339056595#comment52): reset `GKE_CLUSTER_VERSION` to `latest` when `1.30.0-gke.1661000` is rolled out to production.
       - 'E2E_CLUSTER_PREFIX=autopilot-rapid-latest'
 
 #### End GKE autopilot jobs

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -279,6 +279,7 @@ periodics:
       args:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-9'
       - 'GKE_RELEASE_CHANNEL=rapid'
+      - 'GKE_CLUSTER_VERSION=1.29.4-gke.1670000'  # TODO(b/339056595#comment58): remove `GKE_CLUSTER_VERSION` when all versions in the rapid channel are newer than the pinned version
       - 'E2E_CLUSTER_PREFIX=autopilot-rapid'
 
 - <<: *config-sync-autopilot-job
@@ -294,7 +295,7 @@ periodics:
       args:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-10'
       - 'GKE_RELEASE_CHANNEL=rapid'
-      - 'GKE_CLUSTER_VERSION=latest'
+      - 'GKE_CLUSTER_VERSION=1.29.4-gke.1670000'  # TODO(b/339056595#comment52): reset `GKE_CLUSTER_VERSION` to `latest` when `1.30.0-gke.1661000` is rolled out to production.
       - 'E2E_CLUSTER_PREFIX=autopilot-rapid-latest'
 
 #### End GKE autopilot jobs


### PR DESCRIPTION
The current Autopilot jobs failed due to Cilium API client timeout error.
The GKE team has marked a few versions as bad. This commit pins to a specific working version for the rapid and rapid-latest CIs. The regular channel doesn't have the fix available yet. It may take another 1-2 weeks until the fix is available in the regular channel. The stable channel seems to be okay with an older version.

b/339056595