### PR TITLE
chore: Remove KFP presubmit backend test prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -12,15 +12,6 @@ presubmits:
         args:
         - -c
         - cd ./frontend && npm run test:ci:prow
-  - name: kubeflow-pipeline-backend-test
-    run_if_changed: "^(backend/.*)|(test/presubmit-backend-test.sh)$"
-    cluster: build-kubeflow
-    decorate: true
-    spec:
-      containers:
-      - image: golang:1.21-bullseye
-        command:
-        - ./test/presubmit-backend-test.sh
   - name: kubeflow-pipeline-e2e-test
     run_if_changed: "^(frontend/.*)|(backend/.*)|(proxy/.*)|(manifests/kustomize/.*)|(test/.*)|go.mod|go.sum$"
     cluster: build-kubeflow


### PR DESCRIPTION
As part of migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate presubmit backend tests to a GHA: https://github.com/kubeflow/pipelines/pull/10871

This PR removes presubmit backend tests from the prow config in parallel.