### PR TITLE
Removed mkp tests

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-postsubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-postsubmits.yaml
@@ -15,27 +15,3 @@ postsubmits:
       description: Postsubmit integration tests for kubeflow/pipeline.
       testgrid-alert-email: kubeflow-pipelines+test@google.com
       testgrid-num-failures-to-alert: "5"
-  - name: kubeflow-pipeline-postsubmit-mkp-e2e-test
-    cluster: build-kubeflow
-    branches:
-    - ^master|release-.+$
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
-        command:
-        - ./test/postsubmit-tests-with-pipeline-deployment.sh
-        args:
-        - --kfp_deployment
-        - mkp
-        - --workflow_file
-        - e2e_test_gke_v2.yaml
-        - --test_result_folder
-        - e2e_test
-        - --timeout
-        - "7200"
-    annotations:
-      testgrid-dashboards: googleoss-kubeflow-pipelines
-      description: Postsubmit tests for kubeflow/pipeline.
-      testgrid-alert-email: kubeflow-pipelines+test@google.com
-      testgrid-num-failures-to-alert: "5"

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -1,27 +1,5 @@
 presubmits:
   kubeflow/pipelines:
-  - name: kubeflow-pipeline-mkp-test
-    run_if_changed: "^(manifests/gcp_marketplace/.*)|(test/presubmit-tests-mkp.sh)|(test/tag_for_hosted.sh)|(test/cloudbuild/mkp_verify.yaml)$"
-    cluster: build-kubeflow
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
-        command:
-        - ./test/presubmit-tests-mkp.sh
-  - name: kubeflow-pipeline-mkp-snapshot-test
-    run_if_changed: "^(manifests/gcp_marketplace/.*)$"
-    cluster: build-kubeflow
-    decorate: true
-    spec:
-      containers:
-      - image: bash:alpine3.14
-        command:
-        - bash
-        args:
-        # We cannot call the shell script directly because the shebang in script is /bin/bash,
-        # but the bash:alpine3.14 image has its bash in /usr/local/bin/bash.
-        - ./manifests/gcp_marketplace/test/presubmit.sh 
   - name: kubeflow-pipeline-upgrade-test
     run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
     cluster: build-kubeflow


### PR DESCRIPTION
As discussed in https://docs.google.com/document/d/1cHAdK1FoGEbuQ-Rl6adBDL5W2YpDiUbnMLIwmoXBoAU/edit?disco=AAABPj_J-a4, removed:
- kubeflow-pipeline-mkp-test
- kubeflow-pipeline-mkp-snapshot-test
- kubeflow-pipeline-postsubmit-mkp-e2e-test

PR to remove the tests from the kubeflow/pipelines repo:

- https://github.com/kubeflow/pipelines/pull/10924

/assign @chensun 