### PR TITLE
chore: Remove KFP presubmit frontend test prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -1,17 +1,5 @@
 presubmits:
   kubeflow/pipelines:
-  - name: kubeflow-pipeline-frontend-test
-    run_if_changed: "^frontend/.*$"
-    cluster: build-kubeflow
-    decorate: true
-    spec:
-      containers:
-      - image: node:14
-        command:
-        - /bin/sh
-        args:
-        - -c
-        - cd ./frontend && npm run test:ci:prow
   - name: kubeflow-pipeline-mkp-test
     run_if_changed: "^(manifests/gcp_marketplace/.*)|(test/presubmit-tests-mkp.sh)|(test/tag_for_hosted.sh)|(test/cloudbuild/mkp_verify.yaml)$"
     cluster: build-kubeflow


### PR DESCRIPTION
As part of migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate presubmit frontend tests to a GHA: https://github.com/kubeflow/pipelines/pull/10923

This PR removes presubmit frontend tests from the prow config in parallel.