### PR TITLE
Switch older CIT test images to known good ones

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -560,7 +560,7 @@ periodics:
       - "-parallel_count=5"
       - "-project=gcp-guest"
       - "-zone=us-central1-b"
-      - "-images=projects/bct-prod-images/global/images/family/windows-2012-r2,projects/bct-prod-images/global/images/family/windows-2016,projects/bct-prod-images/global/images/family/windows-2019,projects/bct-prod-images/global/images/family/windows-2022,projects/bct-prod-images/global/images/windows-server-2012-r2-dc-v20230505,projects/windows-cloud/global/images/windows-server-2016-dc-v20161012,projects/windows-cloud/global/images/windows-server-2019-dc-v20190108,projects/windows-cloud/global/images/windows-server-2022-dc-v20220215"
+      - "-images=projects/bct-prod-images/global/images/family/windows-2012-r2,projects/bct-prod-images/global/images/family/windows-2016,projects/bct-prod-images/global/images/family/windows-2019,projects/bct-prod-images/global/images/family/windows-2022,projects/bct-prod-images/global/images/windows-server-2012-r2-dc-v20230505-cit,projects/bct-prod-images/global/images/windows-server-2022-dc-v20220615-cit,projects/bct-prod-images/global/images/windows-server-2019-dc-v20220615-cit,projects/bct-prod-images/global/images/windows-server-2016-dc-v20220615-cit"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
       - "-filter=packageupgrade"
 - name: ubuntu-daily-cit-performance


### PR DESCRIPTION
Older images are either not UEFI or getting obsoleted/deleted and/or have bad versions of the agents that can't run the CIt test. Switching to new custom, family-less immages that will consistently pass.