### PR TITLE
chore: Remove KFP presubmit kfp-kubernetes-execution-tests tests prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -290,20 +290,6 @@ presubmits:
         command:
         - ./test/presubmit-test-kfp-kubernetes-library.sh
 
-  - name: kfp-kubernetes-execution-tests
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(api/v2alpha1/.*)|(kubernetes_platform/.*)|(test/presubmit-kfp-kubernetes-execution-tests.sh)$"
-    # START TODO: remove when tests pass
-    optional: true
-    skip_report: false
-    # END TODO
-    spec:
-      containers:
-      - image: python:3.8
-        command:
-        - ./test/presubmit-kfp-kubernetes-execution-tests.sh
-
   - name: test-run-all-gcpc-modules
     cluster: build-kubeflow
     decorate: true


### PR DESCRIPTION
As part of the migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate presubmit kfp-kubernetes-execution-tests to a GHA:

- https://github.com/kubeflow/pipelines/pull/10926

This PR removes presubmit kfp-kubernetes-execution-tests from the prow config in parallel.

/assign @chensun 