### PR TITLE
Removed kubeflow-pipeline-upgrade-test from Kubeflow Pipelines tests

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -1,19 +1,5 @@
 presubmits:
   kubeflow/pipelines:
-  - name: kubeflow-pipeline-upgrade-test
-    run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
-    cluster: build-kubeflow
-    decorate: true
-    # TODO: temporarily make it optional due to https://github.com/kubeflow/pipelines/issues/10779 
-    optional: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
-        command:
-        - ./test/upgrade-tests.sh
-        args:
-        - --test_result_folder
-        - upgrade_test
   - name: kubeflow-pipeline-upgrade-test-v2
     run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
     cluster: build-kubeflow
@@ -42,7 +28,7 @@ presubmits:
       - image: python:3.8
         command:
         - ./test/presubmit-tests-tfx.sh
-  
+
   - name: kubeflow-pipelines-samples-v2
     cluster: build-kubeflow
     decorate: true

--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -1,21 +1,5 @@
 presubmits:
   kubeflow/pipelines:
-  - name: kubeflow-pipeline-upgrade-test-v2
-    run_if_changed: "^(backend/.*)|(manifests/kustomize/.*)|(test/upgrade.*)$"
-    cluster: build-kubeflow
-    decorate: true
-    # TODO(chensun): mark as required once verified v2 upgrade test working
-    optional: true
-    skip_report: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-master
-        command:
-        - ./test/upgrade-tests.sh
-        args:
-        - --test_result_folder
-        - upgrade_test
-        - --test_v2_api
 
   - name: kubeflow-pipelines-tfx-python37
     cluster: build-kubeflow


### PR DESCRIPTION
Removing kubeflow-pipeline-upgrade-test due to https://github.com/kubeflow/pipelines/pull/10932.

cc @chensun 