### PR TITLE
chore: Remove KFP presubmit SDK YAPF test prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -205,17 +205,6 @@ presubmits:
       - image: python:3.8
         command:
         - ./test/presubmit-isort-sdk.sh
-  - name: kubeflow-pipelines-sdk-yapf
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-yapf-sdk.sh)$"
-    branches:
-    - master
-    spec:
-      containers:
-      - image: python:3.8
-        command:
-        - ./test/presubmit-yapf-sdk.sh
   - name: kubeflow-pipelines-sdk-docformatter
     cluster: build-kubeflow
     decorate: true


### PR DESCRIPTION
As part of migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate KFP presubmit SDK YAPF test to a GHA: https://github.com/kubeflow/pipelines/pull/10961

This PR removes presubmit SDK YAPF test from the prow config in parallel.