### PR TITLE
chore: Remove KFP presubmit SDK Execution test prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -205,18 +205,7 @@ presubmits:
       - image: python:3.8
         command:
         - ./test/presubmit-docformatter-sdk.sh
-  - name: kubeflow-pipelines-sdk-execution-tests
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(api/v2alpha1/.*)|(test/presubmit-sdk-execution-tests.sh)$"
-    branches:
-    - master
-    spec:
-      containers:
-      - image: python:3.8
-        command:
-        - ./test/presubmit-sdk-execution-tests.sh
-
+ 
 # kfp.kubernetes tests
   - name: kfp-kubernetes-test-python38
     cluster: build-kubeflow


### PR DESCRIPTION
As part of migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate KFP presubmit SDK Execution test to a GHA: https://github.com/kubeflow/pipelines/pull/10975

This PR removes presubmit SDK Execution test from the prow config in parallel.