### PR TITLE
chore: bump config-sync gke-e2e image

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -14,7 +14,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-base-job-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v1.0.0-3865c4481
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.22.5-gcloud449.0.0-docker20.10.14
       command:
       - make
       - test-e2e-gke-ci


### PR DESCRIPTION
The primary change is the upgrade to Go 1.22