### PR TITLE
chore: bump Config Sync presubmit images

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -24,9 +24,8 @@ prow_ignored:
   spec: &config-sync-e2e-job-spec
     containers:
     - &config-sync-e2e-container
-      # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
       # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240702-590eff485f-1.30
       command:
       - runner.sh
       env:
@@ -63,9 +62,8 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
       # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240702-590eff485f-1.30
         command:
         - runner.sh
         args:


### PR DESCRIPTION
These images have Go 1.22