### PR TITLE
Removed kubeflow-pipelines-backend-visualization

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -129,16 +129,6 @@ presubmits:
         command:
         - ./test/presubmit-component-yaml.sh
 
-  - name: kubeflow-pipelines-backend-visualization
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(backend/src/apiserver/visualization/.*)|(test/presubmit-backend-visualization.sh)$"
-    spec:
-      containers:
-      - image: python:3.8
-        command:
-        - ./test/presubmit-backend-visualization.sh
-  
   - name: kubeflow-pipelines-samples-v2
     cluster: build-kubeflow
     decorate: true


### PR DESCRIPTION
As part of the migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migratekubeflow-pipelines-backend-visualization tests to a GHA: https://github.com/kubeflow/pipelines/pull/10984

This PR removes presubmit kubeflow-pipelines-backend-visualization tests from the prow config in parallel.

cc @chensun @zijianjoy 