### PR TITLE
chore: Remove KFP presubmit SDK Upgrade test prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -225,16 +225,6 @@ presubmits:
         command:
         - ./test/presubmit-test-run-all-gcpc-modules.sh
 
-  - name: test-upgrade-kfp-sdk
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-sdk-upgrade.sh)$"
-    spec:
-      containers:
-      - image: python:3.8
-        command:
-        - ./test/presubmit-test-sdk-upgrade.sh
-
   # this test is not passing
   # - name: kubeflow-pipeline-multiuser-test
   #   cluster: build-kubeflow


### PR DESCRIPTION
As part of migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate KFP presubmit SDK Upgrade test to a GHA: https://github.com/kubeflow/pipelines/pull/10989

This PR removes presubmit SDK Upgrade test from the prow config in parallel.