### PR TITLE
chore: Remove KFP presubmit SDK Runtime tests prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -303,56 +303,6 @@ presubmits:
         command:
         - ./test/presubmit-test-sdk-upgrade.sh
 
-  - name: test-kfp-runtime-code-python38
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-kfp-runtime-code.sh)$"
-    spec:
-      containers:
-      - image: python:3.8
-        command:
-        - ./test/presubmit-test-kfp-runtime-code.sh
-
-  - name: test-kfp-runtime-code-python39
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-kfp-runtime-code.sh)$"
-    spec:
-      containers:
-      - image: python:3.9
-        command:
-        - ./test/presubmit-test-kfp-runtime-code.sh
-
-  - name: test-kfp-runtime-code-python310
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-kfp-runtime-code.sh)$"
-    spec:
-      containers:
-      - image: python:3.10
-        command:
-        - ./test/presubmit-test-kfp-runtime-code.sh
-
-  - name: test-kfp-runtime-code-python311
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-kfp-runtime-code.sh)$"
-    spec:
-      containers:
-      - image: python:3.11
-        command:
-        - ./test/presubmit-test-kfp-runtime-code.sh
-
-  - name: test-kfp-runtime-code-python312
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-kfp-runtime-code.sh)$"
-    spec:
-      containers:
-      - image: python:3.12
-        command:
-        - ./test/presubmit-test-kfp-runtime-code.sh
-
   # this test is not passing
   # - name: kubeflow-pipeline-multiuser-test
   #   cluster: build-kubeflow


### PR DESCRIPTION
As part of migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate KFP presubmit SDK Runtime tests to a GHA: https://github.com/kubeflow/pipelines/pull/10991

This PR removes presubmit SDK Runtime tests from the prow config in parallel.