### PR TITLE
chore: use renamed config-sync test targets

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -129,7 +129,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test-e2e-kind-multi-repo
+      - test-e2e-kind
       - 'E2E_GIT_PROVIDER=local'
       - 'E2E_OCI_PROVIDER=local'
       - 'E2E_HELM_PROVIDER=local'

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -128,7 +128,7 @@ periodics:
       - runner.sh
       args:
       - make
-      - test-e2e-kind-multi-repo
+      - test-e2e-kind
       - 'E2E_GIT_PROVIDER=local'
       - 'E2E_OCI_PROVIDER=local'
       - 'E2E_HELM_PROVIDER=local'

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -87,7 +87,7 @@ presubmits:
       - <<: *config-sync-e2e-container
         args:
         - make
-        - test-e2e-kind-multi-repo-test-group1
+        - test-e2e-kind-test-group1
   - <<: *config-sync-e2e-job
     name: kpt-config-sync-presubmit-e2e-multi-repo-test-group2
     spec:
@@ -96,7 +96,7 @@ presubmits:
       - <<: *config-sync-e2e-container
         args:
         - make
-        - test-e2e-kind-multi-repo-test-group2
+        - test-e2e-kind-test-group2
   - <<: *config-sync-e2e-job
     name: kpt-config-sync-presubmit-e2e-multi-repo-test-group3
     spec:
@@ -105,4 +105,4 @@ presubmits:
       - <<: *config-sync-e2e-container
         args:
         - make
-        - test-e2e-kind-multi-repo-test-group3
+        - test-e2e-kind-test-group3


### PR DESCRIPTION
The multi-repo aliases reflect a legacy naming scheme, and all current branches support the new name.