### PR TITLE
enable MTU workaround for dind presets

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -298,6 +298,8 @@ presets:
   env:
   - name: DOCKER_IN_DOCKER_ENABLED
     value: "true"
+  - name: BOOTSTRAP_MTU_WORKAROUND
+    value: "true"
   volumes:
   - name: docker-graph
     emptyDir: {}
@@ -309,6 +311,8 @@ presets:
     preset-dind-enabled-memory: "true"
   env:
   - name: DOCKER_IN_DOCKER_ENABLED
+    value: "true"
+  - name: BOOTSTRAP_MTU_WORKAROUND
     value: "true"
   volumes:
   - name: docker-graph


### PR DESCRIPTION
This fixes an issue where the dind container is on a host with a MTU lower than the typical default of 1500, resulting in a mismatch.

Upstream maintainers are considering making this the default behavior of the script, but for now this is a quick workaround.

See: https://github.com/kubernetes/test-infra/blob/94f76aedb29b50131fe5dc5e131adcd23f6d4f22/images/bootstrap/runner.sh#L87