### PR TITLE
add node label selectors to all CS jobs

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -25,7 +25,8 @@ prow_ignored:
           cpu: "4000m"
     nodeSelector:
       # This job requires 8vCPUs or less, so it is "small".
-      cloud.google.com/gke-nodepool: small-job-pool
+      kpt-config-sync/type: periodic
+      kpt-config-sync/size: small
 # Base job definition for standard jobs
 - &config-sync-standard-job
   <<: *config-sync-base-job
@@ -140,7 +141,8 @@ periodics:
           memory: "50Gi"
           cpu: "30000m"
     nodeSelector:
-      cloud.google.com/gke-nodepool: large-job-pool-periodic-release
+      kpt-config-sync/type: periodic
+      kpt-config-sync/size: large
 
 #### Begin GKE standard jobs
 - <<: *config-sync-standard-job
@@ -412,4 +414,5 @@ periodics:
           cpu: "250m"
     nodeSelector:
       # This job requires 8vCPUs or less, so it is "small".
-      cloud.google.com/gke-nodepool: small-job-pool
+      kpt-config-sync/type: periodic
+      kpt-config-sync/size: small

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -24,7 +24,8 @@ prow_ignored:
           cpu: "4000m"
     nodeSelector:
       # This job requires 8vCPUs or less, so it is "small".
-      cloud.google.com/gke-nodepool: small-job-pool
+      kpt-config-sync/type: periodic
+      kpt-config-sync/size: small
 # Base job definition for standard jobs
 - &config-sync-standard-job
   <<: *config-sync-base-job
@@ -139,7 +140,8 @@ periodics:
           memory: "50Gi"
           cpu: "30000m"
     nodeSelector:
-      cloud.google.com/gke-nodepool: large-job-pool-periodic
+      kpt-config-sync/type: periodic
+      kpt-config-sync/size: large
 
 #### Begin GKE standard jobs
 - <<: *config-sync-standard-job
@@ -413,4 +415,5 @@ periodics:
           cpu: "250m"
     nodeSelector:
       # This job requires 8vCPUs or less, so it is "small".
-      cloud.google.com/gke-nodepool: small-job-pool
+      kpt-config-sync/type: periodic
+      kpt-config-sync/size: small

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
@@ -39,4 +39,5 @@ postsubmits:
             cpu: "2000m"
       nodeSelector:
         # This job requires 8vCPUs or less, so it is "small".
-        cloud.google.com/gke-nodepool: small-job-pool
+        kpt-config-sync/type: periodic
+        kpt-config-sync/size: small

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -78,7 +78,8 @@ presubmits:
             cpu: "2000m"
       nodeSelector:
         # This job requires 8vCPUs or less, so it is "small".
-        cloud.google.com/gke-nodepool: small-job-pool
+        kpt-config-sync/type: presubmit
+        kpt-config-sync/size: small
   - <<: *config-sync-e2e-job
     name: kpt-config-sync-presubmit-e2e-multi-repo-test-group1
     spec:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-terraform.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-terraform.yaml
@@ -5,7 +5,8 @@ prow_ignored:
   spec: &config-sync-terraform-job-spec
     nodeSelector:
       # This job requires 8vCPUs or less, so it is "small".
-      cloud.google.com/gke-nodepool: small-job-pool
+      kpt-config-sync/type: presubmit
+      kpt-config-sync/size: small
     containers:
     - &config-sync-terraform-container
       image: gcr.io/k8s-testimages/gcloud-terraform:v20220913-3bc71e6c7a


### PR DESCRIPTION
This is more flexible than the strict gke node pool selector, allowing the underlying node pools to be changed without downtime and/or coordinating changes to the prow config. Also separates presubmits from periodic nodes for better isolation/security.