### PR TITLE
chore: sync kind periodics with presubmits

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -123,9 +123,8 @@ periodics:
     preset-dind-enabled-memory: "true"
   spec:
     containers:
-    # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
     # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240702-590eff485f-1.30
       command:
       - runner.sh
       args:
@@ -139,7 +138,7 @@ periodics:
       resources:
         requests:
           memory: "50Gi"
-          cpu: "30000m"
+          cpu: "26000m"
     nodeSelector:
       kpt-config-sync/type: periodic
       kpt-config-sync/size: large

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -122,9 +122,8 @@ periodics:
     preset-dind-enabled-memory: "true"
   spec:
     containers:
-    # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
     # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231012-0288f8bc6c-go-canary
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240702-590eff485f-1.30
       command:
       - runner.sh
       args:
@@ -138,7 +137,7 @@ periodics:
       resources:
         requests:
           memory: "50Gi"
-          cpu: "30000m"
+          cpu: "26000m"
     nodeSelector:
       kpt-config-sync/type: periodic
       kpt-config-sync/size: large


### PR DESCRIPTION
The kind periodic config has drifted a bit from the presubmit config. Updating them to be in sync again.