### PR TITLE
Add a prowjob for gke-networking-api.

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -30,6 +30,7 @@ tide:
     GoogleContainerTools/kpt-config-sync: squash
     kubeflow: squash
     GoogleCloudPlatform/k8s-config-connector: merge
+    GoogleCloudPlatform/gke-networking-api: merge
   squash_label: tide/merge-method-squash
   rebase_label: tide/merge-method-rebase
   merge_label: tide/merge-method-merge
@@ -55,6 +56,7 @@ tide:
     - GoogleCloudPlatform/oss-test-infra
     - GoogleCloudPlatform/testgrid
     - GoogleCloudPlatform/k8s-cloud-provider
+    - GoogleCloudPlatform/gke-networking-api
     - GoogleContainerTools/kpt-config-sync
     - GoogleCloudPlatform/k8s-config-connector
     labels:

--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -220,6 +220,13 @@ plugins:
     - owners-label
     - size
     - verify-owners
+  GoogleCloudPlatform/gke-networking-api:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - size
+    - verify-owners
   GoogleCloudPlatform/netd:
     plugins:
     - approve

--- a/prow/prowjobs/GoogleCloudPlatform/gke-networking-api/OWNERS
+++ b/prow/prowjobs/GoogleCloudPlatform/gke-networking-api/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- bowei
+- yswe

--- a/prow/prowjobs/GoogleCloudPlatform/gke-networking-api/gke-networking-api-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gke-networking-api/gke-networking-api-config.yaml
@@ -1,0 +1,14 @@
+presubmits:
+  GoogleCloudPlatform/gke-networking-api:
+  - name: pull-gke-networking-api-test
+    branches:
+    - main
+    always_run: true         # Run for every PR, or only when requested.
+    labels:
+      preset-service-account: "true"
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230324-c487e233e1-master
+        command:
+        - ./hack/verify-codegen.sh


### PR DESCRIPTION
GKE Networking CRDs were moved to a new repo
GoogleCloudPlatform/gke-networking-api from
kubernetes/cloud-provider-gcp.

See this PR https://github.com/kubernetes/cloud-provider-gcp/pull/725 for additional details.

This CL adds a prowjob to run the verification script for the gke-networking-api repo.