### PR TITLE
chore: Remove KFP presubmit kubeflow-pipelines-samples-v2 test prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -42,21 +42,7 @@ presubmits:
       - image: python:3.8
         command:
         - ./test/presubmit-tests-tfx.sh
-  
-  - name: kubeflow-pipelines-samples-v2
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(samples/.*)|(backend/src/v2/.*)$"
-    # TODO(chensun): restore as required test once we migrated sample test to use v2 client.
-    optional: true
-    spec:
-      containers:
-      - image: python:3.8
-        command:
-        - ./backend/src/v2/test/sample-test.sh
-    skip_branches:
-    - ^sdk\/release-1.*$
-  
+
   - name: kubeflow-pipelines-integration-v2
     run_if_changed: "^(samples/core/(parameterized_tfx_oss|dataflow)/.*)$"
     cluster: build-kubeflow


### PR DESCRIPTION
As part of the migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate presubmit `kubeflow-pipelines-samples-v2` test to a GHA: https://github.com/kubeflow/pipelines/pull/11048

This PR removes presubmit `kubeflow-pipelines-samples-v2` from the prow config in parallel.

cc @chensun 