### PR TITLE
chore: Remove KFP presubmit kubeflow-pipelines-manifests tests prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -21,17 +21,7 @@ presubmits:
       containers:
       - image: python:3.8
         command:
-        - ./backend/src/v2/test/integration-test.sh
-
-  - name: kubeflow-pipelines-manifests
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^manifests/kustomize/.*$"
-    spec:
-      containers:
-      - image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
-        command:
-        - ./manifests/kustomize/hack/presubmit.sh
+        - ./backend/src/v2/test/integration-test.sh 
 
 # kfp.kubernetes tests
 


### PR DESCRIPTION
As part of the migration from Prow to GH Action Workflows for KFP, we have a PR proposed to migrate presubmit kubeflow-pipelines-manifests tests to a GHA:

- https://github.com/kubeflow/pipelines/pull/11066

This PR removes presubmit kubeflow-pipelines-manifests from the prow config in parallel.

