### PR TITLE
bump test image for gke-networking-api

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gke-networking-api/gke-networking-api-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gke-networking-api/gke-networking-api-config.yaml
@@ -9,6 +9,6 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230324-c487e233e1-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240803-cf1183f2db-master
         command:
         - ./hack/verify-codegen.sh


### PR DESCRIPTION
The current image is using go1.20 and throwing errors on go.mod with newer go versions:

https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/GoogleCloudPlatform_gke-networking-api/17/pull-gke-networking-api-test/1820882218180939776