### PR TITLE
Update image locations to use new locations.

### DIFF
--- a/.prow/presubmits.yaml
+++ b/.prow/presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
   run_if_changed: '^prow/(oss/(config|plugins)\.yaml$|prowjobs/)|^\.prow'
   spec:
     containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240730-12bb925b4
+      - image: us-central1-docker.pkg.dev/gob-prow/prow-images/checkconfig:v20240626-70258ed34
         imagePullPolicy: Always
         command:
           - checkconfig
@@ -49,7 +49,7 @@ presubmits:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/configurator:v20240405-c76de01869
+    - image: gcr.io/k8s-staging-test-infra/configurator:v20240801-a5d9345e59
       command:
       - configurator
       args:

--- a/prow/oss/README.md
+++ b/prow/oss/README.md
@@ -15,7 +15,7 @@ job.
 Please check recent [prow announcements](https://github.com/kubernetes/test-infra/tree/master/prow#announcements) before updating, if you are not already familiar with them.
 
 ```shell
-prow/bump.sh --auto
+prow/bump.sh --latest
 # commit change and merge PR
 make -C prow/oss deploy
 # kubectl get pods and watch for problems

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/crier:v20240626-70258ed34
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/deck:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/deck_blueprints_deployment.yaml
+++ b/prow/oss/cluster/deck_blueprints_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck-blueprints
-        image: gcr.io/k8s-prow/deck:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/deck:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --hook-url=http://hook:8888/plugin-help

--- a/prow/oss/cluster/gerrit.yaml
+++ b/prow/oss/cluster/gerrit.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: gerrit
-        image: gcr.io/k8s-prow/gerrit:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/gerrit:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/ghproxy.yaml
+++ b/prow/oss/cluster/ghproxy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/ghproxy:v20240626-70258ed34
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=49

--- a/prow/oss/cluster/grandmatriarch_default.yaml
+++ b/prow/oss/cluster/grandmatriarch_default.yaml
@@ -69,6 +69,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/grandmatriarch:v20240626-70258ed34
         args:
         - http-cookiefile

--- a/prow/oss/cluster/grandmatriarch_test-pods.yaml
+++ b/prow/oss/cluster/grandmatriarch_test-pods.yaml
@@ -74,6 +74,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/grandmatriarch:v20240626-70258ed34
         args:
         - http-cookiefile

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/hook:v20240626-70258ed34
         imagePullPolicy: Always
         args:
         - --webhook-path=/ghapp-hook

--- a/prow/oss/cluster/horologium.yaml
+++ b/prow/oss/cluster/horologium.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/horologium:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/prow-controller-manager:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/sinker:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/sub.yaml
+++ b/prow/oss/cluster/sub.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: sub
       containers:
       - name: sub
-        image: gcr.io/k8s-prow/sub:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/sub:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20240730-12bb925b4
+        image: us-central1-docker.pkg.dev/gob-prow/prow-images/tide:v20240626-70258ed34
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -123,10 +123,10 @@ plank:
       timeout: 7200000000000 # 2h
       grace_period: 15000000000 # 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20240730-12bb925b4"
-        initupload: "gcr.io/k8s-prow/initupload:v20240730-12bb925b4"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20240730-12bb925b4"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20240730-12bb925b4"
+        clonerefs: "us-central1-docker.pkg.dev/gob-prow/prow-images/clonerefs:v20240626-70258ed34"
+        initupload: "us-central1-docker.pkg.dev/gob-prow/prow-images/initupload:v20240626-70258ed34"
+        entrypoint: "us-central1-docker.pkg.dev/gob-prow/prow-images/entrypoint:v20240626-70258ed34"
+        sidecar: "us-central1-docker.pkg.dev/gob-prow/prow-images/sidecar:v20240626-70258ed34"
       gcs_configuration:
         bucket: "oss-prow"
         path_strategy: "explicit"

--- a/prow/oss/oss-autobump-config.yaml
+++ b/prow/oss/oss-autobump-config.yaml
@@ -1,7 +1,7 @@
 ---
 gitHubLogin: "google-oss-robot"
 gitHubToken: "/etc/github-token/oauth"
-onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+onCallAddress: "" # No one is oncall for this at the moment.
 skipPullRequest: false
 selfAssign: true # Commenting `/cc`, so that autobump PR is not assigned to anyone
 gitHubOrg: "GoogleCloudPlatform"
@@ -13,26 +13,18 @@ includedConfigPaths:
   - "prow/oss/cluster"
   - "prow/prowjobs"
   - ".prow"
-targetVersion: "upstream"
+targetVersion: "latest"
 extraFiles:
   - "prow/oss/config.yaml"
 prefixes: 
   - name: "oss-prow"
-    prefix: "gcr.io/k8s-prow/"
+    prefix: "us-central1-docker.pkg.dev/gob-prow/prow-images/"
     repo: "https://github.com/kubernetes/test-infra"
     refConfigFile: "config/prow/cluster/deck_deployment.yaml"
     summarise: false
     consistentImages: true
-    # The following images are not published from kubernetes-sigs/prow and
-    # don't need to be consistent with the Prow images.
-    consistentImageExceptions:
-      - "gcr.io/k8s-prow/alpine"
-      - "gcr.io/k8s-prow/analyze"
-      - "gcr.io/k8s-prow/commenter"
-      - "gcr.io/k8s-prow/configurator"
-      - "gcr.io/k8s-prow/gcsweb"
-      - "gcr.io/k8s-prow/gencred"
-      - "gcr.io/k8s-prow/git"
-      - "gcr.io/k8s-prow/issue-creator"
-      - "gcr.io/k8s-prow/label_sync"
-      - "gcr.io/k8s-prow/pr-creator"
+  - name: "k8s-staging-test-infra GCR images"
+    prefix: "gcr.io/k8s-staging-test-infra"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: false

--- a/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/blueprints/GoogleCloudPlatform_blueprints_checkconfig.yaml
@@ -10,7 +10,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240730-12bb925b4
+      - image: us-central1-docker.pkg.dev/gob-prow/prow-images/checkconfig:v20240626-70258ed34
         command:
         - checkconfig
         args:

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -40,7 +40,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-config-updater
       containers:
-      - image: gcr.io/k8s-prow/configurator:v20240405-c76de01869
+      - image: gcr.io/k8s-staging-test-infra/configurator:v20240801-a5d9345e59
         command:
         - configurator
         args:
@@ -65,7 +65,7 @@ postsubmits:
       serviceAccountName: gencred-refresher
       containers:
       - name: gencred
-        image: gcr.io/k8s-prow/gencred:v20240405-c76de01869
+        image: gcr.io/k8s-staging-test-infra/gencred:v20240801-a5d9345e59
         command:
         - gencred
         args:
@@ -93,7 +93,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240730-12bb925b4
+    - image: us-central1-docker.pkg.dev/gob-prow/prow-images/generic-autobumper:v20240626-70258ed34
       command:
       - generic-autobumper
       args:
@@ -130,7 +130,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240730-12bb925b4
+    - image: us-central1-docker.pkg.dev/gob-prow/prow-images/generic-autobumper:v20240626-70258ed34
       command:
       - generic-autobumper
       args:
@@ -187,7 +187,7 @@ periodics:
     serviceAccountName: gencred-refresher
     containers:
     - name: gencred
-      image: gcr.io/k8s-prow/gencred:v20240405-c76de01869
+      image: gcr.io/k8s-staging-test-infra/gencred:v20240801-a5d9345e59
       command:
       - gencred
       args:

--- a/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-jobs.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240730-12bb925b4
+      - image: us-central1-docker.pkg.dev/gob-prow/prow-images/checkconfig:v20240626-70258ed34
         command:
         - checkconfig
         args:
@@ -90,7 +90,7 @@ postsubmits:
       testgrid-num-failures-to-alert: '3'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/generic-autobumper:v20240730-12bb925b4
+      - image: us-central1-docker.pkg.dev/gob-prow/prow-images/generic-autobumper:v20240626-70258ed34
         command:
         - generic-autobumper
         args:
@@ -126,7 +126,7 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20240730-12bb925b4
+    - image: us-central1-docker.pkg.dev/gob-prow/prow-images/generic-autobumper:v20240626-70258ed34
       command:
       - generic-autobumper
       args:

--- a/prow/tests/jobs_test.go
+++ b/prow/tests/jobs_test.go
@@ -138,12 +138,12 @@ func TestAllJobs(t *testing.T) {
 func TestPrivateJobs(t *testing.T) {
 	const (
 		private           = "private"
-		checkconfigPrefix = "gcr.io/k8s-prow/checkconfig:"
+		checkconfigPrefix = "us-central1-docker.pkg.dev/gob-prow/prow-images/checkconfig:"
 	)
 	trustedPath := path.Join(*jobConfigPath, "private-inrepoconfig-configcheck")
 
 	errorIfNotPermitted := func(t *testing.T, name, cluster string, spec *v1.PodSpec) {
-		if strings.Contains(cluster, private) && (len(spec.Containers) != 1 || !strings.HasPrefix(spec.Containers[0].Image, "gcr.io/k8s-prow/checkconfig:")) {
+		if strings.Contains(cluster, private) && (len(spec.Containers) != 1 || !strings.HasPrefix(spec.Containers[0].Image, "us-central1-docker.pkg.dev/gob-prow/prow-images/checkconfig:")) {
 			t.Errorf("%s: cannot use private cluster %s", name, cluster)
 		}
 	}


### PR DESCRIPTION
This includes three changes:
- Upstream misc test-infra images are now published to gcr.io/k8s-staging-test-infra, so update image references to use that. gcr.io/k8s-prow > gcr.io/k8s-staging-test-infra
- Upstream Prow images use the gob-prow AR images that are maintained by the Prow dev team (and are separate from the ones published in k8s-sigs/prow). gcr.io/k8s-prow > us-central1-docker.pkg.dev/gob-prow/prow-images
- Autobump config needs to use the new locations, and has a split now to update the two different locations (for Prow and misc images). Prow images remain consistent, misc images don't have to.

Images in gcr.io/k8s-staging-test-infra are public, but this requires that oss-prow has permissions to pull images from us-central1-docker.pkg.dev/gob-prow/prow-images. (I've granted permissions for oss-prow's default SA to view Artifact Registry in gob-prow, which I _think_ should take care of it.)