### PR TITLE
Update kubekins-e2e image

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/k8s-cloud-provider/k8s-cloud-provider-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/k8s-cloud-provider/k8s-cloud-provider-config.yaml
@@ -9,7 +9,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230324-c487e233e1-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240817-9d8af80899-master
         command:
         - make
         - --


### PR DESCRIPTION
We want to use a new version of Go in https://github.com/GoogleCloudPlatform/k8s-cloud-provider/pull/217