### PR TITLE
Use default application credentials with autobump

### DIFF
--- a/prow/oss/oss-autobump-config.yaml
+++ b/prow/oss/oss-autobump-config.yaml
@@ -9,6 +9,7 @@ gitHubRepo: "oss-test-infra"
 remoteName: "oss-test-infra"
 headBranchName: "autobump-oss-prow"
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+imageRegistryAuth: google
 includedConfigPaths:
   - "prow/oss/cluster"
   - "prow/prowjobs"


### PR DESCRIPTION
The job needs permissions to read from the source project (gob-prow), but doesn't have them. Update autobump to use application default credentials (via `imageRegistryAuth: google`) to fix this, similar to the gob-prow autobump job.

Tested locally that this should be sufficient (assuming permissions are granted in gob-prow correctly).