### PR TITLE
chore: Remove KFP presubmit run-all-gcpc-modules test prow config

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -25,17 +25,6 @@ presubmits:
 
 # kfp.kubernetes tests
 
-  - name: test-run-all-gcpc-modules
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-run-all-gcpc-modules.sh)$"
-    spec:
-      containers:
-      # run on the lowest version of Python (with the least features) for most aggressive testing
-      - image: python:3.8
-        command:
-        - ./test/presubmit-test-run-all-gcpc-modules.sh
-
   # this test is not passing
   # - name: kubeflow-pipeline-multiuser-test
   #   cluster: build-kubeflow


### PR DESCRIPTION
Removed the KFP presubmit run-all-gcpc-modules test as it is being migrated to GHA