### PR TITLE
chore: remove all-gcpc-modules-test prow config as it's being migrated to GHA

### DIFF
--- a/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
+++ b/prow/prowjobs/kubeflow/pipelines/kubeflow-pipelines-presubmits.yaml
@@ -25,17 +25,6 @@ presubmits:
 
 # kfp.kubernetes tests
 
-  - name: test-run-all-gcpc-modules
-    cluster: build-kubeflow
-    decorate: true
-    run_if_changed: "^(sdk/python/.*)|(test/presubmit-test-run-all-gcpc-modules.sh)$"
-    spec:
-      containers:
-      # run on the lowest version of Python (with the least features) for most aggressive testing
-      - image: python:3.8
-        command:
-        - ./test/presubmit-test-run-all-gcpc-modules.sh
-
   # this test is not passing
   # - name: kubeflow-pipeline-multiuser-test
   #   cluster: build-kubeflow


### PR DESCRIPTION
remove all-gcpc-modules-test prow config as it's being migrated to GHA.  [kubeflow/piplelines/11157](https://github.com/kubeflow/pipelines/pull/11157) 
Relates to:   [kubeflow/piplelines/11154](https://github.com/kubeflow/pipelines/pull/11154) 