### PR TITLE
Add cron jobs to restart pcm/crier/sinker/deck every day

### DIFF
--- a/prow/oss/cluster/crier-kicker.yaml
+++ b/prow/oss/cluster/crier-kicker.yaml
@@ -1,0 +1,58 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: crier-kicker
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: crier-kicker
+  namespace: default
+rules:
+  - apiGroups: ["apps", "extensions"]
+    resources: ["deployments"]
+    resourceNames: ["crier"]
+    verbs: ["get", "patch", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: crier-kicker
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crier-kicker
+subjects:
+  - kind: ServiceAccount
+    name: crier-kicker
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: crier-kicker
+  namespace: default
+spec:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  schedule: "0 8 * * *" # Run at 08:00(UTC) every day.
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          serviceAccountName: crier-kicker
+          restartPolicy: Never
+          containers:
+            - name: kubectl
+              image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20230111-cd1b3caf9c
+              command:
+                - "kubectl"
+                - "-n"
+                - "default"
+                - "rollout"
+                - "restart"
+                - "deployment/crier"

--- a/prow/oss/cluster/deck-kicker.yaml
+++ b/prow/oss/cluster/deck-kicker.yaml
@@ -1,0 +1,58 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: deck-kicker
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deck-kicker
+  namespace: default
+rules:
+  - apiGroups: ["apps", "extensions"]
+    resources: ["deployments"]
+    resourceNames: ["deck"]
+    verbs: ["get", "patch", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deck-kicker
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deck-kicker
+subjects:
+  - kind: ServiceAccount
+    name: deck-kicker
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: deck-kicker
+  namespace: default
+spec:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  schedule: "30 8 * * *" # Run at 08:30(UTC) every day.
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          serviceAccountName: deck-kicker
+          restartPolicy: Never
+          containers:
+            - name: kubectl
+              image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20230111-cd1b3caf9c
+              command:
+                - "kubectl"
+                - "-n"
+                - "default"
+                - "rollout"
+                - "restart"
+                - "deployment/deck"

--- a/prow/oss/cluster/prow-controller-manager-kicker.yaml
+++ b/prow/oss/cluster/prow-controller-manager-kicker.yaml
@@ -1,0 +1,58 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prow-controller-manager-kicker
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prow-controller-manager-kicker
+  namespace: default
+rules:
+  - apiGroups: ["apps", "extensions"]
+    resources: ["deployments"]
+    resourceNames: ["prow-controller-manager"]
+    verbs: ["get", "patch", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prow-controller-manager-kicker
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prow-controller-manager-kicker
+subjects:
+  - kind: ServiceAccount
+    name: prow-controller-manager-kicker
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: prow-controller-manager-kicker
+  namespace: default
+spec:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  schedule: "0 7 * * *" # Run at 07:00(UTC) every day.
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          serviceAccountName: prow-controller-manager-kicker
+          restartPolicy: Never
+          containers:
+            - name: kubectl
+              image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20230111-cd1b3caf9c
+              command:
+                - "kubectl"
+                - "-n"
+                - "default"
+                - "rollout"
+                - "restart"
+                - "deployment/prow-controller-manager"

--- a/prow/oss/cluster/sinker-kicker.yaml
+++ b/prow/oss/cluster/sinker-kicker.yaml
@@ -1,0 +1,58 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: sinker-kicker
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sinker-kicker
+  namespace: default
+rules:
+  - apiGroups: ["apps", "extensions"]
+    resources: ["deployments"]
+    resourceNames: ["sinker"]
+    verbs: ["get", "patch", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sinker-kicker
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sinker-kicker
+subjects:
+  - kind: ServiceAccount
+    name: sinker-kicker
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sinker-kicker
+  namespace: default
+spec:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  schedule: "30 7 * * *" # Run at 07:30(UTC) every day.
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          serviceAccountName: sinker-kicker
+          restartPolicy: Never
+          containers:
+            - name: kubectl
+              image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20230111-cd1b3caf9c
+              command:
+                - "kubectl"
+                - "-n"
+                - "default"
+                - "rollout"
+                - "restart"
+                - "deployment/sinker"


### PR DESCRIPTION
This resolves an issue where components cannot perform their tasks on cluster with legacy auth due to expired credentials, resulting in authentication / authorization issues. For example, we were seeing pod creation issues from the prow-controller-manager.