### PR TITLE
bump timeout for config sync autopilot tests

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -39,7 +39,7 @@ prow_ignored:
       <<: *config-sync-base-job-container
       env:
       - name: GKE_E2E_TIMEOUT
-        value: 2h
+        value: 4h
       - name: GCP_PROJECT
         value: kpt-config-sync-ci-release
       - name: GCP_NETWORK
@@ -82,7 +82,7 @@ prow_ignored:
       <<: *config-sync-base-job-container
       env:
       - name: GKE_E2E_TIMEOUT
-        value: 2h
+        value: 4h
       - name: GCP_PROJECT
         value: kpt-config-sync-ci-release
       - name: GCP_NETWORK

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -38,7 +38,7 @@ prow_ignored:
       <<: *config-sync-base-job-container
       env:
       - name: GKE_E2E_TIMEOUT
-        value: 2h
+        value: 4h
       - name: GCP_PROJECT
         value: kpt-config-sync-ci-main
       - name: GCP_NETWORK
@@ -81,7 +81,7 @@ prow_ignored:
       <<: *config-sync-base-job-container
       env:
       - name: GKE_E2E_TIMEOUT
-        value: 2h
+        value: 4h
       - name: GCP_PROJECT
         value: kpt-config-sync-ci-main
       - name: GCP_NETWORK


### PR DESCRIPTION
It appears that new versions of autopilot (currently only in rapid channel) scale up slower, and as a result the tests are occasionally timing out. The average runtime is very close to the current 2h timeout, causing it to sometimes pass and sometimes time out.

A 4h timeout matches the current timeout set on the prow job config.