### PR TITLE
Trigger TestGrid jobs on main, not master, branch.

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-jobs.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/testgrid/testgrid-jobs.yaml
@@ -28,7 +28,7 @@ postsubmits:
   - name: push-testgrid-images
     cluster: test-infra-trusted
     branches:
-    - ^master$
+    - ^main$
     run_if_changed: '^([^c]|c[^l]|cl[^u]|clu[^s]|clus[^t]|clust[^e]|cluste[^r]).*$' # Anything outside cluster
     decorate: true
     annotations:
@@ -44,7 +44,7 @@ postsubmits:
   - name: post-testgrid-deploy-prod
     cluster: test-infra-trusted
     branches:
-    - ^master$
+    - ^main$
     run_if_changed: '^cluster/prod'
     decorate: true
     annotations:
@@ -62,7 +62,7 @@ postsubmits:
   - name: post-testgrid-deploy-canary
     cluster: test-infra-trusted
     branches:
-    - ^master$
+    - ^main$
     run_if_changed: '^cluster/canary'
     decorate: true
     annotations:
@@ -80,7 +80,7 @@ postsubmits:
   - name: testgrid-prod-autobump
     cluster: test-infra-trusted
     branches:
-    - ^master$
+    - ^main$
     run_if_changed: '^cluster/canary'
     decorate: true
     annotations:
@@ -118,7 +118,7 @@ periodics:
   extra_refs:
   - org: GoogleCloudPlatform
     repo: testgrid
-    base_ref: master
+    base_ref: main
   annotations:
     testgrid-dashboards: googleoss-test-infra
     testgrid-tab-name: autobump-testgrid-canary


### PR DESCRIPTION
We switched from a master branch to a main branch a while back in the GCP/testgrid repo, but apparently neglected to update the related jobs. (I suspect this got missed during the branch change due to other priorities / team changes around that time).

Jobs may need fixes after this is submitted, but this should at least get them up and running again.