### PR TITLE
Remove gotest from galog's presubmits

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/galog.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/galog.yaml
@@ -13,19 +13,6 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/go/main.sh"
-  - name: galog-presubmit-gotest
-    cluster: gcp-guest
-    run_if_changed: '.*\.go$'
-    trigger: "(?m)^/gotest$"
-    rerun_command: "/gotest"
-    context: prow/presubmit/gotest
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/gcp-guest/gotest:latest
-        imagePullPolicy: Always
-        command:
-        - "/go/main.sh"
   - name: galog-presubmit-gobuild
     cluster: gcp-guest
     run_if_changed: '.*\.go$'


### PR DESCRIPTION
It seems the test aren't run with root permissions, causing the persistent presubmit failures. Since these tests are already automatically run as presubmits beforehand, it should be fine to remove these.

/cc @dorileo @ChaitanyaKulkarni28 