### PR TITLE
Revert "create new clusters for autopilot-rapid tests"

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -304,7 +304,7 @@ periodics:
       args:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-9'
       - 'GKE_RELEASE_CHANNEL=rapid'
-      - 'E2E_CLUSTER_PREFIX=tmp-autopilot-rapid' # TODO: remove tmp- prefix after RCA is finished on old clusters
+      - 'E2E_CLUSTER_PREFIX=autopilot-rapid'
 
 - <<: *config-sync-autopilot-job
   name: kpt-config-sync-autopilot-rapid-latest-release
@@ -320,7 +320,7 @@ periodics:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-10'
       - 'GKE_RELEASE_CHANNEL=rapid'
       - 'GKE_CLUSTER_VERSION=latest'
-      - 'E2E_CLUSTER_PREFIX=tmp-autopilot-rapid-latest' # TODO: remove tmp- prefix after RCA is finished on old clusters
+      - 'E2E_CLUSTER_PREFIX=autopilot-rapid-latest'
 
 #### End GKE autopilot jobs
 #### Begin one-off jobs
@@ -412,7 +412,7 @@ periodics:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-11'
       - 'GKE_RELEASE_CHANNEL=rapid'
       - 'GKE_CLUSTER_VERSION=latest'
-      - 'E2E_CLUSTER_PREFIX=tmp-autopilot-rapid-latest-stress' # TODO: remove tmp- prefix after RCA is finished on old clusters
+      - 'E2E_CLUSTER_PREFIX=autopilot-rapid-latest-stress'
       - 'E2E_NUM_CLUSTERS=2' # autopilot uses more clusters to run more quickly
       - 'E2E_ARGS=--stress'
 

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -303,7 +303,7 @@ periodics:
       args:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-9'
       - 'GKE_RELEASE_CHANNEL=rapid'
-      - 'E2E_CLUSTER_PREFIX=tmp-autopilot-rapid' # TODO: remove tmp- prefix after RCA is finished on old clusters
+      - 'E2E_CLUSTER_PREFIX=autopilot-rapid'
 
 - <<: *config-sync-autopilot-job
   name: kpt-config-sync-autopilot-rapid-latest
@@ -319,7 +319,7 @@ periodics:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-10'
       - 'GKE_RELEASE_CHANNEL=rapid'
       - 'GKE_CLUSTER_VERSION=latest'
-      - 'E2E_CLUSTER_PREFIX=tmp-autopilot-rapid-latest' # TODO: remove tmp- prefix after RCA is finished on old clusters
+      - 'E2E_CLUSTER_PREFIX=autopilot-rapid-latest'
 
 #### End GKE autopilot jobs
 #### Begin one-off jobs
@@ -411,7 +411,7 @@ periodics:
       - 'GCP_SUBNETWORK=prow-e2e-subnetwork-11'
       - 'GKE_RELEASE_CHANNEL=rapid'
       - 'GKE_CLUSTER_VERSION=latest'
-      - 'E2E_CLUSTER_PREFIX=tmp-autopilot-rapid-latest-stress' # TODO: remove tmp- prefix after RCA is finished on old clusters
+      - 'E2E_CLUSTER_PREFIX=autopilot-rapid-latest-stress'
       - 'E2E_NUM_CLUSTERS=2' # autopilot uses more clusters to run more quickly
       - 'E2E_ARGS=--stress'
 


### PR DESCRIPTION
This reverts commit 8698884a1f6b4b89e05e439936dadd67e35350db.

Reason for revert: RCA is complete for these clusters, so the tests can switch back to the original cluster names.