### PR TITLE
Bind sinker to the same GSA as prow-controller-manager.

### DIFF
--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -120,6 +120,8 @@ kind: ServiceAccount
 metadata:
   name: sinker
   namespace: default
+  annotations:
+    "iam.gke.io/gcp-service-account": "oss-prow@oss-prow.iam.gserviceaccount.com"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
I noticed that sinker can't connect to some build clusters, presumably due to switching auth for those clusters to rely on workload identity since sinker is missing that.

I've already granted `roles/iam.workloadIdentityUser` to `oss-prow.svc.id.goog[default/sinker]` so this should take affect after this PR merges and we restart sinker.

/assign @michelle192837 