### PR TITLE
Update gcp-guest-config.yaml

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -491,11 +491,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-centos
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -509,17 +509,17 @@ periodics:
 # Please keep this field ordered by version order and arch (eg 7 -> 8 amd64 -> 8 arm64 -> 9 amd64 -> 9 arm64).
       - "-images=projects/centos-cloud/global/images/family/centos-stream-9"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
-      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
+      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec|networkperf|storageperf)$"
       - "-set_exit_status=false"
 - name: cit-periodics-debian
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-debian
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -533,17 +533,17 @@ periodics:
 # Please keep this field ordered by version order and arch (eg 7 -> 8 amd64 -> 8 arm64 -> 9 amd64 -> 9 arm64).
       - "-images=projects/debian-cloud/global/images/family/debian-11,projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
-      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
+      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec|networkperf|storageperf)$"
       - "-set_exit_status=false"
 - name: cit-periodics-opensuse
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-opensuse
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -563,11 +563,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-rhel
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -581,17 +581,17 @@ periodics:
 # Please keep this field ordered by version order (eg 7 -> 8 -> 9). Arch should go (amd64 -> arm64).
       - "-images=projects/rhel-cloud/global/images/family/rhel-8,projects/rhel-cloud/global/images/family/rhel-9,projects/rhel-cloud/global/images/family/rhel-9-arm64,"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
-      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
+      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec|networkperf|storageperf)$"
       - "-set_exit_status=false"
 - name: cit-periodics-rhel-sap
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-rhel-sap
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -611,11 +611,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-rocky
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -635,11 +635,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-sles
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -659,11 +659,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-ubuntu
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -683,11 +683,11 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-ubuntu-pro
-  interval: 6h
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -703,15 +703,15 @@ periodics:
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
       - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
       - "-set_exit_status=false"
-- name: cit-periodics-windows
+- name: cit-periodics-windows-client
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 6h
+    timeout: 8h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cit-periodics-windows
-  interval: 6h
+    testgrid-tab-name: cit-periodics-windows-client
+  interval: 8h
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest
@@ -723,7 +723,31 @@ periodics:
       - "-project=gcp-guest"
       - "-zone=us-central1-b"
 # Please keep this field ordered by Server OS then client and order by OS version release within those families.
-      - "-images=projects/windows-cloud/global/images/family/windows-2016,projects/windows-cloud/global/images/family/windows-2016-core,projects/windows-cloud/global/images/family/windows-2019,projects/windows-cloud/global/images/family/windows-2019-core,projects/windows-cloud/global/images/family/windows-2022,projects/windows-cloud/global/images/family/windows-2022-core,projects/bct-prod-images/global/images/family/windows-2025,projects/bct-prod-images/global/images/family/windows-2025-core,projects/gce-windows-client-images/global/images/family/windows-11-24h2-x64,projects/gce-windows-client-images/global/images/family/windows-11-23h2-x64,projects/gce-windows-client-images/global/images/family/windows-11-22h2-x64,projects/gce-windows-client-images/global/images/family/windows-11-21h2-x64,projects/gce-windows-client-images/global/images/family/windows-10-22h2-x64,projects/gce-windows-client-images/global/images/family/windows-10-21h2-x64"
+      - "-images=projects/gce-windows-client-images/global/images/family/windows-11-24h2-x64,projects/gce-windows-client-images/global/images/family/windows-11-23h2-x64,projects/gce-windows-client-images/global/images/family/windows-11-22h2-x64,projects/gce-windows-client-images/global/images/family/windows-11-21h2-x64,projects/gce-windows-client-images/global/images/family/windows-10-22h2-x64,projects/gce-windows-client-images/global/images/family/windows-10-21h2-x64"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
+      - "-set_exit_status=false"
+- name: cit-periodics-windows-server
+  cluster: gcp-guest
+  decorate: true
+  decoration_config:
+    timeout: 8h
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cit-periodics-windows-server
+  interval: 8h
+  spec:
+    containers:
+    - image: gcr.io/compute-image-tools/cloud-image-tests:latest
+      imagePullPolicy: Always
+      command:
+      - "/manager"
+      args:
+      - "-parallel_count=5"
+      - "-project=gcp-guest"
+      - "-zone=us-central1-b"
+# Please keep this field ordered by OS version. (2019 -> 2019 core -> 2022...)
+      - "-images=projects/windows-cloud/global/images/family/windows-2016,projects/windows-cloud/global/images/family/windows-2016-core,projects/windows-cloud/global/images/family/windows-2019,projects/windows-cloud/global/images/family/windows-2019-core,projects/windows-cloud/global/images/family/windows-2022,projects/windows-cloud/global/images/family/windows-2022-core,projects/bct-prod-images/global/images/family/windows-2025,projects/bct-prod-images/global/images/family/windows-2025-core"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
       - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
       - "-set_exit_status=false"
@@ -755,7 +779,7 @@ periodics:
       - "-storageperf_test_filter=(?i)^(([a-z][0-3])|n4)"
       - "-networkperf_test_filter=(?i)^(([a-z][0-3])|n4)"
 # Same as cit-periods, just copy and paste.
-      - "-images=projects/windows-cloud/global/images/family/windows-2016,projects/windows-cloud/global/images/family/windows-2016-core,projects/windows-cloud/global/images/family/windows-2019,projects/windows-cloud/global/images/family/windows-2019-core,projects/windows-cloud/global/images/family/windows-2022,projects/windows-cloud/global/images/family/windows-2022-core,projects/debian-cloud/global/images/family/debian-11,projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64,projects/centos-cloud/global/images/family/centos-stream-9,projects/rhel-cloud/global/images/family/rhel-8,projects/rhel-cloud/global/images/family/rhel-9,projects/rhel-cloud/global/images/family/rhel-9-arm64,projects/rocky-linux-cloud/global/images/family/rocky-linux-8,projects/rocky-linux-cloud/global/images/family/rocky-linux-8-optimized-gcp,projects/rocky-linux-cloud/global/images/family/rocky-linux-8-optimized-gcp-arm64,projects/rocky-linux-cloud/global/images/family/rocky-linux-9,projects/rocky-linux-cloud/global/images/family/rocky-linux-9-optimized-gcp,projects/rocky-linux-cloud/global/images/family/rocky-linux-9-arm64,projects/rocky-linux-cloud/global/images/family/rocky-linux-9-optimized-gcp-arm64,projects/almalinux-cloud/global/images/family/almalinux-8,projects/almalinux-cloud/global/images/family/almalinux-9,projects/opensuse-cloud/global/images/family/opensuse-leap,projects/opensuse-cloud/global/images/family/opensuse-leap-arm64,projects/suse-cloud/global/images/family/sles-12,projects/suse-cloud/global/images/family/sles-15,projects/suse-cloud/global/images/family/sles-15-arm64,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1604-lts,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1804-lts,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1804-lts,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1804-lts-arm64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts,projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts-arm64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts,projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts-arm64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-arm64,projects/bct-prod-images/global/images/family/windows-2025,projects/bct-prod-images/global/images/family/windows-2025-core"
+      - "-images=projects/windows-cloud/global/images/family/windows-2016,projects/windows-cloud/global/images/family/windows-2019,projects/windows-cloud/global/images/family/windows-2022,projects/rocky-linux-cloud/global/images/family/rocky-linux-8,projects/rocky-linux-cloud/global/images/family/rocky-linux-8-optimized-gcp,projects/rocky-linux-cloud/global/images/family/rocky-linux-8-optimized-gcp-arm64,projects/rocky-linux-cloud/global/images/family/rocky-linux-9,projects/rocky-linux-cloud/global/images/family/rocky-linux-9-optimized-gcp,projects/rocky-linux-cloud/global/images/family/rocky-linux-9-arm64,projects/rocky-linux-cloud/global/images/family/rocky-linux-9-optimized-gcp-arm64,projects/opensuse-cloud/global/images/family/opensuse-leap,projects/opensuse-cloud/global/images/family/opensuse-leap-arm64,projects/almalinux-cloud/global/images/family/almalinux-8,projects/almalinux-cloud/global/images/family/almalinux-9,projects/suse-cloud/global/images/family/sles-12,projects/suse-cloud/global/images/family/sles-15,projects/suse-cloud/global/images/family/sles-15-arm64,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1604-lts,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1804-lts,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1804-lts,projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1804-lts-arm64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts,projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts-arm64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts,projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts-arm64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64,projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-arm64,projects/bct-prod-images/global/images/family/windows-2025"
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
       - "-filter=(networkperf)|(storageperf)"
 - name: oslogin-periodics


### PR DESCRIPTION
- Changing the test interval from 6hrs to 8 hours and also setting an 8 hour timeout.
- Adding network and storage performance tests to CentOS, Debian, RHEL
- Splitting Windows into Windows Client and Windows Server

This may cause some quota issues due to the performance tests. If it does, I'll address them by getting additional quota or changing zones.

I'll add the performance tests to a small set of OS in following PRs to hopefully catch any quota issues.