### PR TITLE
Mark optional jobs in gke-networking-api.

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -110,6 +110,14 @@ tide:
     - do-not-merge/work-in-progress
     repos:
     - GoogleCloudPlatform/oss-test-infra
+  context_options:
+    orgs:
+      GoogleCloudPlatform:
+        repos:
+          gke-networking-api:
+            optional-contexts:
+              # The job is triggered only on dependabot PRs.
+              - regenerate-crds
 
 plank:
   job_url_prefix_config:


### PR DESCRIPTION
The `regenerate-crds` job is only triggered on PRs created by dependabot. This prevents automatic merges for other PRs in the GoogleCloudPlatform/gke-networking-api repository. Marking the job as optional will allow automatic merges to proceed.