### PR TITLE
Update Tide configuration to require ci-passed label for PR merges in Kubeflow repository

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -89,6 +89,18 @@ tide:
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+  - repos:
+    - kubeflow/pipelines
+    labels:
+    - lgtm
+    - approved
+    - ci-passed
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
   - orgs:
     - kubeflow
     labels:


### PR DESCRIPTION
- This PR updates the Tide configuration for the Kubeflow/Pipelines repository to enforce the requirement of a ci-passed label before allowing pull requests to be merged. 
- This change ensures that only changes with successfully passing continuous integration checks can be merged.