### PR TITLE
google-guest-agent: turn to using the build system

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/google-guest-agent.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/google-guest-agent.yaml
@@ -12,7 +12,7 @@ presubmits:
       - image: gcr.io/gcp-guest/gocheck:latest
         imagePullPolicy: Always
         command:
-        - "/go/main.sh"
+        - "V=1 make check"
   - name: google-guest-agent-presubmit-gotest
     cluster: gcp-guest
     run_if_changed: '.*'
@@ -25,7 +25,7 @@ presubmits:
       - image: gcr.io/gcp-guest/gotest:latest
         imagePullPolicy: Always
         command:
-        - "/go/main.sh"
+        - "V=1 make test"
   - name: google-guest-agent-presubmit-gobuild
     cluster: gcp-guest
     run_if_changed: '.*'
@@ -38,4 +38,4 @@ presubmits:
       - image: gcr.io/gcp-guest/gobuild:latest
         imagePullPolicy: Always
         command:
-        - "/go/main.sh"
+        - "V=1 make build"


### PR DESCRIPTION
google-guest-agent is wrapping the checks and builds into its own build system, instead of using the container provided build scripts with this change now it uses the in tree build system.