### PR TITLE
Lower accelerator specific cit-peridiocs to once per day

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -458,7 +458,8 @@ periodics:
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-accelerator-images-accelerator-tests
-  interval: 6h
+  # Run at 8PM every night to avoid conflicting with daily usage
+  cron: "00 20 * * *"
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest


### PR DESCRIPTION
We have limited capacity, we need to be more economical with how we use it. This is enough for a regression signal.

This should help our image builds find capacity more easily.

/cc @zmarano @lpleahy
