### PR TITLE
Fix accelerator cit-periodics cron

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -459,7 +459,7 @@ periodics:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-accelerator-images-accelerator-tests
   # Run at 8PM every night to avoid conflicting with daily usage
-  cron: "00 20 * * *"
+  cron: "00 04 * * *"
   spec:
     containers:
     - image: gcr.io/compute-image-tools/cloud-image-tests:latest


### PR DESCRIPTION
The timezone for this is UTC so it needs to run at 0400 UTC to run at 8PM pacific.

/cc @zmarano @lpleahy 