### PR TITLE
chore: bump gke-e2e version for config sync e2e

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -15,7 +15,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-base-job-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.22.5-gcloud449.0.0-docker20.10.14
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.23.4-gcloud449.0.0-docker20.10.14
       command:
       - make
       - test-e2e-gke-ci

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -14,7 +14,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-base-job-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.22.5-gcloud449.0.0-docker20.10.14
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.23.4-gcloud449.0.0-docker20.10.14
       command:
       - make
       - test-e2e-gke-ci


### PR DESCRIPTION
The primary motivation is to pick up Go version 1.23