### PR TITLE
Update A3Ultra reservation name for accelerator periodics

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -479,7 +479,7 @@ periodics:
       - "-set_exit_status=false"
       - "-compute_endpoint_override=https://www.googleapis.com/compute/alpha/"
       - "-use_reservations=true"
-      - "-reservation_urls=guestos-a3u-gsc"
+      - "-reservation_urls=image-exfr-2"
 - name: cit-periodics-accelerator-images
   cluster: gcp-guest
   decorate: true


### PR DESCRIPTION
The reservation was deleted and recreated. guestos-a3u-gsc no longer exists

/hold
/cc @zmarano @jjerger 