### PR TITLE
Add milestone plugin to Kubeflow

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -347,6 +347,7 @@ plugins:
     - label
     - lgtm
     - lifecycle   # Lets PRs & issues be flagged as stale
+    - milestone # Applies a milestone for issues or PRs.
     - override
     - project # Lets issues be tagged into projects
     - retitle


### PR DESCRIPTION
I would like to enable milestone plugin for Kubeflow org: https://prow.k8s.io/command-help#milestone

That allows us to automatically assign Issues/PRs to the release milestones.

/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins


/cc @rimolive @thesuperzapper @terrytangyuan @tenzen-y