### PR TITLE
Revert oracle-toolkit Ansible runner version

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/OWNERS
+++ b/prow/prowjobs/google/oracle-toolkit/OWNERS
@@ -4,3 +4,5 @@
 approvers:
 - jcnars
 - mfielding
+- alexbasinov
+- patelmithlesh

--- a/prow/prowjobs/google/oracle-toolkit/OWNERS
+++ b/prow/prowjobs/google/oracle-toolkit/OWNERS
@@ -5,4 +5,3 @@ approvers:
 - jcnars
 - mfielding
 - alexbasinov
-- patelmithlesh

--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -9,7 +9,7 @@ presubmits:
     spec:
       hostNetwork: true
       containers:
-      - image: quay.io/ansible/ansible-runner:stable-2.11-latest
+      - image: quay.io/ansible/ansible-runner:stable-2.9-latest
         command:
         # . represents the base directory of the cloned oracle-toolkit repo, which is oracle-toolkit
         - ./presubmit_tests/test-pr-poc.sh


### PR DESCRIPTION
When run with ansible 2.11, tests are failing with the error

```
ERROR! couldn't resolve module/action 'mount'. This often indicates a
misspelling, missing collection, or incorrect module path.

The error appears to be in
'/home/prow/go/src/github.com/google/oracle-toolkit/roles/brute-ora-cleanup/tasks/main.yml':
line 231, column 3, but may be elsewhere in the file depending on the exact syntax problem.
```

Testing with 2.12 I see the same error, but in 2.9, the error goes away. So for now let's revert to 2.9 to unblock tests.

Successful output (internal):
https://paste.googleplex.com/4939247786917888?raw