### PR TITLE
Rename kubeflow/training-operator to kubeflow/trainer

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -63,7 +63,7 @@ approve:
   - kubeflow/pipelines
   - kubeflow/spark-operator
   - kubeflow/testing
-  - kubeflow/training-operator
+  - kubeflow/trainer
   - kubeflow/website
   require_self_approval: true
   commandHelpLink: https://oss.gprow.dev/command-help


### PR DESCRIPTION
Part of: https://github.com/kubeflow/training-operator/issues/2402

These changes are required to rename `kubeflow/training-operator` to `kubeflow/trainer`

cc @kubeflow/kubeflow-steering-committee @franciscojavierarceo @juliusvonkohout @kubeflow/wg-training-leads @Electronic-Waste @astefanutti @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins

/hold for review