### PR TITLE
Fix create-build-cluster.sh Prow SA binding to test cluster.

### DIFF
--- a/prow/oss/create-build-cluster.sh
+++ b/prow/oss/create-build-cluster.sh
@@ -183,7 +183,7 @@ function ensureUploadSA() {
   fi
 
   # Create a k8s service account to associate with the GCP service account
-  if ! kubectl -n test-pods get ${sa}; then
+  if ! kubectl -n test-pods get serviceaccount ${sa}; then
     kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
@@ -244,6 +244,7 @@ function gencreds() {
   # Generate entries to add to the kubeconfigs.yaml file.
   local kubeconfigs="$(git rev-parse --show-toplevel)/${PROW_DEPLOYMENT_DIR}/kubeconfigs/kubeconfigs.yaml"
   export KUBECONFIG="${tempdir}/kubeconfig.yaml" 
+  authed="" # Force getClusterCreds to run again with the temporary KUBECONFIG.
   getClusterCreds
 
   echo

--- a/prow/oss/create-build-cluster.sh
+++ b/prow/oss/create-build-cluster.sh
@@ -238,7 +238,7 @@ function gencreds() {
   # Grant the Prow control plane access to the cluster.
   for i in ${CONTROL_PLANE_SA//,/ }
   do
-    gcloud projects add-iam-policy-binding "${PROJECT}" --member="${i}" --role="roles/container.developer"
+    gcloud projects add-iam-policy-binding "${PROJECT}" --member="serviceAccount:${i}" --role="roles/container.developer"
   done
 
   # Generate entries to add to the kubeconfigs.yaml file.
@@ -253,6 +253,7 @@ function gencreds() {
   grep -B 1 -A 2 certificate-authority-data "${KUBECONFIG}"
   echo
   echo "Append the following entry to the 'contexts' section: "
+  echo
   cat <<EOF
   - context:
       cluster: $(kubectl config current-context)


### PR DESCRIPTION
Oops, I forgot to retest after adding the `roles/container.developer` IAM grant.
I've fixed this bug and validated:
```
ERROR: (gcloud.projects.add-iam-policy-binding) INVALID_ARGUMENT: Policy members must be of the form "<type>:<value>".
- '@type': type.googleapis.com/google.rpc.BadRequest
  fieldViolations:
  - description: Policy members must be prefixed of the form '<type>:<value>', where
      <type> is 'domain', 'group', 'serviceAccount', or 'user'.
    field: policy.bindings.member
```
/assign @AlexBasinov @simony-gke 