### PR TITLE
Fix broken links to old Prow source location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ limitations under the License.
 
 # OSS PROW
 
-- OSS [prow](https://github.com/kubernetes/test-infra/tree/master/prow) config for google-owned OSS projects
+- OSS [prow](https://github.com/kubernetes-sigs/prow) config for google-owned OSS projects
 - See what jobs are running on the [Prow Deck](https://oss.gprow.dev/)
 - Please follow [onboarding.md](./prow/oss/onboarding.md) to onboard 
 - [Learn how to configure new Prow Jobs](https://docs.prow.k8s.io/docs/jobs/#how-to-configure-new-jobs) 

--- a/prow/oss/README.md
+++ b/prow/oss/README.md
@@ -1,4 +1,4 @@
-See [upstream prow](https://github.com/kubernetes/test-infra/tree/master/prow) documentation for more detailed and generic information about what prow is and how it works.
+See [upstream prow](https://github.com/kubernetes-sigs/prow) documentation for more detailed and generic information about what prow is and how it works.
 
 ## Onboarding
 
@@ -12,7 +12,7 @@ for ongoing/histories. This is configured as
 [`ci-oss-test-infra-autobump-prow`](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/49cc9a1bff81427ea8f10b9625269be7a9cf3ae0/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml#L335)
 job.
 
-Please check recent [prow announcements](https://github.com/kubernetes/test-infra/tree/master/prow#announcements) before updating, if you are not already familiar with them.
+Please check recent [prow announcements](https://docs.prow.k8s.io/docs/announcements/) before updating, if you are not already familiar with them.
 
 ```shell
 prow/bump.sh --latest
@@ -103,4 +103,4 @@ kubectl --context=oss-prow create -f ~/foo.yaml
 Some of the prow secrets are managed by kubernetes external secrets, which
 allows prow cluster creating secrets based on values from google secret manager
 (Not necessarily the same GCP project where prow is located). See more detailed
-instruction at [Prow Secret](https://github.com/kubernetes/test-infra/blob/master/prow/prow_secrets.md).
+instruction at [Prow Secret](https://docs.prow.k8s.io/docs/prow-secrets/).

--- a/prow/oss/onboarding.md
+++ b/prow/oss/onboarding.md
@@ -97,8 +97,8 @@ https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys
 https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
 [set up ssh key for cloning]: https://github.com/kubernetes/test-infra/blob/b86dee86579b993b54cb295cfd77feab129d15bb/prow/pod-utilities.md#how-to-configure
 [Prow config example PR]: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/376
-[documented Prow config]: https://github.com/kubernetes/test-infra/blob/master/prow/config/prow-config-documented.yaml
+[documented Prow config]: https://github.com/kubernetes-sigs/prow/blob/e8fa16f56508b4209238eb956d0d02143dd0d56b/pkg/config/prow-config-documented.yaml#L4
 [prow job example pr]: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/375
-[How to add new jobs]: https://github.com/kubernetes/test-infra/tree/master/prow/jobs.md#how-to-configure-new-jobs
-[Pod-utilities]: https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md
-[Testing prow jobs]: https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#How-to-test-a-ProwJob
+[How to add new jobs]: https://docs.prow.k8s.io/docs/jobs/#how-to-configure-new-jobs
+[Pod-utilities]: https://docs.prow.k8s.io/docs/components/pod-utilities/
+[Testing prow jobs]: https://docs.prow.k8s.io/docs/build-test-update/#how-to-test-a-prowjob


### PR DESCRIPTION
I looked for any links to github.com/kubernetes/test-infra and replaced ones that were not permalinked with the updated URLs.

/assign @simony-gke 