### PR TITLE
Add the machine shape argument to accelerator tests

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -480,6 +480,7 @@ periodics:
       - "-compute_endpoint_override=https://www.googleapis.com/compute/alpha/"
       - "-use_reservations=true"
       - "-reservation_urls=image-exfr-2"
+      - "-x86_shape=a3-ultragpu-8g"
 - name: cit-periodics-accelerator-images
   cluster: gcp-guest
   decorate: true


### PR DESCRIPTION
Previously the machine shape was hard coded into the test suite. We want to make it generic, so the first step is to pass in the machine shape argument.