### PR TITLE
Stop LGTM acting as approve in Kubeflow

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -47,24 +47,11 @@ approve:
 - repos:
   - GoogleCloudPlatform/k8s-config-connector
   - GoogleContainerTools
-  - kubeflow/arena
-  - kubeflow/blog
-  - kubeflow/community
-  - kubeflow/dashboard
-  - kubeflow/examples
-  - kubeflow/internal-acls
-  - kubeflow/katib
-  - kubeflow/kfp-tekton
-  - kubeflow/kubeflow
-  - kubeflow/manifests
-  - kubeflow/model-registry
-  - kubeflow/mpi-operator
-  - kubeflow/notebooks
-  - kubeflow/pipelines
-  - kubeflow/spark-operator
-  - kubeflow/testing
-  - kubeflow/trainer
-  - kubeflow/website
+  require_self_approval: true
+  commandHelpLink: https://oss.gprow.dev/command-help
+- repos:
+  - kubeflow
+  lgtm_acts_as_approve: false
   require_self_approval: true
   commandHelpLink: https://oss.gprow.dev/command-help
 


### PR DESCRIPTION
Currently in the Kubeflow org, we have issues with people LGTMing PRs that are in root approvers, causing the PR to merge immediately.

So we can separate the idea of LGTM and APPROVE, this PR makes it so that an LGTM does not also APPROVE.

It also makes it so that we don't have to explicitly list out our repos anymore, an just applies the configs to the whole `kubeflow` org.