### PR TITLE
kpt-config-sync: more nodes for stress tests

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -395,7 +395,9 @@ periodics:
       - 'GKE_CLUSTER_VERSION=latest'
       - 'E2E_CLUSTER_PREFIX=standard-rapid-latest-stress'
       - 'E2E_NUM_CLUSTERS=1'
-      - 'GKE_MACHINE_TYPE=n2-standard-8' # stress test uses bigger nodes to run more quickly
+      - 'GKE_NUM_NODES=4' # Stress tests need more nodes for scheduling pods
+      - 'GKE_MACHINE_TYPE=n2-standard-4'
+      - 'GKE_DISK_SIZE=25Gb'
       - 'E2E_ARGS=--stress'
 
 - <<: *config-sync-autopilot-job


### PR DESCRIPTION
The stress tests need enough nodes to schedule 1,000 pods. The pods are small, but each node has a 110 pod limit. Control plane initial scale is dependent on number of vCPUs, so fewer cores per node should work with more nodes.

Since the stress tests extend the non-stress test template, I've hard coded the values in the stress config, so we can remove them from the non-stress test template later, and fall back to dynamic defaults in the test code.