### PR TITLE
chore: bump kubekins-e2e for Config Sync jobs

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -124,7 +124,7 @@ periodics:
   spec:
     containers:
     # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-1.30
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.31
       command:
       - runner.sh
       args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -123,7 +123,7 @@ periodics:
   spec:
     containers:
     # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-1.30
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.31
       command:
       - runner.sh
       args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
@@ -20,9 +20,8 @@ postsubmits:
     spec:
       serviceAccountName: postsubmit-runner
       containers:
-      # TODO: Switch back to a k8s-versioned release, once Go 1.21 is available there
       # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-go-canary
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.31
         command:
         - runner.sh
         args:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -25,7 +25,7 @@ prow_ignored:
     containers:
     - &config-sync-e2e-container
       # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-1.30
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.31
       command:
       - runner.sh
       securityContext:
@@ -55,7 +55,7 @@ presubmits:
     spec:
       containers:
       # https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml
-      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-1.30
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20250227-3a13bdd784-1.31
         command:
         - runner.sh
         args:


### PR DESCRIPTION
This bumps the kubekins-e2e image used by the Config Sync jobs to the current latest k8s 1.31 image.