### PR TITLE
kpt-config-sync: more stress test nodes

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -395,8 +395,8 @@ periodics:
       - 'GKE_CLUSTER_VERSION=latest'
       - 'E2E_CLUSTER_PREFIX=standard-rapid-latest-stress'
       - 'E2E_NUM_CLUSTERS=1'
-      - 'GKE_NUM_NODES=4' # Stress tests need more nodes for scheduling pods
-      - 'GKE_MACHINE_TYPE=n2-standard-4'
+      - 'GKE_NUM_NODES=5' # TestStressManyDeployments needs 50cpu & 51GiB for pods (13 nodes)
+      - 'GKE_MACHINE_TYPE=n2-standard-4' # 3.9cpu & 13.9GB allocatable
       - 'GKE_DISK_SIZE=25Gb'
       - 'E2E_ARGS=--stress'
       resources:


### PR DESCRIPTION
TestStressManyDeployments needs at least 13x 4cpu  nodes to have enough cpu for 1k pods requesting 50m each.