### PR TITLE
Remove all references to the old build cluster

### DIFF
--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -37,7 +37,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
+          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -49,9 +49,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/build-openshift-eng
           name: build-openshift-eng
-          readOnly: true
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
           readOnly: true
         - mountPath: /etc/build-cloud-kubernetes-node-management-team
           name: build-cloud-kubernetes-node-management-team
@@ -91,10 +88,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-openshift-eng
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-cloud-kubernetes-node-management-team
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
+          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: http
           containerPort: 8080
@@ -52,9 +52,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/build-openshift-eng
           name: build-openshift-eng
-          readOnly: true
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
           readOnly: true
         - mountPath: /etc/build-cloud-kubernetes-node-management-team
           name: build-cloud-kubernetes-node-management-team
@@ -113,10 +110,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-openshift-eng
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-cloud-kubernetes-node-management-team
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/deck_blueprints_deployment.yaml
+++ b/prow/oss/cluster/deck_blueprints_deployment.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
+          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: http
           containerPort: 8080
@@ -53,9 +53,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/build-openshift-eng
           name: build-openshift-eng
-          readOnly: true
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
           readOnly: true
         - mountPath: /etc/build-cloud-kubernetes-node-management-team
           name: build-cloud-kubernetes-node-management-team
@@ -161,10 +158,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-openshift-eng
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-cloud-kubernetes-node-management-team
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
+          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/build-kubeflow/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
@@ -53,9 +53,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/build-openshift-eng
           name: build-openshift-eng
-          readOnly: true
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
           readOnly: true
         - mountPath: /etc/build-cloud-kubernetes-node-management-team
           name: build-cloud-kubernetes-node-management-team
@@ -118,10 +115,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-openshift-eng
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-cloud-kubernetes-node-management-team
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/kubernetes_external_secrets.yaml
+++ b/prow/oss/cluster/kubernetes_external_secrets.yaml
@@ -170,19 +170,6 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: kubeconfig-build-bms-oracle-team
-  namespace: default
-spec:
-  backendType: gcpSecretsManager
-  projectId: oss-prow
-  data:
-  - key: prow_build_cluster_kubeconfig_build-bms-oracle-team
-    name: kubeconfig
-    version: latest
----
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
   name: kubeconfig-build-openshift-eng
   namespace: default
 spec:

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -28,16 +28,13 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to append multiple configs.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
+          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
         - mountPath: /etc/build-openshift-eng
           name: build-openshift-eng
-          readOnly: true
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
           readOnly: true
         - mountPath: /etc/build-cloud-kubernetes-node-management-team
           name: build-cloud-kubernetes-node-management-team

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -68,10 +68,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-openshift-eng
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-cloud-kubernetes-node-management-team
         secret:
           defaultMode: 420

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -27,16 +27,13 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-bms-oracle-team/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
+          value: "/etc/kubeconfig/config-20240403:/etc/build-openshift-eng/kubeconfig:/etc/build-cloud-kubernetes-node-management-team/kubeconfig:/etc/build-kpt-config-sync/kubeconfig:/etc/build-compute-image-import/kubeconfig:/etc/build-blueprints/kubeconfig:/etc/build-elcarro/kubeconfig:/etc/gke-gcloud-auth-plugin-based/kubeconfigs.yaml"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
         - mountPath: /etc/build-openshift-eng
           name: build-openshift-eng
-          readOnly: true
-        - mountPath: /etc/build-bms-oracle-team
-          name: build-bms-oracle-team
           readOnly: true
         - mountPath: /etc/build-cloud-kubernetes-node-management-team
           name: build-cloud-kubernetes-node-management-team
@@ -70,10 +67,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-openshift-eng
-      - name: build-bms-oracle-team
-        secret:
-          defaultMode: 420
-          secretName: kubeconfig-build-bms-oracle-team
       - name: build-cloud-kubernetes-node-management-team
         secret:
           defaultMode: 420

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -175,12 +175,6 @@ plank:
         bucket: "oss-prow"
       default_service_account_name: "prowjob-default-sa" # Use workload identity
       gcs_credentials_secret: ""                         # rather than service account key secret
-  - cluster: build-bms-oracle-team
-    config:
-      gcs_configuration:
-        bucket: "bmaas-testing-prow-bucket"
-      default_service_account_name: "prowjob-default-sa" # Use workload identity
-      gcs_credentials_secret: ""                         # rather than service account key secret
   - cluster: build-compute-image-import
     config:
       gcs_configuration:

--- a/prow/oss/gencred-config/gencred-config.yaml
+++ b/prow/oss/gencred-config/gencred-config.yaml
@@ -5,12 +5,6 @@ clusters:
   gsm:
     name: prow_build_cluster_kubeconfig_build-openshift-eng
     project: oss-prow
-- gke: projects/bmaas-testing/locations/southamerica-east1-b/clusters/bms-orcl-prow-sydrp
-  name: build-bms-oracle-team
-  duration: 48h
-  gsm:
-    name: prow_build_cluster_kubeconfig_build-bms-oracle-team
-    project: oss-prow
 - gke: projects/gke-accel-cntnr-ng-tests/locations/us-west1-b/clusters/gke-accel-cntnr-ng-tests
   name: build-cloud-kubernetes-node-management-team
   duration: 48h


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2458, we registered a new build cluster to run presubmit jobs. However, these jobs are now failing with the following error:

"Terminal error: nonretryable error: no build client found for cluster
    alias "build-gcp-oracle-team". If this was previously working, then it''s likely
    that the credentials expired, there was a CA cert expiry, or we cannot reach your
    cluster API for some other reason."

Failed prow job for reference: [Prow job link ](https://oss.gprow.dev/prowjob?prowjob=c4b45b30-4535-4b21-a924-dddba384ab01)

Based on an internal Q&A thread, filing this PR to remove the old cluster context from the legacy kubeconfig secret to address the issue.