### PR TITLE
feat(kubeflow): Enable milestoneapplier plugin and milestone team

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -83,6 +83,15 @@ label:
   # This is used to triage issues in Kubeflow repositories.
   - lifecycle/needs-triage
 
+repo_milestone:
+  kubeflow/trainer:
+    maintainers_team: kubeflow-trainer-maintainers
+    maintainers_friendly_name: Kubeflow Trainer Maintainers
+
+milestone_applier:
+  kubeflow/trainer:
+    master: v2.0
+
 plugins:
   GoogleCloudPlatform:
     plugins:
@@ -336,6 +345,7 @@ plugins:
     - lgtm
     - lifecycle   # Lets PRs & issues be flagged as stale
     - milestone # Applies a milestone for issues or PRs.
+    - milestoneapplier
     - override
     - project # Lets issues be tagged into projects
     - retitle


### PR DESCRIPTION
This should allow `kubeflow-trainer-maintainers` GitHub team to apply milestones for the Kubeflow Trainer project.
We can create this team without `write` access to the repo, which will allow maintainers to use `/milestone` command.

Does it sound good to you @terrytangyuan @johnugeorge @Electronic-Waste @tenzen-y @rimolive @varodrig  @astefanutti?

/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins