### PR TITLE
Treat GH approve as LGTM for kubeflow org

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -53,6 +53,9 @@ approve:
   - kubeflow
   lgtm_acts_as_approve: false
   require_self_approval: true
+  # We treat GitHub approve as LGTM (not approve) to avoid accidental merges.
+  # Note, we set `review_acts_as_lgtm=true` in `lgtm` plugin.
+  ignore_review_state: true
   commandHelpLink: https://oss.gprow.dev/command-help
 
 blunderbuss:
@@ -73,6 +76,11 @@ lgtm:
   - GoogleCloudPlatform/testgrid
   review_acts_as_lgtm: true
   trusted_team_for_sticky_lgtm: 'TestGrid Admins'
+- repos:
+  - kubeflow
+  # We treat GitHub approve as LGTM (not approve) to avoid accidental merges.
+  # Note, we also set `ignore_review_state=true` in `approve` plugin.
+  review_acts_as_lgtm: true
 
 label:
   additional_labels:


### PR DESCRIPTION
This PR updates the Kubeflow org config so using the GitHub review is treated as an LGTM / LGTM-cancel rather than an approve.

This is to avoid accidental merges by root approvers who use the GH review to say they have looked at it and are happy, and means that people now have to explicitly `/approve` to merge a PR.