### PR TITLE
fix(kubeflow): rename kubeflow-trainer-maintainers to kubeflow-trainer-team

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -93,8 +93,8 @@ label:
 
 repo_milestone:
   kubeflow/trainer:
-    maintainers_team: kubeflow-trainer-maintainers
-    maintainers_friendly_name: Kubeflow Trainer Maintainers
+    maintainers_team: kubeflow-trainer-team
+    maintainers_friendly_name: Kubeflow Trainer Team
 
 milestone_applier:
   kubeflow/trainer:


### PR DESCRIPTION
As we discussed in https://github.com/kubeflow/internal-acls/pull/766#discussion_r2046453042, we decided to rename `kubeflow-trainer-maintainers` to `kubeflow-trainer-team`.

/cc @terrytangyuan @johnugeorge @andreyvelich @tenzen-y @rimolive @varodrig @astefanutti
/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins