### PR TITLE
Add milestone for Kubeflow SDK

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -95,10 +95,15 @@ repo_milestone:
   kubeflow/trainer:
     maintainers_team: kubeflow-trainer-team
     maintainers_friendly_name: Kubeflow Trainer Team
+  kubeflow/sdk:
+    maintainers_team: kubeflow-trainer-team
+    maintainers_friendly_name: Kubeflow Trainer Team
 
 milestone_applier:
   kubeflow/trainer:
     master: v2.0
+  kubeflow/sdk:
+    main: v0.1
 
 plugins:
   GoogleCloudPlatform:


### PR DESCRIPTION
This adds v0.1 milestone for Kubeflow SDK repository.

For now, we will use the kubeflow trainer team to apply milestone.


cc @franciscojavierarceo @terrytangyuan @astefanutti @Electronic-Waste @tenzen-y