### PR TITLE
Add milestone for Kubeflow Community repo

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -98,6 +98,9 @@ repo_milestone:
   kubeflow/sdk:
     maintainers_team: kubeflow-trainer-team
     maintainers_friendly_name: Kubeflow Trainer Team
+  kubeflow/community:
+    maintainers_team: kubeflow-outreach-committee
+    maintainers_friendly_name: Kubeflow Outreach Committee
 
 milestone_applier:
   kubeflow/trainer:


### PR DESCRIPTION
This adds v1.0 milestone for Kubeflow Community repository.

For now, we will use the Kubeflow Outreach Committee to apply milestone.

cc @franciscojavierarceo @andreyvelich 