### PR TITLE
chore: update stress test job definition

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -396,7 +396,9 @@ periodics:
       - 'GKE_CLUSTER_VERSION=latest'
       - 'E2E_CLUSTER_PREFIX=standard-rapid-latest-stress'
       - 'E2E_NUM_CLUSTERS=1'
-      - 'GKE_MACHINE_TYPE=n2-standard-8' # stress test uses bigger nodes to run more quickly
+      - 'GKE_NUM_NODES=5' # Stress tests need more nodes for scheduling pods
+      - 'GKE_MACHINE_TYPE=n2-standard-4'
+      - 'GKE_DISK_SIZE=25Gb'
       - 'E2E_ARGS=--stress'
 
 - <<: *config-sync-autopilot-job

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -395,7 +395,7 @@ periodics:
       - 'GKE_CLUSTER_VERSION=latest'
       - 'E2E_CLUSTER_PREFIX=standard-rapid-latest-stress'
       - 'E2E_NUM_CLUSTERS=1'
-      - 'GKE_NUM_NODES=4' # Stress tests need more nodes for scheduling pods
+      - 'GKE_NUM_NODES=5' # Stress tests need more nodes for scheduling pods
       - 'GKE_MACHINE_TYPE=n2-standard-4'
       - 'GKE_DISK_SIZE=25Gb'
       - 'E2E_ARGS=--stress'


### PR DESCRIPTION
This updates the main branch definition to be consistent with the actual current configuration, and updates the release branch to be consistent with the main branch after updating the base_ref.