### PR TITLE
Enable Workload Identity for ansible-runner Pod

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -19,7 +19,6 @@ presubmits:
     decorate: true
     spec:
       serviceAccountName: prowjob-default-sa
-      hostNetwork: true
       containers:
       - image: quay.io/ansible/ansible-runner:stable-2.9-latest
         command:


### PR DESCRIPTION
Remove the `hostNetwork: true` parameter from the `ansible-runner` Pod spec in order to enable Workload Identity.

As per the [official documentation on Workload Identity restrictions](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#restrictions):

> Caution: Pods running on the [host network](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hosts-namespaces) (hostNetwork: true) don't use Workload Identity Federation for GKE. GKE automatically routes requests from these Pods to the Compute Engine metadata server.


Internal bug: b/414410133