### PR TITLE
Use different SSH keys for RAC and single-instance setup

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -36,10 +36,10 @@ presubmits:
         projected:
           sources:
           - secret:
-              name: ansible-ssh-private-key
+              name: single-instance-ansible-private-ssh-key
               items:
-                - key: ansible_ssh_private_key
-                  path: id_rsa_bms_tk_key
+                - key: ansible_private_ssh_key
+                  path: ansible_private_ssh_key
                   mode: 0400
           - configMap:
               name: single-instance-asm
@@ -86,10 +86,10 @@ presubmits:
         projected:
           sources:
           - secret:
-              name: ansible-ssh-private-key
+              name: rac-ansible-private-ssh-key
               items:
-                - key: ansible_ssh_private_key
-                  path: id_rsa_bms_tk_key
+                - key: ansible_private_ssh_key
+                  path: ansible_private_ssh_key
                   mode: 0400
           - configMap:
               name: rac-asm


### PR DESCRIPTION
This PR updates the Pods specs to use separate SSH keys for RAC and single-instance setups.

This change provides a safety mechanism to reduce the risk of accidentally connecting to the wrong BMS machine. It also makes it harder for someone with access to one machine to connect to others.