### PR TITLE
Update GKE E2E test image version to v2.0.0-go1.24.3-gcloud513...

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -15,7 +15,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-base-job-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.23.4-gcloud449.0.0-docker20.10.14
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.24.3-gcloud513.0.0-docker20.10.14
       command:
       - make
       - test-e2e-gke-ci

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -14,7 +14,7 @@ prow_ignored:
     serviceAccountName: e2e-test-runner
     containers:
     - &config-sync-base-job-container
-      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.23.4-gcloud449.0.0-docker20.10.14
+      image: us-docker.pkg.dev/kpt-config-sync-ci-artifacts/test-infra/gke-e2e:v2.0.0-go1.24.3-gcloud513.0.0-docker20.10.14
       command:
       - make
       - test-e2e-gke-ci


### PR DESCRIPTION
This pull request updates the container image versions used in two Prow job configuration files to ensure compatibility with newer dependencies.
