### PR TITLE
Update cadence and timeout for cleanerupper

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -6,10 +6,10 @@ periodics:
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cleanerupper
-  interval: 1h
+  interval: 2h
   agent: kubernetes
   spec:
-    activeDeadlineSeconds: 1800
+    activeDeadlineSeconds: 3600
     containers:
     - image: gcr.io/gcp-guest/cleanerupper:latest
       command:


### PR DESCRIPTION
I've found it isn't completing in the original 30 minute window so I'm going to bump it to 1 hour, with another hour inbetween runs. I don't think this needed to run hourly.