### PR TITLE
Update cleanerupper timeout to 1h45m

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
   interval: 2h
   agent: kubernetes
   spec:
-    activeDeadlineSeconds: 3600
+    activeDeadlineSeconds: 6300
     containers:
     - image: gcr.io/gcp-guest/cleanerupper:latest
       command:


### PR DESCRIPTION
There's no reason we can't push it all the way until almost the next run.