### PR TITLE
Update cleanerupper prow jobs to be more scoped down

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -1,11 +1,11 @@
 # Periodics from legacy prow cluster
 periodics:
-- name: cleanerupper-cep
+- name: cleanerupper-cloud-cluster-guest-kms-cep
   cluster: gcp-guest
   decorate: true
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cleanerupper-cep
+    testgrid-tab-name: cleanerupper-cloud-cluster-guest-kms-cep
   interval: 2h
   agent: kubernetes
   spec:
@@ -26,12 +26,12 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''
-- name: cleanerupper-compute-image-test-pools
+- name: cleanerupper-compute-image-test-pool-001
   cluster: gcp-guest
   decorate: true
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cleanerupper-compute-image-test-pools
+    testgrid-tab-name: cleanerupper-compute-image-test-pool-001
   interval: 2h
   agent: kubernetes
   spec:
@@ -50,11 +50,207 @@ periodics:
       - "-load_balancers=true"
       - "-networks=true"
       - "-snapshots=true"
-      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-test-pool-001-1,compute-image-test-pool-001-2,compute-image-test-custom-vpc"
+      - "-projects=compute-image-test-pool-001"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''
-- name: cleanerupper-osconfig-projects
+- name: cleanerupper-compute-image-test-pool-002
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-compute-image-test-pool-002
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-test-pool-002"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-compute-image-test-pool-003
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-compute-image-test-pool-003
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-test-pool-003"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-compute-image-test-pool-004
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-compute-image-test-pool-004
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-test-pool-004"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-compute-image-test-pool-005
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-compute-image-test-pool-005
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-test-pool-005"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-compute-image-test-pool-001-1
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-compute-image-test-pool-001-1
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-test-pool-001-1"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-compute-image-test-pool-001-2
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-compute-image-test-pool-001-2
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-test-pool-001-2"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-compute-image-test-custom-vpc
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-compute-image-test-custom-vpc
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-test-custom-vpc"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-osconfig-agent
   cluster: gcp-guest
   decorate: true
   annotations:
@@ -78,7 +274,63 @@ periodics:
       - "-load_balancers=true"
       - "-networks=true"
       - "-snapshots=true"
-      - "-projects=compute-image-osconfig-agent,compute-image-osconfig-agent-2,oslogin-cit"
+      - "-projects=compute-image-osconfig-agent"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-osconfig-agent-2
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-osconfig-agent-2
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-osconfig-agent-2"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-oslogin-cit
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-oslogin-cit
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=oslogin-cit"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -5,7 +5,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cleanerupper
+    testgrid-tab-name: cleanerupper-cep
   interval: 2h
   agent: kubernetes
   spec:
@@ -31,7 +31,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cleanerupper
+    testgrid-tab-name: cleanerupper-compute-image-test-pools
   interval: 2h
   agent: kubernetes
   spec:
@@ -59,7 +59,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cleanerupper
+    testgrid-tab-name: cleanerupper-osconfig-projects
   interval: 2h
   agent: kubernetes
   spec:
@@ -87,7 +87,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
-    testgrid-tab-name: cleanerupper-osconfig
+    testgrid-tab-name: cleanerupper-osconfig-policies
   interval: 5h
   agent: kubernetes
   spec:

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -1,6 +1,32 @@
 # Periodics from legacy prow cluster
 periodics:
-- name: cleanerupper
+- name: cleanerupper-cep
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-snapshots=true"
+      - "-projects=cloud-cluster-guest-kms-cep"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-compute-image-test-pools
   cluster: gcp-guest
   decorate: true
   annotations:
@@ -24,11 +50,39 @@ periodics:
       - "-load_balancers=true"
       - "-networks=true"
       - "-snapshots=true"
-      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2,guestos-metadata-scanner,oslogin-cit"
+      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-test-pool-001-1,compute-image-test-pool-001-2,compute-image-test-custom-vpc"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''
 - name: cleanerupper-osconfig
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-images=true"
+      - "-machine_images=true"
+      - "-load_balancers=true"
+      - "-networks=true"
+      - "-snapshots=true"
+      - "-projects=compute-image-osconfig-agent,compute-image-osconfig-agent-2,oslogin-cit"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-osconfig-policies
   cluster: gcp-guest
   decorate: true
   annotations:
@@ -47,7 +101,7 @@ periodics:
       - "-duration=12h"
       - "-guest_policies=true"
       - "-ospolicy_assignments=true"
-      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2,guestos-metadata-scanner"
+      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -54,7 +54,7 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''
-- name: cleanerupper-osconfig
+- name: cleanerupper-osconfig-projects
   cluster: gcp-guest
   decorate: true
   annotations:

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -101,7 +101,7 @@ periodics:
       - "-duration=12h"
       - "-guest_policies=true"
       - "-ospolicy_assignments=true"
-      - "-projects=compute-image-test-pool-001,compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005,compute-image-osconfig-agent,compute-image-osconfig-agent-2,compute-image-test-custom-vpc,compute-image-test-pool-001-1,compute-image-test-pool-001-2"
+      - "-projects=compute-image-osconfig-agent,compute-image-osconfig-agent-2"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: ''


### PR DESCRIPTION
Splits the existing job into 3 logical groups:

1. Compute image test pools
2. osconfig projects
3. CEP projects

Also removes the metadata scanner project which was turned down in 2023. Updates tab names and grouping to be clear around the new structure.