### PR TITLE
Remove ansible linter from oracle-toolkit

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -1,16 +1,5 @@
 presubmits:
   google/oracle-toolkit:
-  - name: ansible-lint-validator
-    decorate: true
-    optional: true
-    run_if_changed: '^.*\.ya?ml$'
-    spec:
-      serviceAccountName: prowjob-default-sa
-      containers:
-        - image: cytopia/ansible-lint
-          imagePullPolicy: Always
-          command:
-            - ansible-lint
   - name: oracle-toolkit-install-single-instance-on-bms
     cluster: build-gcp-oracle-team
     always_run: true


### PR DESCRIPTION
The Ansible linter's default rule set has a number of rules we don't follow, such as maximum line length.  As its warnings are just being ignored for now, let's remove it, pending more work on fine-tuning the rules.