### PR TITLE
Add deb12 and deb12_arm64 to package build validation presubmits

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -82,7 +82,7 @@ presubmits:
         imagePullPolicy: Always
         command:
         - "/main.sh"
-        args: ["gcp-guest", "us-west1-a", "deb11,el8,el9"]
+        args: ["gcp-guest", "us-west1-a", "deb12,deb12_arm64,deb11,el8,el9"]
 
   GoogleCloudPlatform/guest-diskexpand:
   - name: disk-expand-presubmit-build
@@ -201,7 +201,7 @@ presubmits:
       - image: gcr.io/gcp-guest/daisy-builder:latest
         command:
         - "/main.sh"
-        args: ["gcp-guest", "us-west1-a", "deb11,el8,el8_arm64,el9,el9_arm64,goo"]
+        args: ["gcp-guest", "us-west1-a", "deb12,deb12_arm64,deb11,el8,el8_arm64,el9,el9_arm64,goo"]
 
   GoogleCloudPlatform/guest-logging-go:
   - name: guest-logging-presubmit-gocheck
@@ -257,7 +257,7 @@ presubmits:
       - image: gcr.io/gcp-guest/daisy-builder:latest
         command:
         - "/main.sh"
-        args: ["gcp-guest", "us-west1-a", "deb11,el8,el8_arm64,el9,el9_arm64"]
+        args: ["gcp-guest", "us-west1-a", "deb12,deb12_arm64,deb11,el8,el8_arm64,el9,el9_arm64"]
   - name: oslogin-presubmit-selinux-module
     cluster: gcp-guest
     run_if_changed: "policy/"


### PR DESCRIPTION
Add deb12 and deb12_arm64 to package build validation presubmits for packages actively being worked upon