### PR TITLE
enable owners-label plugin on kubeflow repos

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -361,6 +361,7 @@ plugins:
     - milestone # Applies a milestone for issues or PRs.
     - milestoneapplier
     - override
+    - owners-label
     - project # Lets issues be tagged into projects
     - retitle
     - size


### PR DESCRIPTION
This PR enables the `owners-label` plugin on the `kubeflow` org repos.

Otherwise we cant use the labels feature of `OWNERS` as [documented in our contributing guide](https://www.kubeflow.org/docs/about/contributing/#owners).

cc @andreyvelich 