### PR TITLE
Add v2.1 milestore for Kubeflow Trainer

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -101,7 +101,8 @@ repo_milestone:
 
 milestone_applier:
   kubeflow/trainer:
-    master: v2.0
+    master: v2.1
+    release-2.0: v2.0
   kubeflow/sdk:
     main: v0.1
 


### PR DESCRIPTION
We should update milestone for Kubeflow Trainer project after release-2.0 branch is created.

cc @Electronic-Waste @tenzen-y @astefanutti

/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins