### PR TITLE
Add guest-package-builder project cleanerupper jobs

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/legacy-periodics.yaml
@@ -1,5 +1,52 @@
 # Periodics from legacy prow cluster
 periodics:
+- name: cleanerupper-guest-package-builder
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-guest-package-builder
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=12h"
+      - "-instances=true"
+      - "-disks=true"
+      - "-machine_images=true"
+      - "-snapshots=true"
+      - "-projects=guest-package-builder"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
+- name: cleanerupper-guest-package-builder-images
+  cluster: gcp-guest
+  decorate: true
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cleanerupper-guest-package-builder
+  interval: 2h
+  agent: kubernetes
+  spec:
+    activeDeadlineSeconds: 6300
+    containers:
+    - image: gcr.io/gcp-guest/cleanerupper:latest
+      command:
+      - "/cleanerupper"
+      args:
+      - "-dry_run=false"
+      - "-duration=7d"
+      - "-images=true"
+      - "-projects=guest-package-builder"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: ''
 - name: cleanerupper-cloud-cluster-guest-kms-cep
   cluster: gcp-guest
   decorate: true


### PR DESCRIPTION
- Have the cleanerupper jobs in the same tab (this is experimental)
- Gives images a 7d time to live to allow for testing.
- Clean everything else up after 12h.

/cc @ChaitanyaKulkarni28 @dorileo @bkatyl 