### PR TITLE
Add presubmit test for Oracle single-instance deployment on GCP

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -1,5 +1,6 @@
 presubmits:
   google/oracle-toolkit:
+
   - name: oracle-toolkit-install-single-instance-on-bms
     cluster: build-gcp-oracle-team
     always_run: true
@@ -50,6 +51,7 @@ presubmits:
               items:
                 - key: google-cloud-sdk.repo
                   path: google-cloud-sdk.repo
+
   - name: oracle-toolkit-install-rac-on-bms
     cluster: build-gcp-oracle-team
     always_run: true
@@ -105,3 +107,20 @@ presubmits:
               items:
                 - key: google-cloud-sdk.repo
                   path: google-cloud-sdk.repo
+
+  - name: oracle-toolkit-install-single-instance-on-gcp
+    cluster: build-gcp-oracle-team
+    always_run: false # Run only when requested
+    skip_report: true # Skip setting a status on GitHub
+    max_concurrency: 1
+    decorate: true
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+        command:
+        - ./presubmit_tests/single-instance-on-gcp.sh
+        resources:
+          requests:
+            memory: "2.0Gi"
+            cpu: "3.0"


### PR DESCRIPTION
This PR adds a new presubmit test for Oracle single-instance setup. The test will run the `./presubmit_tests/single-instance-on-gcp.sh` script, which doesn't yet exist in the [oracle-toolkit](https://github.com/google/oracle-toolkit) repo. I'm filing this PR first, before adding the script to our repo, in order to set up the Prow job and test its execution in a real OSS Prow cluster environment.

Since the OSS Prow cluster injects various [environment variables](https://docs.prow.k8s.io/docs/jobs/#job-environment-variables), I want to validate that the script can access them correctly. To do this,  I'll file a separate Draft PR for our oracle-toolkit repo that triggers the job and helps verify behavior before committing the actual runner script. 

Temporarily set the following job parameters:

always_run: false ensures the job won't run on every PR.
skip_report: true avoids setting GitHub status checks (success/failure).

These settings will be updated once the `presubmit_tests/single-instance-on-gcp.sh` script is added and verified.


Note that the job uses `gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine` instead of `quay.io/ansible/ansible-runner:stable-2.9-latest`. This is to ensure the gcloud CLI is pre-installed and available, which is required for interacting with GCP.

