### PR TITLE
set always_run to true and remove skip_report for single-instance-on-gcp tests

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -110,8 +110,7 @@ presubmits:
 
   - name: oracle-toolkit-install-single-instance-on-gcp
     cluster: build-gcp-oracle-team
-    always_run: false # Run only when requested
-    skip_report: true # Skip setting a status on GitHub
+    always_run: true
     max_concurrency: 3
     decorate: true
     decoration_config:


### PR DESCRIPTION
Set always_run to true and remove skip_report for single-instance presubmit tests running on GCP