### PR TITLE
set always_run to true and remove skip_report for single-instance-on-gcp test

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -3,8 +3,7 @@ presubmits:
 
   - name: oracle-toolkit-install-single-instance-on-bms
     cluster: build-gcp-oracle-team
-    always_run: false
-    skip_if_only_changed: "^docs/|^terraform/|^tools/|\\.md$|^LICENSE$|^OWNERS$"
+    always_run: true
     # Introducing max_concurrency, as noted in the design doc (internal) comment thread: https://docs.google.com/document/d/1mv2nV0Cv6EKv-ZTScv59JdyqvmNfYeMojqFJdJVhdmk/edit?pli=1&disco=AAAAUQ1gyBE
     max_concurrency: 1
     decorate: true
@@ -55,8 +54,7 @@ presubmits:
 
   - name: oracle-toolkit-install-rac-on-bms
     cluster: build-gcp-oracle-team
-    always_run: false
-    skip_if_only_changed: "^docs/|^terraform/|^tools/|\\.md$|^LICENSE$|^OWNERS$"
+    always_run: true
     # Introducing max_concurrency, as noted in the design doc (internal) comment thread: https://docs.google.com/document/d/1mv2nV0Cv6EKv-ZTScv59JdyqvmNfYeMojqFJdJVhdmk/edit?pli=1&disco=AAAAUQ1gyBE
     max_concurrency: 1
     decorate: true
@@ -112,8 +110,7 @@ presubmits:
 
   - name: oracle-toolkit-install-single-instance-on-gcp
     cluster: build-gcp-oracle-team
-    always_run: false
-    skip_if_only_changed: "^docs/|\\.md$|^LICENSE$|^OWNERS$"
+    always_run: true
     max_concurrency: 3
     decorate: true
     decoration_config:

--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -3,7 +3,7 @@ presubmits:
 
   - name: oracle-toolkit-install-single-instance-on-bms
     cluster: build-gcp-oracle-team
-    always_run: true
+    always_run: false
     skip_if_only_changed: "^docs/|^terraform/|^tools/|\\.md$|^LICENSE$|^OWNERS$"
     # Introducing max_concurrency, as noted in the design doc (internal) comment thread: https://docs.google.com/document/d/1mv2nV0Cv6EKv-ZTScv59JdyqvmNfYeMojqFJdJVhdmk/edit?pli=1&disco=AAAAUQ1gyBE
     max_concurrency: 1
@@ -55,7 +55,7 @@ presubmits:
 
   - name: oracle-toolkit-install-rac-on-bms
     cluster: build-gcp-oracle-team
-    always_run: true
+    always_run: false
     skip_if_only_changed: "^docs/|^terraform/|^tools/|\\.md$|^LICENSE$|^OWNERS$"
     # Introducing max_concurrency, as noted in the design doc (internal) comment thread: https://docs.google.com/document/d/1mv2nV0Cv6EKv-ZTScv59JdyqvmNfYeMojqFJdJVhdmk/edit?pli=1&disco=AAAAUQ1gyBE
     max_concurrency: 1
@@ -112,8 +112,7 @@ presubmits:
 
   - name: oracle-toolkit-install-single-instance-on-gcp
     cluster: build-gcp-oracle-team
-    always_run: false # Run only when requested
-    skip_report: true # Skip setting a status on GitHub
+    always_run: false
     skip_if_only_changed: "^docs/|\\.md$|^LICENSE$|^OWNERS$"
     max_concurrency: 3
     decorate: true

--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -4,6 +4,7 @@ presubmits:
   - name: oracle-toolkit-install-single-instance-on-bms
     cluster: build-gcp-oracle-team
     always_run: true
+    skip_if_only_changed: "^docs/|^terraform/|^tools/|\\.md$|^LICENSE$|^OWNERS$"
     # Introducing max_concurrency, as noted in the design doc (internal) comment thread: https://docs.google.com/document/d/1mv2nV0Cv6EKv-ZTScv59JdyqvmNfYeMojqFJdJVhdmk/edit?pli=1&disco=AAAAUQ1gyBE
     max_concurrency: 1
     decorate: true
@@ -55,6 +56,7 @@ presubmits:
   - name: oracle-toolkit-install-rac-on-bms
     cluster: build-gcp-oracle-team
     always_run: true
+    skip_if_only_changed: "^docs/|^terraform/|^tools/|\\.md$|^LICENSE$|^OWNERS$"
     # Introducing max_concurrency, as noted in the design doc (internal) comment thread: https://docs.google.com/document/d/1mv2nV0Cv6EKv-ZTScv59JdyqvmNfYeMojqFJdJVhdmk/edit?pli=1&disco=AAAAUQ1gyBE
     max_concurrency: 1
     decorate: true
@@ -112,6 +114,7 @@ presubmits:
     cluster: build-gcp-oracle-team
     always_run: false # Run only when requested
     skip_report: true # Skip setting a status on GitHub
+    skip_if_only_changed: "^docs/|\\.md$|^LICENSE$|^OWNERS$"
     max_concurrency: 3
     decorate: true
     decoration_config:


### PR DESCRIPTION
Activate the single-instance on gcp test, which was previously disabled (`always_run: false`) while still under development. Now that it is now ready, they will run unconditionally for all PRs.