### PR TITLE
Add Data Guard test and update Prow job to use gcp-test-runner.sh 

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -121,8 +121,32 @@ presubmits:
       containers:
       - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
         command:
-        - ./presubmit_tests/single-instance-on-gcp.sh
+        - ./presubmit_tests/gcp-test-runner.sh
+        args:
+        - single-instance
         resources:
           requests:
             memory: "2.0Gi"
             cpu: "3.0"
+
+  - name: oracle-toolkit-install-data-guard-on-gcp
+    cluster: build-gcp-oracle-team
+    always_run: true
+    max_concurrency: 3
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+        command:
+        - ./presubmit_tests/gcp-test-runner.sh
+        args:
+        - data-guard
+        resources:
+          requests:
+            memory: "2.0Gi"
+            cpu: "3.0"
+


### PR DESCRIPTION
Updated the Prow job config to run the single-instance test using the new command:
`./presubmit_tests/gcp-test-runner.sh single-instance` instead of the old script.

Added a new presubmit job for testing two-node Data Guard deployment using the same test runner script with th appropriate parameter.

A follow-up PR will rename `./presubmit_tests/single-instance-on-gcp.sh` to `gcp-test-runner.sh` in the https://github.com/google/oracle-toolkit repo. This change will consolidate all GCP test logic into one script that supports multiple test types through parameters.