### PR TITLE
Replace single-instance with Data Guard test

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -108,27 +108,6 @@ presubmits:
                 - key: google-cloud-sdk.repo
                   path: google-cloud-sdk.repo
 
-  - name: oracle-toolkit-install-single-instance-on-gcp
-    cluster: build-gcp-oracle-team
-    always_run: true
-    max_concurrency: 3
-    decorate: true
-    decoration_config:
-      timeout: 4h
-      grace_period: 5m
-    spec:
-      serviceAccountName: prowjob-default-sa
-      containers:
-      - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
-        command:
-        - ./presubmit_tests/gcp-test-runner.sh
-        args:
-        - single-instance
-        resources:
-          requests:
-            memory: "2.0Gi"
-            cpu: "3.0"
-
   - name: oracle-toolkit-install-data-guard-on-gcp
     cluster: build-gcp-oracle-team
     always_run: true
@@ -142,9 +121,7 @@ presubmits:
       containers:
       - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
         command:
-        - ./presubmit_tests/gcp-test-runner.sh
-        args:
-        - data-guard
+        - ./presubmit_tests/data-guard-on-gcp.sh
         resources:
           requests:
             memory: "2.0Gi"


### PR DESCRIPTION
Replaces the single-instance presubmit test with the Data Guard test, since Data Guard is a superset of the single-instance test and exercises the same code paths in the oracle-toolkit.