### PR TITLE
Use up-to-date kubekins image

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/elcarro-oracle-operator/elcarro-oracle-operator.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/elcarro-oracle-operator/elcarro-oracle-operator.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-master
         command:
         - make
         args:


### PR DESCRIPTION
The previous image repository has not been updated in 3+ years and is broken.