### PR TITLE
Use dedicated GitHub team for Kubeflow SDK

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -96,8 +96,8 @@ repo_milestone:
     maintainers_team: kubeflow-trainer-team
     maintainers_friendly_name: Kubeflow Trainer Team
   kubeflow/sdk:
-    maintainers_team: kubeflow-trainer-team
-    maintainers_friendly_name: Kubeflow Trainer Team
+    maintainers_team: kubeflow-sdk-team
+    maintainers_friendly_name: Kubeflow SDK Team
 
 milestone_applier:
   kubeflow/trainer:


### PR DESCRIPTION
We will use dedicated team to apply milestones for Kubeflow SDK.

cc @Electronic-Waste @tenzen-y @astefanutti @kramaranya @szaher

/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins