### PR TITLE
fix issue for renaming of config-sync

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -26,7 +26,7 @@ tide:
     GoogleCloudPlatform/artifact-registry-yum-plugin: squash
     GoogleCloudPlatform/blueprints: squash
     GoogleCloudPlatform/compute-image-import: squash
-    GoogleContainerTools/kpt-config-sync: squash
+    GoogleContainerTools/config-sync: squash
     kubeflow: squash
     GoogleCloudPlatform/k8s-config-connector: merge
     GoogleCloudPlatform/gke-networking-api: merge
@@ -55,7 +55,7 @@ tide:
     - GoogleCloudPlatform/testgrid
     - GoogleCloudPlatform/k8s-cloud-provider
     - GoogleCloudPlatform/gke-networking-api
-    - GoogleContainerTools/kpt-config-sync
+    - GoogleContainerTools/config-sync
     - GoogleCloudPlatform/k8s-config-connector
     labels:
     - lgtm

--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -70,7 +70,7 @@ lgtm:
   - grpc-ecosystem
   review_acts_as_lgtm: true
 - repos:
-  - GoogleContainerTools/kpt-config-sync
+  - GoogleContainerTools/config-sync
   review_acts_as_lgtm: false
 - repos:
   - GoogleCloudPlatform/testgrid
@@ -310,7 +310,7 @@ plugins:
     - verify-owners
     - wip
 
-  GoogleContainerTools/kpt-config-sync:
+  GoogleContainerTools/config-sync:
     plugins:
     - approve
     - assign

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-postsubmits.yaml
@@ -1,5 +1,5 @@
 postsubmits:
-  GoogleContainerTools/kpt-config-sync:
+  GoogleContainerTools/config-sync:
   # this postsubmit job publishes artifacts (images, manifests, etc) when a new ref is pushed.
   - name: kpt-config-sync-publish-artifacts
     annotations:

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml
@@ -44,7 +44,7 @@ prow_ignored:
 
 
 presubmits:
-  GoogleContainerTools/kpt-config-sync:
+  GoogleContainerTools/config-sync:
   - name: kpt-config-sync-presubmit
     cluster: build-kpt-config-sync
 #    branches: ["master"]

--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-terraform.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-terraform.yaml
@@ -18,7 +18,7 @@ prow_ignored:
           cpu: "1000m"
 
 presubmits:
-  GoogleContainerTools/kpt-config-sync:
+  GoogleContainerTools/config-sync:
   - <<: *config-sync-terraform-job
     name: kpt-config-sync-terraform-presubmit
     run_if_changed: "^e2e/testinfra/terraform/"


### PR DESCRIPTION
Following the renaming of the GoogleContainerTools/kpt-config-sync repository to GoogleContainerTools/config-sync, this change updates all corresponding references within the Prow configuration files.

This ensures that CI automation, including the `tide`, `lgtm`, and `approve` plugins, correctly targets the new repository name.
