### PR TITLE
Enable free edition tests by default

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -129,8 +129,7 @@ presubmits:
 
   - name: oracle-toolkit-install-free-edition-on-gcp
     cluster: build-gcp-oracle-team
-    always_run: false # Run only when requested
-    skip_report: true # Skip setting a status on GitHub
+    always_run: true
     max_concurrency: 3
     decorate: true
     decoration_config:


### PR DESCRIPTION
Now that Terraform support for filesystem installs (#345) has landed, we can enable free edition filesystem-based tests by default.

The on-demand free edition tests have been succeeding consistently:

https://oss.gprow.dev/job-history/gs/gcp-oracle-prow-bucket/pr-logs/directory/oracle-toolkit-install-free-edition-on-gcp