### PR TITLE
Set required env vars for gcenode

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -376,8 +376,9 @@ periodics:
       - 'E2E_CLUSTER_PREFIX=standard-regular-gcenode'
       - 'E2E_NUM_CLUSTERS=1'
       - 'E2E_ARGS=--gcenode'
-      - 'E2E_OCI_PROVIDER=local' # Use local to minimize AR quota usage
-      - 'E2E_HELM_PROVIDER=local'
+      - 'E2E_GIT_PROVIDER=csr'
+      - 'E2E_OCI_PROVIDER=gar'
+      - 'E2E_HELM_PROVIDER=gar'
 
 - <<: *config-sync-standard-job
   name: kpt-config-sync-standard-regular-githubapp


### PR DESCRIPTION
There are currently no tests that run as part of https://testgrid.corp.google.com/googleoss-kpt-config-sync-main#standard-regular-gcenode. This change adds the required repository configs to enable the gcenode tests