### PR TITLE
Increase test timeout for CIT A3U and A4 rdma tests.

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -484,6 +484,7 @@ periodics:
       - "-reservation_urls=nvidia-h200-8mx2qd0luip8o"
       - "-x86_shape=a3-ultragpu-8g"
       - "-accelerator_type=nvidia-h200-141gb"
+      - "-timeout=30m"
 - name: cit-periodics-accelerator-images-accelerator-tests-a4
   cluster: gcp-guest
   decorate: true
@@ -516,6 +517,7 @@ periodics:
       - "-reservation_urls=nvidia-b200-9r888mvujoxrz"
       - "-x86_shape=a4-highgpu-8g"
       - "-accelerator_type=nvidia-b200"
+      - "-timeout=30m"
 - name: cit-periodics-accelerator-images
   cluster: gcp-guest
   decorate: true


### PR DESCRIPTION
Increase the test timeout for cit-periodics-accelerator-images-accelerator-tests-a3u and cit-periodics-accelerator-images-accelerator-tests-a4 to 30 minutes from the default 20 minutes

This is to fix the timeouts in https://testgrid.k8s.io/googleoss-gcp-guest#cit-periodics-accelerator-images-accelerator-tests-a3u.