### PR TITLE
reduce number of cluster for git provider jobs

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics.yaml
@@ -222,6 +222,7 @@ periodics:
       - 'E2E_OCI_PROVIDER=local' # Use local to minimize AR quota usage
       - 'E2E_HELM_PROVIDER=local'
       - 'E2E_ARGS="--test-features=sync-source-git"'
+      - 'E2E_NUM_CLUSTERS=2'
       resources:
         <<: *config-sync-base-job-spec-resources
 
@@ -242,6 +243,7 @@ periodics:
       - 'E2E_OCI_PROVIDER=local' # Use local to minimize AR quota usage
       - 'E2E_HELM_PROVIDER=local'
       - 'E2E_ARGS="--test-features=sync-source-git"'
+      - 'E2E_NUM_CLUSTERS=2'
       resources:
         <<: *config-sync-base-job-spec-resources
 
@@ -262,6 +264,7 @@ periodics:
       - 'E2E_OCI_PROVIDER=local' # Use local to minimize AR quota usage
       - 'E2E_HELM_PROVIDER=local'
       - 'E2E_ARGS="--test-features=sync-source-git"'
+      - 'E2E_NUM_CLUSTERS=2'
       resources:
         <<: *config-sync-base-job-spec-resources
 
@@ -282,6 +285,7 @@ periodics:
       - 'E2E_OCI_PROVIDER=local' # Use local to minimize AR quota usage
       - 'E2E_HELM_PROVIDER=local'
       - 'E2E_ARGS="--test-features=sync-source-git"'
+      - 'E2E_NUM_CLUSTERS=2'
       resources:
         <<: *config-sync-base-job-spec-resources
 


### PR DESCRIPTION
This reduces the number of test clusters used by the Config Sync git provider prowjobs. These test suites now only run a very small number of tests and do not need as many clusters to complete in reasonable time.