### PR TITLE
Update plugins.yaml

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -342,7 +342,6 @@ plugins:
   GoogleCloudPlatform/gke-mcp:
     plugins:
     - approve
-    - blunderbuss
     - lgtm
     - owners-label
     - size


### PR DESCRIPTION
Disable blunderbuss plugin for gke-mcp repo.

We don't like the 2 assigned reviewers, and blunderbuss is not configurable on the repo level. We are going to use Github's built in auto assign feature instead.