### PR TITLE
prow: update needs-triage label for kubeflow repos

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -93,6 +93,7 @@ label:
   - tide/merge-method-rebase
   - tide/merge-method-squash
   # This is used to triage issues in Kubeflow repositories.
+  - lifecycle/needs-triage
   - needs-triage
 
 repo_milestone:

--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -93,7 +93,7 @@ label:
   - tide/merge-method-rebase
   - tide/merge-method-squash
   # This is used to triage issues in Kubeflow repositories.
-  - lifecycle/needs-triage
+  - needs-triage
 
 repo_milestone:
   kubeflow/trainer:


### PR DESCRIPTION
Renames the triage label from `lifecycle/needs-triage` to bare `needs-triage`
across all kubeflow repositories, aligning with the k8s convention:
https://github.com/kubernetes/kubernetes/issues?q=label%3Aneeds-triage

This makes the prow slash command simpler:
  /label needs-triage
  /remove-label needs-triage

Follow-up PRs will update labels.yml and issue templates in:
- kubeflow/trainer
- kubeflow/sdk

cc: @andreyvelich

Ref: [kubeflow/mcp-server#3](https://github.com/kubeflow/mcp-server/pull/3#discussion_r3221022098)