### PR TITLE
Add optional context for gke-mcp job

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -132,6 +132,9 @@ tide:
             optional-contexts:
               # The job is triggered only on dependabot PRs.
               - regenerate-crds
+          gke-mcp:
+            optional-contexts:
+              - evaluate
 
 plank:
   job_url_prefix_config:


### PR DESCRIPTION
**What this PR does / why we need it:**
Currently, PRs in the `GoogleCloudPlatform/gke-mcp` repository are being blocked from auto-merging by Tide when the `evaluate` job is skipped. Tide requires all contexts to explicitly succeed by default, and it treats the `skipped` state as a failure to succeed ("Job evaluate has not succeeded").

This PR adds the `evaluate` job to the `optional-contexts` list for `gke-mcp` under `tide.context_options`. This configuration change tells Tide to ignore the status of this specific context, allowing PRs to be auto-merged seamlessly even when the job is legitimately bypassed.