### PR TITLE
Add a new presubmit job to run Python unit tests

### DIFF
--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -176,12 +176,12 @@ presubmits:
     spec:
       serviceAccountName: prowjob-default-sa
       containers:
-      - image: mirror.gcr.io/library/python:3.14.5-slim
+      - image: quay.io/ansible/ansible-runner:stable-2.9-latest
         command:
          - /bin/sh
          - -c
          - |
-           pip install ansible-core pytest PyYAML
+           pip install pytest
            pytest inventory_plugins/
         resources:
           requests:

--- a/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
+++ b/prow/prowjobs/google/oracle-toolkit/oracle-toolkit-presubmit.yaml
@@ -164,3 +164,26 @@ presubmits:
           requests:
             memory: "2.0Gi"
             cpu: "3.0"
+  - name: oracle-toolkit-python-unit-tests
+    cluster: build-gcp-oracle-team
+    # Only triggers if files in the inventory_plugins directory are changed
+    run_if_changed: "^inventory_plugins/"
+    max_concurrency: 3
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: mirror.gcr.io/library/python:3.14.5-slim
+        command:
+         - /bin/sh
+         - -c
+         - |
+           pip install ansible-core pytest PyYAML
+           pytest inventory_plugins/
+        resources:
+          requests:
+            memory: "2.0Gi"
+            cpu: "3.0"


### PR DESCRIPTION
Add a new presubmit job to run Python unit tests for the inventory plugin.

The presubmit job is only triggers if files in the inventory_plugins directory are changed.