### PR TITLE
Add release package test config for c3 machine family

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -662,3 +662,29 @@ periodics:
       - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
       - "-set_exit_status=false"
       - "-x86_shape=e2-standard-2"
+- name: cit-periodics-release-package-c3
+  cluster: gcp-guest
+  decorate: true
+  decoration_config:
+    timeout: 8h
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cit-periodics-release-package-c3
+  # Run every 12 hours at 10:00, 22:00 UTC / 03:00, 15:00 PDT
+  cron: "0 10,22 * * *"
+  spec:
+    containers:
+    - image: gcr.io/compute-image-tools/cloud-image-tests:latest
+      imagePullPolicy: Always
+      command:
+      - "/manager"
+      args:
+      - "-parallel_count=5"
+      - "-project=gcp-guest"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-b,europe-west1-b,asia-east1-a"
+      - "-all_image_families=gce-unstable-pkg-test-images"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      # Please keep filter list synced between all release package images. Do not edit this list; copy/paste from line 1121 for any updates.
+      - "-filter=^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|sql|vmspec)$"
+      - "-set_exit_status=false"
+      - "x86_shape=c3-standard-4"


### PR DESCRIPTION
/cc @bkatyl 

Adding TestGrid tab for c3 machine family, scheduled to run twice a day at 3AM and 3PM PDT. 
Periodic schedule subject to change.