### PR TITLE
Fix: Amending TestGrid fixes to align better with constraints

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -653,7 +653,7 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=15"
+      - "-parallel_count=50"
       - "-project=gcp-guest"
       - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-b,europe-west1-b,asia-east1-a"
       - "-all_image_families=gce-unstable-pkg-test-images"
@@ -680,7 +680,7 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=15"
+      - "-parallel_count=25"
       - "-project=gcp-guest"
       - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-b,europe-west1-b,asia-southeast1-a"
       - "-all_image_families=gce-unstable-pkg-test-images"
@@ -707,7 +707,7 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=15"
+      - "-parallel_count=25"
       - "-project=gcp-guest"
       - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-a,europe-west1-b,asia-east1-a"
       - "-all_image_families=gce-unstable-pkg-test-images"
@@ -734,7 +734,7 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=15"
+      - "-parallel_count=25"
       - "-project=gcp-guest"
       - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-b,europe-west1-b,asia-east1-a"
       - "-all_image_families=gce-unstable-pkg-test-images"

--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -640,7 +640,7 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 16h
+    timeout: 12h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-release-package-e2
@@ -667,7 +667,7 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 16h
+    timeout: 12h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-release-package-c3
@@ -694,7 +694,7 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 16h
+    timeout: 12h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-release-package-c4a
@@ -721,7 +721,7 @@ periodics:
   cluster: gcp-guest
   decorate: true
   decoration_config:
-    timeout: 16h
+    timeout: 12h
   annotations:
     testgrid-dashboards: googleoss-gcp-guest
     testgrid-tab-name: cit-periodics-release-package-n4


### PR DESCRIPTION
- Decreased timeout to 12 hours to accommodate with 12-hour job scheduling.
- Increased parallel count to 25 based off current timeout progress.

/cc @bkatyl 