### PR TITLE
run prow job in team specific cluster

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
@@ -7,7 +7,7 @@ presubmits:
     labels:
       preset-service-account: "true"
     decorate: true
-    # cluster: build-gke-managed-storage // Uncomment this in followup PR once the cluster is registered in kubeconfigs.yaml as checkconfig validates live configs
+    cluster: build-gke-managed-storage
     spec:
       serviceAccountName: prowjob-default-sa
       containers:


### PR DESCRIPTION
This is a follow up for https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2608 to update the prow job with team cluster. Presubmits did not allow me to make this change in the old PR.