### PR TITLE
kubeflow: add dependabot to trusted_apps to auto-run ci on bot prs

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -19,6 +19,13 @@ triggers:
   only_org_members: true
   trigger_github_workflows: true
 - repos:
+  - kubeflow/pipelines
+  join_org_url: "https://www.kubeflow.org/docs/about/contributing/"
+  only_org_members: true
+  trigger_github_workflows: true
+  trusted_apps:
+    - dependabot
+- repos:
   - GoogleCloudPlatform/compute-daisy
   - GoogleCloudPlatform/cloud-image-tests
   - GoogleCloudPlatform/guest-configs
@@ -26,7 +33,6 @@ triggers:
   - GoogleCloudPlatform/google-guest-agent
   trusted_apps:
     - copybara-service
-    - dependabot
 
 config_updater:
   maps:

--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -26,6 +26,7 @@ triggers:
   - GoogleCloudPlatform/google-guest-agent
   trusted_apps:
     - copybara-service
+    - dependabot
 
 config_updater:
   maps:


### PR DESCRIPTION
## Description

Dependency update PRs are a source of maintainer toil for `kubeflow/pipelines`, requiring a manual `/ok-to-test` label application before CI starts. This PR adds `dependabot` as a trusted app so when maintainers wake up to frequent and routine dependabot PRs, they already know if it passed CI.

https://github.com/kubeflow/pipelines/issues/13676

/cc @jeffspahr @droctothorpe