### PR TITLE
Add Prow setup for gke-labs/kube-agents

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/OWNERS
+++ b/prow/prowjobs/gke-labs/kube-agents/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- bradhoekstra
+- dshnayder
+- haoxuw
+- jayantid
+- toshiowang

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -1,0 +1,18 @@
+presubmits:
+  gke-labs/kube-agents:
+  - name: pull-kube-agents-smoke-test
+    cluster: build-kube-agents
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 20m
+    spec:
+      serviceAccountName: prowjob-default-sa
+      containers:
+      - image: gcr.io/devops-bench-shared/devops-bench-harness:latest
+        command:
+        - ./hack/ci-connection-test.sh
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "500m"


### PR DESCRIPTION
Add configurations to use Prow as CI for [gke-labs/kube-agents](https://github.com/gke-labs/kube-agents).
- Created job directory with team `OWNERS` file.
- Added smoke test presubmit job to execute scripts inside [devops-bench](https://github.com/gke-labs/devops-bench).



