### PR TITLE
update job memory limits

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
@@ -24,10 +24,10 @@ presubmits:
         resources:
           requests:
             memory: 8Gi
-            ephemeral-storage: 4Gi
+            ephemeral-storage: 6Gi
           limits:
             memory: 8Gi
-            ephemeral-storage: 4Gi
+            ephemeral-storage: 10Gi
         volumeMounts:
       volumes:
       - name: ssh


### PR DESCRIPTION
Prow job run is failing due to possible ephemeral storage issue so increasing the limits
https://oss.gprow.dev/view/gs/oss-cloud-kubernetes-test/pr-logs/pull/GoogleCloudPlatform_gcs-fuse-csi-driver/1493/pull-gcs-fuse-csi-driver-e2e-test/2075501935040925696

https://screenshot.googleplex.com/4YrUcw6eD45KoKN