### PR TITLE
update the boskos URL as it not discoverable across namesapces

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
@@ -19,6 +19,8 @@ presubmits:
         env:
         - name: GCE_PD_BOSKOS_RESOURCE_TYPE
           value: "oss-boskos-e2e-test-project"
+        - name: BOSKOS_URL
+          value: "http://boskos.boskos.svc.cluster.local"
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
Boskos pool is not discoverable to the prow job since boskos resources are located in different namespace. Add boskos URL to expose correct path