### PR TITLE
feat: Add v0.1 milestone for Kubeflow MCP Server

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -124,6 +124,8 @@ milestone_applier:
     release-0.3: v0.3
     release-0.2: v0.2
     release-0.1: v0.1
+  kubeflow/mcp-server:
+    main: v0.1
 
 plugins:
   GoogleCloudPlatform:


### PR DESCRIPTION
Configure milestone for kubeflow/mcp-server project

Tracking: https://github.com/kubeflow/mcp-server/issues/56

/cc @andreyvelich @thesuperzapper @ kramaranya @astefanutti
/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins