### PR TITLE
feat: enable /milestone for kubeflow/mcp-server and add SDK team as m…

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -111,6 +111,9 @@ repo_milestone:
   kubeflow/sdk:
     maintainers_team: kubeflow-sdk-team
     maintainers_friendly_name: Kubeflow SDK Team
+  kubeflow/mcp-server:
+    maintainers_team: kubeflow-sdk-team
+    maintainers_friendly_name: Kubeflow SDK Team
 
 milestone_applier:
   kubeflow/trainer:


### PR DESCRIPTION
Enable the Prow /milestone command for kubeflow/mcp-server (same pattern as SDK/Trainer).

milestone_applier already maps main to v0.1. This adds repo_milestone so maintainers can set milestones via comment (e.g. /milestone v0.1).

Uses `kubeflow-sdk-team` as the maintainers team.

Related to : https://github.com/kubeflow/mcp-server/issues/56 and https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2630

/cc @andreyvelich

/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins