### PR TITLE
configs(kube-agents): update presubmit job to use kube-agents-prow registry

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     spec:
       serviceAccountName: prowjob-default-sa
       containers:
-      - image: us-central1-docker.pkg.dev/hangdng-gkedemos/kube-agents/devops-bench-harness:latest
+      - image: us-central1-docker.pkg.dev/kube-agents-prow/kube-agents/devops-bench-harness:latest
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
Update presubmit job for kube-agents to:
- Pull runner image from `us-central1-docker.pkg.dev/kube-agents-prow/kube-agents/devops-bench-harness:latest`.