### PR TITLE
Update memory limits for prow job

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
@@ -34,10 +34,8 @@ presubmits:
         resources:
           requests:
             memory: 8Gi
-            ephemeral-storage: 6Gi
           limits:
-            memory: 8Gi
-            ephemeral-storage: 10Gi
+            memory: 10Gi
       volumes:
       - name: ssh
         secret:


### PR DESCRIPTION
Prow job is currently failing due to ephemeral storage memory issues, this PR removes the memory limit for ephemeral storage. Internal prow job too does not add any restrictions as it needs more memory to build unmanaged driver. As all the tests are run in separate clusters, we wouldn't have any memory issues with unlimited container.