### PR TITLE
configs(kube-agents): install make and envsubst for kube-agents-prow to reuse installation script

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -17,6 +17,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
+          apt-get update && apt-get install -y --no-install-recommends make gettext-base
           export GEMINI_API_KEY="$(cat /etc/gemini-secret/GEMINI_API_KEY)"
           trap './hack/ci-teardown.sh' EXIT
           ./hack/ci-connection-test.sh


### PR DESCRIPTION
Installs `make` and `gettext-base` (`envsubst`) packages in the `pull-kube-agents-smoke-test` presubmit container environment.
- This enables the `kube-agents` CI scripts to reuse the kube-agents installation scripts and reduce the diversion.