### PR TITLE
increase test timeout to match internal prow job timeout

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcs-fuse-csi-driver/gcs-fuse-csi-driver-config.yaml
@@ -8,6 +8,8 @@ presubmits:
       preset-service-account: "true"
       preset-dind-enabled: "true"
     decorate: true
+    decoration_config:
+      timeout: 4h
     cluster: build-gke-managed-storage
     spec:
       serviceAccountName: prowjob-default-sa


### PR DESCRIPTION
Increase prow job timeout to match internal prow job timeout, currently it times out at 2h and thus cannot complete all the tests