### PR TITLE
configs(kube-agents): install missing packages for kube-agents-prow to reuse installation script

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          apt-get update && apt-get install -y --no-install-recommends make gettext-base
+          apt-get update && apt-get install -y --no-install-recommends make gettext-base golang-go git openssl ca-certificates
           export GEMINI_API_KEY="$(cat /etc/gemini-secret/GEMINI_API_KEY)"
           trap './hack/ci-teardown.sh' EXIT
           ./hack/ci-connection-test.sh


### PR DESCRIPTION
Installed `go`, `git`, `openssl`, and `ca-certificates` which are required in the installation script.