### PR TITLE
configs(kube-agents): increase presubmit test timeout

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     skip_report: true
     decorate: true
     decoration_config:
-      timeout: 20m
+      timeout: 2h
     spec:
       serviceAccountName: prowjob-default-sa
       containers:


### PR DESCRIPTION
Increase the presubmit test timeout so there would be enough time to deploy kube-agents and run the evaluation.