### PR TITLE
update cluster name to trigger cluster refresh for regional cluster

### DIFF
--- a/prow/oss/cluster/kubeconfigs/kubeconfigs.yaml
+++ b/prow/oss/cluster/kubeconfigs/kubeconfigs.yaml
@@ -72,7 +72,7 @@ contexts:
 - context:
     cluster: gke_oss-cloud-kubernetes-test_us-central1_gcs-fuse-e2e-build-cluster-regional
     user: gke-auth-plugin
-  name: build-gke-managed-storage
+  name: build-gke-managed-storage-regional
 current-context: test-infra-trusted
 kind: Config
 preferences: {}

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -205,7 +205,7 @@ plank:
         bucket: "kube-agents-prow"
       default_service_account_name: "prowjob-default-sa" # Use workload identity
       gcs_credentials_secret: ""                         # rather than service account key secret
-  - cluster: build-gke-managed-storage
+  - cluster: build-gke-managed-storage-regional
     config:
       gcs_configuration:
         bucket: "oss-cloud-kubernetes-test"


### PR DESCRIPTION
Current build cluster was updated from zonal to regional in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2634 but the latest prow job is still using the zonal cluster. This PR updates the cluster name so that Prow picks regional cluster