### PR TITLE
Add Kubeflow Trainer v2.4 milestone

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -117,7 +117,8 @@ repo_milestone:
 
 milestone_applier:
   kubeflow/trainer:
-    master: v2.3
+    master: v2.4
+    release-2.3: v2.3
     release-2.2: v2.2
     release-2.1: v2.1
     release-2.0: v2.0


### PR DESCRIPTION
We should update milestone for Kubeflow Trainer project after release-2.3 branch is created.
ref: https://github.com/kubeflow/trainer/issues/3664

cc @tenzen-y @robert-bell @Sridhar1030

/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins @upadhyayshipra @martiul @AvocadoSushi123 @atulydvg