### PR TITLE
configs(kube-agents): replace devops-bench eval image with kubekins-e2e base image to run evals via library dependency

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -11,13 +11,16 @@ presubmits:
     spec:
       serviceAccountName: prowjob-default-sa
       containers:
-      - image: us-central1-docker.pkg.dev/kube-agents-prow/kube-agents/devops-bench-harness:latest
+      - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-1.32
         command:
         - /bin/bash
         - -c
         - |
           set -euo pipefail
-          apt-get update && apt-get install -y --no-install-recommends make gettext-base golang-go git openssl ca-certificates
+          apt-get update && apt-get install -y --no-install-recommends make gettext-base golang-go git openssl ca-certificates curl
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh && chmod +x install-opentofu.sh && ./install-opentofu.sh --install-method standalone
           export GEMINI_API_KEY="$(cat /etc/gemini-secret/GEMINI_API_KEY)"
           trap './hack/ci-teardown.sh' EXIT
           ./hack/ci-connection-test.sh

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -18,6 +18,7 @@ presubmits:
         - |
           set -euo pipefail
           apt-get update && apt-get install -y --no-install-recommends make gettext-base golang-go git openssl ca-certificates curl
+          gcloud components install gke-gcloud-auth-plugin --quiet
           curl -LsSf https://astral.sh/uv/install.sh | sh
           export PATH="$HOME/.local/bin:$PATH"
           curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh && chmod +x install-opentofu.sh && ./install-opentofu.sh --install-method standalone


### PR DESCRIPTION
### Summary
Replace the `devops-bench-harness` container image in `pull-kube-agents-smoke-test` with the standard Prow base image (`kubekins-e2e`).

### Why
This change works together with [kube-agents#466](https://github.com/gke-labs/kube-agents/pull/466) to decouple `kube-agents` from `devops-bench`. By consuming `devops-bench` as a library dependency via `uv`, the presubmit job no longer depends on a custom `devops-bench` Docker image.

### Testing
- Verified in a local container (`gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-1.32`) that `uv`, OpenTofu, and `gcloud` are installed.

