### PR TITLE
Add Kubeflow SDK 0.6 milestone

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -126,7 +126,8 @@ milestone_applier:
     release-2.1: v2.1
     release-2.0: v2.0
   kubeflow/sdk:
-    main: v0.5
+    main: v0.6
+    release-0.5: v0.5
     release-0.4: v0.4
     release-0.3: v0.3
     release-0.2: v0.2


### PR DESCRIPTION
We should update milestone for Kubeflow SDK after release-0.5 branch is created.
ref: https://github.com/kubeflow/sdk/issues/648


cc @tariq-hasan @kramaranya @Fiona-Waters  @abhijeet-dhumal @robert-bell 

/assign @airbornepony @chases2 @cjwagner @michelle192837 @nathanperkins @upadhyayshipra @Martiul @AvocadoSushi123 @atulydvg