### PR TITLE
feat(kube-agents): enable required presubmit smoke test on every PR

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - name: pull-kube-agents-smoke-test
     max_concurrency: 1
     cluster: build-kube-agents
-    always_run: false
-    skip_report: true
+    always_run: true
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 2h


### PR DESCRIPTION
# Enable automated presubmit smoke test for kube-agents

## Description

This PR promotes `pull-kube-agents-smoke-test` to an active, required presubmit for `gke-labs/kube-agents`:

- **`always_run: true`**: Automatically triggers the smoke test on every new PR and subsequent commit pushes.
- **`skip_report: false`**: Reports test status checks back to GitHub to gate PR merges on green test results.