### PR TITLE
fix(kube-agents): temporarily set the smoke test to not block merging

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -5,6 +5,10 @@ presubmits:
     cluster: build-kube-agents
     always_run: true
     skip_report: false
+    # Reported on every PR but not merge-blocking: the job provisions a GKE
+    # cluster and runs a full eval, so it is currently too slow to gate Tide on.
+    # Drop this once the runtime is down.
+    optional: true
     decorate: true
     decoration_config:
       timeout: 2h


### PR DESCRIPTION
## Temporarily make pull-kube-agents-smoke-test non-blocking

  Adds `optional: true` to `pull-kube-agents-smoke-test`.

  ### Why

  The job is currently too slow and too serialized to gate merges on:

  - It provisions a GKE cluster and runs a full agent evaluation, with a 2h timeout.
  - `max_concurrency: 1` means runs execute one at a time, while `always_run: true` queues a new one on every PR and every push. On an active day the queue does not drain, so merges end up waiting behind runs that are themselves waiting.

 Until the runtime and the queue backlog are addressed, this should not be a merge gate. It was made blocking as a side effect of switching `skip_report: true` to `false` for visibility, reporting a context is what makes Tide require it (`ContextRequired() = !Optional && !SkipReport`). `optional: true` separates the two, so the result stays visible on the PR without gating merge.

  ### Effect

  | | Runs on every PR | Status on PR | Blocks merge |
  | --- | --- | --- | --- |
  | before | yes | yes | yes |
  | after | yes | yes | no |