### PR TITLE
configs(kube-agents): skip the smoke test on docs-only pull requests

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -3,8 +3,9 @@ presubmits:
   - name: pull-kube-agents-smoke-test
     max_concurrency: 1
     cluster: build-kube-agents
-    always_run: true
+    always_run: false
     skip_report: false
+    skip_if_only_changed: '^(docs/|\.github/|examples/|[^/]+\.md$|LICENSE$|OWNERS$|OWNERS_ALIASES$)'
     # Reported on every PR but not merge-blocking: the job provisions a GKE
     # cluster and runs a full eval, so it is currently too slow to gate Tide on.
     # Drop this once the runtime is down.

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -16,7 +16,8 @@ presubmits:
       # for nearly three times a normal run. 80m leaves generous headroom over
       # the average while bounding what one wedged run costs the queue
       # (gke-labs/kube-agents#635). Lower this again as the runtime comes down.
-      timeout: 80m
+      timeout: 85m
+      grace_period: 5m
     spec:
       serviceAccountName: prowjob-default-sa
       containers:
@@ -26,13 +27,13 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          apt-get update && apt-get install -y --no-install-recommends gettext-base openssl
-          gcloud components install gke-gcloud-auth-plugin --quiet
+          apt-get update && apt-get install -y --no-install-recommends gettext-base
+          command -v gke-gcloud-auth-plugin >/dev/null
           curl -LsSf https://astral.sh/uv/install.sh | sh
           export PATH="$HOME/.local/bin:$PATH"
           curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh && chmod +x install-opentofu.sh && ./install-opentofu.sh --install-method standalone
           export GEMINI_API_KEY="$(cat /etc/gemini-secret/GEMINI_API_KEY)"
-          trap './hack/ci-teardown.sh' EXIT
+          trap 'rc=$?; trap - EXIT INT TERM; ./hack/ci-teardown.sh; exit $rc' EXIT INT TERM
           ./hack/ci-connection-test.sh
           ./hack/ci-deploy.sh
           ./hack/ci-eval-pr.sh

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          apt-get update && apt-get install -y --no-install-recommends make gettext-base golang-go git openssl ca-certificates curl
+          apt-get update && apt-get install -y --no-install-recommends gettext-base openssl
           gcloud components install gke-gcloud-auth-plugin --quiet
           curl -LsSf https://astral.sh/uv/install.sh | sh
           export PATH="$HOME/.local/bin:$PATH"

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -12,7 +12,11 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 2h
+      # The job averages ~43min, so 2h let a single hang sit on the only slot
+      # for nearly three times a normal run. 80m leaves generous headroom over
+      # the average while bounding what one wedged run costs the queue
+      # (gke-labs/kube-agents#635). Lower this again as the runtime comes down.
+      timeout: 80m
     spec:
       serviceAccountName: prowjob-default-sa
       containers:


### PR DESCRIPTION
### Why
pull-kube-agents-smoke-test provisions a GKE cluster and runs a full eval — roughly 43 minutes — and runs at max_concurrency: 1. Every run occupies the single slot, so a documentation-only pull request delays every code pull request behind it by the full runtime, while testing nothing that a prose change could have affected.

  This is item 4,5 and part of item 1 of gke-labs/kube-agents#635

### Impact
No change to merge gating: the job remains optional: true, so it reports but does not block Tide. If it is made required later, Prow requires a conditionally-run job only on pull requests it matches, so docs-only pull requests would still merge freely, provided the context is left to Tide and not hand-added to GitHub branch protection, which has no conditional notion and would deadlock on a context that never reports.

### Testing

`skip_if_only_changed` is already in use in this [Prow instance](prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-presubmits.yaml) and [Prow doc](https://docs.prow.k8s.io/docs/jobs/#:~:text=Postsubmit%20jobs%20apply%20run_if_changed%20and%20skip_if_only_changed%20filters%20based%20on%20which%20files%20were%20modified%20by%20the%20commits%20included%20in%20the%20specific%20push%20event%20from%20github.), so support is confirmed.

The regex was verified against representative paths:

| Path | Result |
  | --- | --- |
  | `docs/site/src/x.astro` | skip |
  | `README.md` | skip |
  | `.github/workflows/a.yml` | skip |
  | `examples/litellm/x.yaml` | skip |
  | `agents/platform/skills/foo/SKILL.md` | **run** |
  | `k8s-operator/main.go` | **run** |
  | `charts/kube-agents/values.yaml` | **run** |
  | `admin_console/app.py` | **run** |

The apt-get line installed seven packages, six of which the base image already provides. Verified in two steps against the exact image the job runs, `gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-1.32` (digest `sha256:bd6e368acf41f6682a8c2e0dc49eab75c4795164a01cf85e3b681b6eadd6a0d1, built 08/06/2026`).

1. Probe the base image for what's already there. No installs, just resolution:
```
  docker run --rm --entrypoint "" \
    gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-1.32 bash -c '
      for t in make git curl openssl envsubst go gke-gcloud-auth-plugin; do
        printf "%-24s %s\n" "$t" "$(command -v $t || echo MISSING)"
      done
      go version'
```

```
  make                     /usr/bin/make
  git                      /usr/bin/git
  curl                     /usr/bin/curl
  openssl                  /usr/bin/openssl
  envsubst                 MISSING
  go                       /usr/local/go/bin/go
  gke-gcloud-auth-plugin   /google-cloud-sdk/bin/gke-gcloud-auth-plugin
  go version go1.24.13 linux/amd64
```
`envsubst` is the only thing genuinely absent, so gettext-base stays. 

Two further findings. gke-gcloud-auth-plugin already ships with the base image's Cloud SDK — gcloud components install reports "All components are up to date", so that line was a network round trip that did nothing. And the golang-go package was never used: `kubekins-e2e` sets `PATH=/usr/local/go/bin:$PATH`, putting its own Go ahead of Debian's `/usr/bin/go`, so go resolved to `/usr/local/go/bin/go` (1.24.13) and the apt-installed 1.19 sat unreachable. Removing it leaves the job on the same Go binary it was already using.

2. Run the trimmed setup block end to end in the same image:
```
  docker run --rm --entrypoint "" \
    gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-1.32 bash -c '
      set -euo pipefail
      apt-get update && apt-get install -y --no-install-recommends gettext-base
      command -v gke-gcloud-auth-plugin >/dev/null
      curl -LsSf https://astral.sh/uv/install.sh | sh
      export PATH="$HOME/.local/bin:$PATH"
      curl --proto "=https" --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o /tmp/i.sh
      chmod +x /tmp/i.sh && /tmp/i.sh --install-method standalone
      echo "=== Validation ==="
      command -v gke-gcloud-auth-plugin uv tofu
      tofu version && uv --version'
```
Completed clean under set -euo pipefail, with the command -v guard passing silently:
```
  0 upgraded, 1 newly installed, 0 to remove and 81 not upgraded.
  Need to get 160 kB of archives.
  ...
  === Validation ===
  /google-cloud-sdk/bin/gke-gcloud-auth-plugin
  /root/.local/bin/uv
  /usr/local/bin/tofu
  OpenTofu v1.12.5
  uv 0.12.3 (x86_64-unknown-linux-gnu)
```