### PR TITLE
configs(kube-agents): lease evaluation project from Boskos in presubmit smoke test

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -1,7 +1,12 @@
 presubmits:
   gke-labs/kube-agents:
   - name: pull-kube-agents-smoke-test
+    # TODO: raise to 2 once job logs confirm acquire/heartbeat/release work across
+    # real runs. This caps parallelism only, Boskos still rotates across the pool.
     max_concurrency: 1
+    # Boskos server, pool config and reaper for build-kube-agents:
+    # gke-internal/test-infra deployments/gke-agentic-tooling-team/boskos
+    # Pool must be configured there before raising max_concurrency.
     cluster: build-kube-agents
     always_run: false
     skip_report: false
@@ -27,13 +32,54 @@ presubmits:
         - -c
         - |
           set -euo pipefail
-          apt-get update && apt-get install -y --no-install-recommends gettext-base
+          apt-get update && apt-get install -y --no-install-recommends gettext-base jq
           command -v gke-gcloud-auth-plugin >/dev/null
           curl -LsSf https://astral.sh/uv/install.sh | sh
           export PATH="$HOME/.local/bin:$PATH"
           curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh && chmod +x install-opentofu.sh && ./install-opentofu.sh --install-method standalone
           export GEMINI_API_KEY="$(cat /etc/gemini-secret/GEMINI_API_KEY)"
-          trap 'rc=$?; trap - EXIT INT TERM; ./hack/ci-teardown.sh; exit $rc' EXIT INT TERM
+          export REQUIRE_CACHE="true"
+          # ─── Ensure boskosctl is available (pinned version) ─────────────────────────
+          if ! command -v boskosctl >/dev/null; then
+            GOBIN=/usr/local/bin go install sigs.k8s.io/boskos/cmd/boskosctl@v0.0.0-20260730151943-11fb0c84248b
+          fi
+
+          # ─── Boskos Lease, Heartbeat & Cleanup Handler ──────────────────────────────
+          BOSKOS_SERVER="http://boskos.boskos.svc.cluster.local"
+          BOSKOS_RESOURCE_TYPE="kube-agents-evals-project"
+          BOSKOS_OWNER="${JOB_NAME}-${BUILD_ID}"
+          BOSKOSCTL=(boskosctl --server-url="${BOSKOS_SERVER}" --owner-name="${BOSKOS_OWNER}")
+
+          echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Leasing GCP Project from Boskos ==="
+          RESOURCE="$("${BOSKOSCTL[@]}" acquire --type="${BOSKOS_RESOURCE_TYPE}" \
+            --state=free --target-state=busy --timeout=10m)"
+          LEASED_PROJECT="$(echo "${RESOURCE}" | jq -r .name)"
+          if [ -z "${LEASED_PROJECT}" ] || [ "${LEASED_PROJECT}" = "null" ]; then
+            echo "ERROR: could not parse leased project from: ${RESOURCE}"
+            exit 1
+          fi
+          export PROJECT_ID="${LEASED_PROJECT}"
+          echo "✓ Successfully leased project: ${PROJECT_ID}"
+
+          cleanup() {
+            local rc=$?
+            trap - EXIT INT TERM
+            kill "${HEARTBEAT_PID:-}" 2>/dev/null || true
+            echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running CI Teardown ==="
+            ./hack/ci-teardown.sh || true
+            if [ -n "${LEASED_PROJECT:-}" ] && [ "${LEASED_PROJECT}" != "null" ]; then
+              echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Releasing Boskos Project: ${LEASED_PROJECT} ==="
+              "${BOSKOSCTL[@]}" release --name="${LEASED_PROJECT}" --target-state=free || true
+            fi
+            exit $rc
+          }
+          trap cleanup EXIT INT TERM
+
+          "${BOSKOSCTL[@]}" heartbeat --resource "${RESOURCE}" --period=30s &
+          HEARTBEAT_PID=$!
+
+          # Clean up any leftover state if a previous job was hard-killed
+          ./hack/ci-teardown.sh || true
           ./hack/ci-connection-test.sh
           ./hack/ci-deploy.sh
           ./hack/ci-eval-pr.sh


### PR DESCRIPTION

## Summary

Adds dynamic GCP project leasing via Boskos to the `pull-kube-agents-smoke-test` presubmit job in `oss-test-infra`.

## Why This Change

The `kube-agents` smoke test job currently runs against a single hardcoded GCP project (`kube-agents-evals`), requiring `max_concurrency: 1` to prevent concurrent job collisions. Adding dynamic Boskos leasing allows multiple presubmit jobs to run safely in parallel across an isolated pool of evaluation projects (`kube-agents-evals`, `kube-agents-evals-2`, etc.).

## What Changed

- **Pinned `boskosctl`**: Installs pinned `sigs.k8s.io/boskos/cmd/boskosctl@v0.0.0-20260730151943-11fb0c84248b` for deterministic CI builds.
- **Dynamic Lease Acquisition**: Runs `boskosctl acquire` against the in-cluster Boskos server (`http://boskos.boskos.svc.cluster.local`) with `--owner-name="${JOB_NAME}-${BUILD_ID}"` and a 10-minute timeout.
- **Robust Lease & Project Validation**: Extracts and validates the leased project name with `jq -r .name` with fail-fast validation against empty/null values.
- **Heartbeat Management**: Launches `boskosctl heartbeat --period=30s &` in the background to prevent the Boskos Reaper's 30-minute inactivity timer (`--expire`) from reclaiming the lease during evaluations.
- **Staged Cleanup Trap**: Installs a cleanup trap immediately upon lease validation (before the heartbeat launch) that terminates `boskosctl`, executes `ci-teardown.sh`, and releases the project back to Boskos (`--target-state=free`).
- **Start-of-Job Cleanup**: Executes `./hack/ci-teardown.sh || true` immediately after acquiring the lease to sweep any leftover resources from prior hard-killed runs before starting deployment.
- **`max_concurrency`**: Kept at `1` for initial rollout; will be bumped to `2` once log is verified to confirm acquire/heartbeat/release behave as expected across real runs.

## Testing

- Config syntax and job validation: `go test -v -count=1 ./prow/tests/` (PASS).
- Live validation on live GKE cluster:
  - Verified `boskosctl acquire`, JSON parsing, background heartbeat, release to `free` state, and start-of-job cleanup execution.