### PR TITLE
configs(kube-agents): enable sticky LGTM for the gke-labs Googlers team

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -75,7 +75,6 @@ lgtm:
   - chaotoppicks
   - google
   - grpc-ecosystem
-  - gke-labs/kube-agents
   review_acts_as_lgtm: true
 - repos:
   - GoogleContainerTools/config-sync
@@ -93,6 +92,10 @@ lgtm:
   - GoogleCloudPlatform/gke-mcp
   review_acts_as_lgtm: true
   trusted_team_for_sticky_lgtm: 'GKE MCP Contributors'
+- repos:
+  - gke-labs/kube-agents
+  review_acts_as_lgtm: true
+  trusted_team_for_sticky_lgtm: 'Googlers'
 
 label:
   additional_labels:


### PR DESCRIPTION
## What

Enables Prow's sticky LGTM for `gke-labs/kube-agents`, trusting the [`Googlers`](https://github.com/orgs/gke-labs/teams/googlers) team (28 members) in the `gke-labs` org.

Today every push to a pull request in that repo drops the label — `New changes are detected. LGTM label has been removed.` With sticky LGTM that removal is skipped when the PR **author** is in the trusted team, removing the re-LGTM round trip on rebases and review-feedback pushes.

## Why a new entry rather than an option on the existing one

`gke-labs/kube-agents` was listed in the first `lgtm` entry alongside the `GoogleCloudPlatform`, `GoogleContainerTools`, `chaotoppicks`, `google`, and `grpc-ecosystem` orgs. `Configuration.LgtmFor` returns the first entry containing an exact `org/repo` match and does not merge entries, so adding `trusted_team_for_sticky_lgtm` there would have enabled sticky LGTM across all five orgs.

Moving the repo to its own entry follows what `GoogleCloudPlatform/testgrid` and `GoogleCloudPlatform/gke-mcp` already do. `review_acts_as_lgtm: true` is carried over explicitly: it defaults to false, so dropping it would have silently stopped GitHub approvals counting as LGTM.

## Verification

- `go test -count=1 ./prow/tests/...` passes (4 tests). `TestMain` loads `plugins.yaml` through `PluginAgent()`, so this exercises parsing and validation of the new key.
- Temporary `LgtmFor` assertions (not committed) confirmed resolution is unchanged for the neighbouring repos and correct for this one:

  | repo | sticky team | `review_acts_as_lgtm` |
  | --- | --- | --- |
  | `gke-labs/kube-agents` | `Googlers` | true |
  | `GoogleCloudPlatform/testgrid` | `TestGrid Admins` | true |
  | `GoogleCloudPlatform/gke-mcp` | `GKE MCP Contributors` | true |
  | `google/*` | — | true |
  | `GoogleContainerTools/config-sync` | — | false |

- `Googlers` is the team's **display name**, which is what `stickyLgtm` compares against (`teamInOrg.Name`) — not the `googlers` slug.
- The `google-oss-prow` installation on `gke-labs` holds the `members: write` organization permission, so `ListTeams` / `ListTeamMembersBySlug` will succeed rather than failing closed.

## Trade-off

Sticky LGTM keys off the PR author, so a trusted author's `lgtm` survives any subsequent push, including a force-push that replaces the entire diff. `gke-labs/kube-agents` retains `approve` + OWNERS as the second gate, and the trusted set is limited to the 28 members of `Googlers`.

Generated with the help of Claude.
