### PR TITLE
configs(tide): author-scoped kubeflow/pipelines query for dependabot

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -105,6 +105,17 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
+  - repos:
+    - kubeflow/pipelines
+    author: "dependabot[bot]"
+    labels:
+    - ci-passed
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
   - orgs:
     - kubeflow
     labels:


### PR DESCRIPTION
Part of kubeflow/pipelines#14110. Depends on kubeflow/pipelines#14111 (classifier eligibility for Dependabot PRs).

Adds an author-scoped Tide query for kubeflow/pipelines so verified Dependabot PRs (carrying the SHA-bound `ci-passed` label, no `do-not-merge*`/`needs-rebase` labels) can merge after CI without per-PR human `lgtm`/`approved`. All other PRs keep the existing human-gated query unchanged; Tide remains the sole merge authority.

Keeps: `ci-passed`, required CI/DCO checks, `do-not-merge*` and `needs-rebase` missingLabels.
Omits for this narrow query only: human `lgtm` / `approved`.

Safety: eligibility is gated by the repo-local `ci-passed` classifier (SHA-bound to the current head, stripped on synchronize/reopen) plus Tide re-checking contexts every sync. No Actions add `lgtm`/`approved`; no GitHub native auto-merge or merge queue.

Landing order per the issue: kubeflow/pipelines#14111 lands first (classifier eligibility), then an observation window on real Dependabot PR label cycles, then this query — which only takes effect once `ci-passed` is actually being applied to Dependabot PRs.