### PR TITLE
configs(tide): author-scoped kubeflow/pipelines query for dependabot

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -108,8 +108,8 @@ tide:
   - repos:
     - kubeflow/pipelines
     author: "dependabot[bot]"
-    labels:
-    - ci-passed
+    # The ci-passed label is informational for this path: merge is gated by
+    # the required 'ci-passed' commit status in branch protection below.
     missingLabels:
     - do-not-merge
     - do-not-merge/hold
@@ -250,6 +250,14 @@ branch-protection:
       #required_status_checks:
       #  contexts:
       #  - cla/google
+      repos:
+        pipelines:
+          # Required merge gate (kubeflow/pipelines#14111): the ci-passed
+          # commit status is published on the verified head SHA only after
+          # the CI Check poll passes, so the label can remain informational.
+          required_status_checks:
+            contexts:
+            - ci-passed
       exclude:
       - "^revert-" # don't protect revert branches
       - "^dependabot/" # don't protect branches created by dependabot

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -105,6 +105,17 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
+  - repos:
+    - kubeflow/pipelines
+    author: "dependabot[bot]"
+    labels:
+    - ci-passed
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
   - orgs:
     - kubeflow
     labels:


### PR DESCRIPTION
Part of kubeflow/pipelines#14110. Depends on kubeflow/pipelines#14111 (Dependabot CI eligibility + SHA-bound `ci-passed` status).

## Summary

- Add an author-scoped Tide query for kubeflow/pipelines so Dependabot PRs with passing CI can merge without per-PR human `lgtm`/`approved`. All other PRs keep the existing human-gated query unchanged; Tide remains the sole merge authority.
- Make the `ci-passed` commit status a required branch-protection check for kubeflow/pipelines. The Dependabot query no longer requires the `ci-passed` label — the status context is the merge gate and the label is informational.

## Safety

- Eligibility is gated by the repo-local `ci-passed` classifier (SHA-bound to the verified head, status + label published only after the CI poll passes, label stripped on synchronize/reopen; the label job also re-reads the PR head before labeling).
- Tide re-checks contexts every sync. No Actions add `lgtm`/`approved`; no GitHub native auto-merge or merge queue.
- `do-not-merge*` and `needs-rebase` missingLabels retained.

## Behavior note for maintainers

This adds the first required status check for kubeflow/pipelines. The standard Tide flow is unchanged (ok-to-test → CI passes → `ci-passed` status + label published → lgtm + approved → merge). The one new constraint: UI merges of PRs without `ok-to-test` (and therefore no `ci-passed` status) will be blocked by branch protection, where previously no required status checks were configured.

## Landing order

kubeflow/pipelines#14111 must land first — the status must exist before it is required, otherwise master merges block on a check that is never published — then an observation window on real Dependabot PR label cycles, then this query, which only takes effect once `ci-passed` is actually being applied to Dependabot PRs.