### PR TITLE
feat(kube-agents): mount the bench ledger token and enable the eval minter

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -46,7 +46,12 @@ presubmits:
           # other credential source, and the *-infra repos are private.
           export BENCH_GITHUB_TOKEN="$(cat /etc/bench-github-token/BENCH_GITHUB_TOKEN)"
           # Turns on the in-cluster token minter, which is what lets the agent
-          # write that issue. Not a secret -- a GitHub App ID is public.
+          # write that issue. An App ID is an identifier, not a credential:
+          # minting requires signing a JWT with the App's private key, which
+          # is non-exportable inside each pool project's Cloud KMS. What bounds
+          # where a run can write is the App's installation list -- the three
+          # *-infra repos, repository_selection: selected -- not this value,
+          # which gke-labs/kube-agents already publishes.
           export EVAL_GITHUB_APP_ID="4675512"
           export REQUIRE_CACHE="true"
           # ─── Ensure boskosctl is available (pinned version) ─────────────────────────

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -41,6 +41,13 @@ presubmits:
           export PATH="$HOME/.local/bin:$PATH"
           curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh && chmod +x install-opentofu.sh && ./install-opentofu.sh --install-method standalone
           export GEMINI_API_KEY="$(cat /etc/gemini-secret/GEMINI_API_KEY)"
+          # The bench verifier reads back the GitHub ledger issue the run
+          # published and grades its contents; ledger_issue_contains has no
+          # other credential source, and the *-infra repos are private.
+          export BENCH_GITHUB_TOKEN="$(cat /etc/bench-github-token/BENCH_GITHUB_TOKEN)"
+          # Turns on the in-cluster token minter, which is what lets the agent
+          # write that issue. Not a secret -- a GitHub App ID is public.
+          export EVAL_GITHUB_APP_ID="4675512"
           export REQUIRE_CACHE="true"
           # ─── Ensure boskosctl is available (pinned version) ─────────────────────────
           if ! command -v boskosctl >/dev/null; then
@@ -112,7 +119,13 @@ presubmits:
         - name: gemini-secret
           mountPath: /etc/gemini-secret
           readOnly: true
+        - name: bench-github-token
+          mountPath: /etc/bench-github-token
+          readOnly: true
       volumes:
       - name: gemini-secret
         secret:
           secretName: kube-agents-gemini-api-key
+      - name: bench-github-token
+        secret:
+          secretName: kube-agents-bench-github-token


### PR DESCRIPTION
> **Prerequisite met.** `kube-agents-bench-github-token` was created in `test-pods` on `build-kube-agents` by hangdng@google.com at 2026-08-24T21:17:47Z, with key `BENCH_GITHUB_TOKEN` (verified). This is ready to merge.

## Summary

Adds the two credentials the fleet-audit eval scenarios need to `pull-kube-agents-smoke-test`: `BENCH_GITHUB_TOKEN`, mounted from a new secret, and `EVAL_GITHUB_APP_ID`, a plain value. Both follow the existing `gemini-secret` pattern rather than introducing a second mechanism.

## Why

Six fleet-audit scenarios are graded on the GitHub issue the run publishes rather than on the agent's chat reply — their SOPs mandate a one-line closing message that deliberately restates nothing, so the findings only exist in the issue. Two credentials make that work, in opposite directions:

- **`EVAL_GITHUB_APP_ID`** turns on the in-cluster GitHub token minter, which is how the agent authenticates to write the issue. `hack/ci-deploy.sh:175` keeps `githubMinter.enabled=false` until it is set. The value is a GitHub App ID, which is public — it appears in every JWT the App signs.
- **`BENCH_GITHUB_TOKEN`** is a read-only credential the bench verifier uses to read that issue back and grade it. `ledger_issue_contains` (`bench/kube_agents_bench/verifiers.py:524`) has no other source, and the `*-infra` repos are private, so without it every ledger check returns `status: "error"` and drives `VerificationCoverage` below the gate's floor.

## Prerequisites — verified 2026-08-24

`EVAL_GITHUB_APP_ID` is only safe to set once **every** project in the `kube-agents-evals-project` Boskos pool can serve it. A lease on an unprovisioned project would render the minter against a KMS key that does not exist, fail the readiness probe, and burn the full `helm upgrade --wait --timeout 15m` before the run dies. Checked across all three pool projects — `kube-agents-evals`, `kube-agents-evals-2`, `kube-agents-evals-3`:

- minter GSA `kubeagents-github-minter-gsa@<project>.iam.gserviceaccount.com` — present in all three
- key ring `github-token-minter-keyring`, key `github-token-minter-key` — present in all three
- one `ENABLED` `RSA_SIGN_PKCS1_2048_SHA256` key version — present in all three

App `4675512` (`kube-agents-evals-token-minter`) is installed on the three `*-infra` repos with `repository_selection: selected` and permissions `contents:write`, `issues:write`, `pull_requests:write`, `metadata:read`.

## The secret

`kube-agents-bench-github-token` in namespace `test-pods` on cluster `build-kube-agents`, key `BENCH_GITHUB_TOKEN`.

It holds a fine-grained PAT owned by `gke-agentic`, scoped to exactly the three `*-infra` repositories, with **Issues: Read-only** and **Metadata: Read-only** and nothing else. Verified before staging: it reads all three private repos and returns 404 on a private repo in the same org outside the three.

The token carries an expiry, and an expired token is indistinguishable from a valid one until a run fails, so it will need rotating.

## Risk

The job is `optional: true` and does not gate Tide. No other job reads either variable, and no other job mounts either secret, so a wrong value fails this job the same way it fails today and changes nothing elsewhere. Revert is a plain revert; nothing outside this repository has to be undone.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
