### PR TITLE
Update base_ref to v1.25 for kpt-config-sync release periodics

### DIFF
--- a/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
+++ b/prow/prowjobs/GoogleContainerTools/kpt-config-sync/kpt-config-sync-periodics-release.yaml
@@ -50,7 +50,7 @@ prow_ignored:
   - &config-sync-ci-ref
     org: GoogleContainerTools
     repo: kpt-config-sync
-    base_ref: v1.24
+    base_ref: v1.25
 - &config-sync-base-job-spec
   serviceAccountName: e2e-test-runner
   nodeSelector:


### PR DESCRIPTION
Update base_ref to v1.25 for kpt-config-sync release periodics as part of Config Sync 1.25.0 release.