### PR TITLE
fix(kube-agents): raise smoke-test timeout to 240m for three cases at three repetitions

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -22,11 +22,29 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      # The job averages ~43min, so 2h let a single hang sit on the only slot
-      # for nearly three times a normal run. 80m leaves generous headroom over
-      # the average while bounding what one wedged run costs the queue
-      # (gke-labs/kube-agents#635). Lower this again as the runtime comes down.
-      timeout: 85m
+      # Sized at roughly 2x the expected run, which is the ratio 85m held
+      # against the ~43min average it was set for (gke-labs/kube-agents#635).
+      # What moved is the expected run, not the policy: the job used to make
+      # two devops-bench invocations and now makes nine.
+      #
+      #   two active tasks x one run each  ->  ~43min   (85m, ~2.0x)
+      #   three active tasks x three reps  ->  ~78min   (150m, ~1.9x)
+      #
+      # Two changes get it there. gke-labs/kube-agents#939 activated a third
+      # case (cluster-agent-crashloop-debug), and #925 runs each case
+      # EVAL_REPETITIONS times, default 3, because the gate it lands grades a
+      # pass RATE per case rather than a single pass -- one flaky run no
+      # longer reds the job, but three runs are what a rate is computed from.
+      # Only the ~5min per task-repetition scales with that; the ~33min of
+      # Boskos lease, image build and deploy is paid once either way.
+      #
+      # 78min is an ESTIMATE and wants replacing with a measurement from the
+      # first runs at three repetitions. It is also probably pessimistic:
+      # gke-labs/kube-agents#951 stopped gpu-stress-test-diagnosis creating
+      # its own cluster per invocation, and cluster creation was the bulk of
+      # what a repetition of that task cost. Lower this again once the runs
+      # say what the number really is.
+      timeout: 150m
       grace_period: 5m
     spec:
       serviceAccountName: prowjob-default-sa


### PR DESCRIPTION
Raises `pull-kube-agents-smoke-test`'s timeout from `85m` to `240m`.

**This needs to land before `gke-labs/kube-agents#925`, not after.** That PR changes the number of devops-bench invocations the job makes; if it merges first, the job times out.

> **Updated 2026-08-26.** This PR originally proposed `150m` from an estimate. #925 has since had a full green run, so the number below is measured, and the measurement says `150m` is not enough. See [What changed from the first revision](#what-changed-from-the-first-revision).

## Why

`85m` was set against a job that made **two** invocations and averaged ~43min (`gke-labs/kube-agents#635`). It now makes **nine**:

- `gke-labs/kube-agents#939` activated a third case, `cluster-agent-crashloop-debug`.
- `gke-labs/kube-agents#925` runs each case `EVAL_REPETITIONS` times, default 3. That is not gold-plating: the gate it lands grades a pass **rate** per case instead of a single pass, so one flaky run no longer reds the job — and three runs are what a rate is computed from.

## The measurement

Job [2092688725648609280](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/925/pull-kube-agents-smoke-test/2092688725648609280) ran all three cases at one repetition on 2026-08-26 and went green in **52.2min** wall (`started.json` → `finished.json`). Per-case wall time is the gap between consecutive run directories; agent latency is from the run records:

| | wall | agent latency |
| --- | --- | --- |
| Boskos lease + image build + deploy | 14.4min | — (paid once) |
| `gpu-stress-test-diagnosis` | 21.1min | 1102s |
| `agent-kanban-smoke` | 14.1min | 800s |
| `cluster-agent-crashloop-debug` | 2.5min | 89s |
| **total** | **52.2min** | |

Only the per-invocation 37.8min scales with `EVAL_REPETITIONS`:

| | invocations | expected | timeout | ratio |
| --- | --- | --- | --- | --- |
| today | 2 | ~43min | 85m | ~2.0x |
| after #925 | 9 | **~128min** | **240m** | ~1.9x |

The policy is unchanged and deliberately so — the existing comment picked `85m` over `2h` to bound what one wedged run costs the only slot it holds, and `240m` keeps that same ratio against the larger run. What moved is the expected run, not the tolerance for a hang.

## What changed from the first revision

The original `150m` came from an estimate of ~78min: ~33min fixed setup plus ~5min per invocation. Both halves were wrong, and they did not cancel — setup is **less than half** what I assumed, while a repetition costs **~12.6min on average, not ~5min**. `150m` against a 128min run is **1.17x**, which a single slow `gpu-stress-test-diagnosis` erases; that case alone was 18.4min of agent time in the run above.

The first revision also predicted the estimate would prove pessimistic, because `gke-labs/kube-agents#951` stopped `gpu-stress-test-diagnosis` creating its own cluster per invocation. The measurement says otherwise. That case is still the most expensive of the three, and what it spends is agent time, not provisioning — so there is no reduction coming from that direction.

## What is still not known

**128min is a single sample**, and agent latency is both the dominant term and the most variable one — the three cases here span 89s to 1102s. Nothing yet says what the spread looks like across runs at three repetitions. The comment in the file asks for this to be revisited once several exist, explicitly in either direction.

I would rather over-provision the ceiling than red an optional job on a timeout, given the ceiling only costs anything on a run that has already hung. If the 4h worst case on a pool slot is the greater concern, `180m` (~1.4x) is the cost-conscious alternative and I am happy to take it instead — say the word.

## Testing

`go test ./prow/tests/...` passes.

One honest caveat about what that proves: **the suite does not validate `timeout` at all.** I checked by mutation — setting `timeout: 24h` also passes. So this confirms the file still parses and the job still loads, and nothing more; the number itself is a judgement call and wants a human eye.

Refs `gke-labs/kube-agents#635`, `gke-labs/kube-agents#925`, `gke-labs/kube-agents#939`, `gke-labs/kube-agents#951`.
