### PR TITLE
feat(kube-agents): point the smoke test at the eval baseline store, read-only

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -58,6 +58,28 @@ presubmits:
           # which gke-labs/kube-agents already publishes.
           export EVAL_GITHUB_APP_ID="4675512"
           export REQUIRE_CACHE="true"
+          # The evidence a pull request is GRADED AGAINST. Read-only here.
+          #
+          # One variable carries both directions, so turning the store on takes
+          # two exports in two files, and this is the one that gets forgotten.
+          # The nightly recorder sets the same variable and appends to it
+          # (periodic-kube-agents-eval-baseline). Without this line the
+          # presubmit reads the empty directory checked into the repo, finds no
+          # case admitted, and reports a green with the collapse rung, the
+          # judged-regression rung and the suite aggregate all inert -- the
+          # rate-based half of the gate silently absent, while the absolute
+          # rungs still block so it looks like it is working.
+          #
+          # What keeps a pull request from writing the baseline it is judged
+          # against is IAM, not this line: prowjob-default-sa is granted
+          # roles/storage.objectViewer on the bucket and NOT objectCreator,
+          # which is why the grant must be exactly that pair of roles and why
+          # the bucket lives in kube-agents-prow, where this account holds no
+          # project-level role that would override it. gke-labs/kube-agents
+          # also refuses to write when JOB_TYPE is not periodic/postsubmit and
+          # when PULL_NUMBER is set, but those are edits away; the missing role
+          # is not.
+          export EVAL_BASELINE_STORE="gs://kube-agents-evals-bench/evidence"
           # ─── Ensure boskosctl is available (pinned version) ─────────────────────────
           # Named once, used by both the GCS fast path and the fallback below.
           BOSKOSCTL_VERSION="v0.0.0-20260730151943-11fb0c84248b"


### PR DESCRIPTION
Points `pull-kube-agents-smoke-test` at the eval baseline store, **read-only**.

## When this can merge

**Not yet.** Two things have to be true first, and one of them is somebody else's:

1. **The bucket and the grant exist.** `gs://kube-agents-evals-bench` returns 404 today. The full provisioning runbook lives on [#2665](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2665) — bucket, the recorder's dedicated service account, Workload Identity, and the grants. This pull request depends on exactly one line of it, the last one:

   ```bash
   gcloud storage buckets add-iam-policy-binding "gs://kube-agents-evals-bench" \
     --member="serviceAccount:prowjob-default-sa@kube-agents-prow.iam.gserviceaccount.com" \
     --role=roles/storage.objectViewer
   ```

   `objectViewer` and **not** `roles/storage.objectCreator`. The omission is the whole point — see below. Confirm it landed that way rather than trusting the request:

   ```bash
   gcloud storage buckets get-iam-policy "gs://kube-agents-evals-bench" --format=json \
     | jq '.bindings[] | select(.members[]? | test("prowjob-default-sa"))'
   # expected: roles/storage.objectViewer, and nothing else
   ```

2. **`gke-labs/kube-agents#925` has merged.** That is the pull request that adds the scoring engine which reads this variable. Before it, `EVAL_BASELINE_STORE` is not read by anything and this line is inert.

The third blocker on the original list is gone: [#2667](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2667) merged, and the timeout has since been raised again to `240m` for the three-repetition matrix.

Ordering against the nightly recorder, [#2665](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2665): either order is safe, and **merging them together is better**. A reachable but empty store behaves exactly like today's empty checked-in one — nothing is admitted, the job is green — so this can land before a single line of evidence has been written. The reason to batch them is that they are two halves of one switch, and a half-thrown switch here is silent.

Holding as a draft until both hold.

## Why this is a separate export from the nightly's

`EVAL_BASELINE_STORE` is one variable carrying both directions: the nightly periodic sets it and appends, the presubmit sets it and reads. So switching the store on is **two exports in two job definitions**, and this is the one that gets forgotten — because forgetting it is invisible.

A presubmit that leaves it unset reads the empty `bench/baselines/` directory checked into the repo, finds no case admitted, and reports a **green**. Not an error, not a warning: a legitimate-looking pass with the collapse rung, the judged-regression rung and the suite aggregate all inert. The absolute rungs and the correctness floor still block, so the gate still catches things and still looks like it is working. The rate-based half — the entire reason `gke-labs/kube-agents#899` exists — is just absent.

## Why `objectViewer` and not `objectCreator`

A pull request must never write the baseline it is graded against.

`gke-labs/kube-agents` refuses to write twice in software: `hack/ci-eval-pr.sh` only records when `JOB_TYPE` is `periodic` or `postsubmit`, and `bench-gate record` refuses outright when `PULL_NUMBER` is set. Both are one careless edit away from not being true.

Withholding `objectCreator` from this job's identity is the guard that survives that edit, and it is why the bucket is sited in `kube-agents-prow`: `prowjob-default-sa` holds **no project-level role at all** there, so a bucket-level `objectViewer` grant is its entire access. In the Boskos pool projects the same account already holds `roles/storage.admin` and `roles/resourcemanager.projectIamAdmin`, where the same grant would restrict nothing.

The corollary is that the nightly recorder cannot run as `prowjob-default-sa` — one identity cannot hold `objectCreator` for one job and be denied it for another. That is the `TODO` on #2665, and it is load-bearing rather than a preference.

Neither role carries `storage.objects.delete`, and GCS implements an overwrite as a delete plus a create, so the evidence is append-only for both jobs.

## Testing

`go test ./prow/tests/...` passes.

The same caveat as #2667, restated because it applies here too: the suite validates that the file parses and the job loads. It does not execute the container command, so it cannot tell you this variable is spelled right or that the bucket resolves. The first real signal is a presubmit run after the bucket exists — which is another reason not to merge this ahead of item 1 above.

Refs `gke-labs/kube-agents#899`, `gke-labs/kube-agents#925`, GoogleCloudPlatform/oss-test-infra#2665, GoogleCloudPlatform/oss-test-infra#2667.

