### PR TITLE
fix(kube-agents): raise smoke-test timeout 150m -> 240m, replacing the estimate with a measurement

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -22,29 +22,55 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      # Sized at roughly 2x the expected run, which is the ratio 85m held
-      # against the ~43min average it was set for (gke-labs/kube-agents#635).
-      # What moved is the expected run, not the policy: the job used to make
-      # two devops-bench invocations and now makes nine.
+      # 85m was ~2x the ~43min this job averaged when it made two devops-bench
+      # invocations (gke-labs/kube-agents#635). It now makes THIRTY, and the
+      # policy of sizing above the expected run is unchanged -- only the
+      # expected run moved.
       #
-      #   two active tasks x one run each  ->  ~43min   (85m, ~2.0x)
-      #   three active tasks x three reps  ->  ~78min   (150m, ~1.9x)
+      #   two active tasks  x one run each  ->  ~43min   (85m,  2.0x)
+      #   ten active tasks  x one run each  ->  ~69min   (150m, 2.2x)
+      #   ten active tasks  x three reps    -> ~172min   (240m, 1.4x)
       #
-      # Two changes get it there. gke-labs/kube-agents#939 activated a third
-      # case (cluster-agent-crashloop-debug), and #925 runs each case
+      # Two independent changes get it there. gke-labs/kube-agents#956 took the
+      # active task matrix from three cases to ten -- six domain probes, one
+      # full-audit canary, and the incumbents. And #925 runs each case
       # EVAL_REPETITIONS times, default 3, because the gate it lands grades a
-      # pass RATE per case rather than a single pass -- one flaky run no
-      # longer reds the job, but three runs are what a rate is computed from.
-      # Only the ~5min per task-repetition scales with that; the ~33min of
-      # Boskos lease, image build and deploy is paid once either way.
+      # pass RATE per case rather than a single pass: one flaky run no longer
+      # reds the job, but three runs are what a rate is computed from.
       #
-      # 78min is an ESTIMATE and wants replacing with a measurement from the
-      # first runs at three repetitions. It is also probably pessimistic:
-      # gke-labs/kube-agents#951 stopped gpu-stress-test-diagnosis creating
-      # its own cluster per invocation, and cluster creation was the bulk of
-      # what a repetition of that task cost. Lower this again once the runs
-      # say what the number really is.
-      timeout: 150m
+      # 172min is MEASURED at one repetition and scaled, not estimated. Build
+      # 2092820036916875264 -- the run #956 merged on -- executed all ten tasks
+      # once in 68.9min wall (started.json -> finished.json):
+      #
+      #   fixed: Boskos lease, image build (710s), deploy, teardown   17.3min
+      #   consistency-authorized-networks-probe                       1039s
+      #   compliance-rbac-overgrant (the full-audit canary)            827s
+      #   gpu-stress-test-diagnosis                                    244s
+      #   cost-idle-pool-probe                                         175s
+      #   security-overgrant-probe                                     164s
+      #   cluster-agent-crashloop-debug                                149s
+      #   reliability-pdb-probe                                        148s
+      #   capacity-pinned-pool-probe                                   139s
+      #   agent-kanban-smoke                                           106s
+      #   upgrades-lagging-master-probe                                104s
+      #
+      # Only the 51.6min of invocations scales, so three repetitions is
+      # 17.3 + 3 x 51.6 = ~172min.
+      #
+      # 150m against that is 0.87x -- not a tight budget but a guaranteed
+      # timeout, which is why #925 cannot merge on the number #2667 set. 240m
+      # is 1.4x, thinner than this job's historical 2x, and it is not thinner
+      # still only because seeded-cluster reuse cut gpu-stress-test-diagnosis
+      # from 21.1min to 244s.
+      #
+      # The caveat, and it is a specific one rather than general unease:
+      # consistency-authorized-networks-probe cost 1039s against the 150-350s
+      # #956 budgets for each of its six probes, on the single run that exists.
+      # If that is its normal cost rather than one bad sample, the probe set is
+      # roughly a third more expensive than designed and 1.4x gets thin.
+      # Revisit in either direction once several runs at three repetitions
+      # exist.
+      timeout: 240m
       grace_period: 5m
     spec:
       serviceAccountName: prowjob-default-sa


### PR DESCRIPTION
Raises `pull-kube-agents-smoke-test`'s timeout from `150m` to `240m`.

**Follow-up to #2667**, which merged at `150m` a few minutes before this correction was ready. That number came from an estimate. `gke-labs/kube-agents` has since produced two full runs to measure against, and the second of them — after `gke-labs/kube-agents#956` took the active task matrix from three cases to **ten** — says `150m` is not a tight budget but a **guaranteed timeout**.

**This still needs to land before `gke-labs/kube-agents#925`, not after.** That PR changes the number of devops-bench invocations the job makes; at `150m` it times out instead of reporting a verdict.

## Why

`85m` was set against a job that made **two** invocations and averaged ~43min (`gke-labs/kube-agents#635`). It now makes **thirty**, from two independent changes:

- **`gke-labs/kube-agents#956`** (merged today) took the matrix from three active tasks to ten — six domain probes, one full-audit canary, and the incumbents.
- **`gke-labs/kube-agents#925`** runs each case `EVAL_REPETITIONS` times, default 3. That is not gold-plating: the gate it lands grades a pass **rate** per case instead of a single pass, so one flaky run no longer reds the job — and three runs are what a rate is computed from.

## The measurement

Build [2092820036916875264](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/956/pull-kube-agents-smoke-test/2092820036916875264) — the run `#956` merged on — executed all ten tasks at one repetition and took **68.9min** wall (`started.json` → `finished.json`):

| | wall |
| --- | --- |
| fixed: Boskos lease, image build (710s), deploy, teardown | 17.3min |
| `consistency-authorized-networks-probe` | 1039s |
| `compliance-rbac-overgrant` (full-audit canary) | 827s |
| `gpu-stress-test-diagnosis` | 244s |
| `cost-idle-pool-probe` | 175s |
| `security-overgrant-probe` | 164s |
| `cluster-agent-crashloop-debug` | 149s |
| `reliability-pdb-probe` | 148s |
| `capacity-pinned-pool-probe` | 139s |
| `agent-kanban-smoke` | 106s |
| `upgrades-lagging-master-probe` | 104s |
| **total** | **68.9min** |

Only the 51.6min of invocations scales with `EVAL_REPETITIONS`:

| | invocations | expected | 150m | 240m |
| --- | --- | --- | --- | --- |
| today, on `main` | 10 | ~69min | 2.18x | 3.48x |
| after #925 | 30 | **~172min** | **0.87x** | **1.40x** |

The policy is unchanged and deliberately so — the existing comment picked `85m` over `2h` to bound what one wedged run costs the only slot it holds. What moved is the expected run, not the tolerance for a hang. `240m` is 1.4x, which is thinner than this job's historical ~2x; it is not thinner still only because seeded-cluster reuse cut `gpu-stress-test-diagnosis` from 21.1min to 244s.

## What changed from #2667, and from this PR's own first revision

Recorded because the number has now moved twice and both moves were the same mistake — extrapolating from a matrix that then changed underneath.

- **#2667's `150m`** came from an estimate of ~78min: ~33min fixed setup plus ~5min per invocation. Fixed setup is really 17.3min, and a repetition really is ~5.2min on average — so the per-invocation figure was right all along, and what was wrong was the count.
- **This PR's first revision said ~128min**, off a three-case run. `#956` landed ten cases the following day. Same class of error, opposite direction.

#2667 also predicted the estimate would prove pessimistic because `gke-labs/kube-agents#951` stopped `gpu-stress-test-diagnosis` creating its own cluster per invocation. On that one point it was right, and by a wide margin: that case went from 21.1min to 244s, and it is now the third-cheapest of the ten rather than the most expensive. That reduction is most of why `240m` still holds at ten tasks.

## What is still not known

One specific risk rather than general unease. **`consistency-authorized-networks-probe` cost 1039s**, against the 150–350s `#956` budgets for each of its six probes, on the single run any of them has ever had. If that is its normal cost rather than one bad sample, the probe set is roughly a third more expensive than designed and 1.4x gets thin. The comment in the file asks for this to be revisited once several runs at three repetitions exist, explicitly in either direction.

I would rather over-provision the ceiling than red an optional job on a timeout, given the ceiling only costs anything on a run that has already hung. If the 4h worst case on a pool slot is the greater concern, say the word — but note that at 172min expected there is much less room to trade away than there was at 128min.

## Testing

`go test ./prow/tests/...` passes.

One honest caveat about what that proves: **the suite does not validate `timeout` at all.** I checked by mutation — setting `timeout: 24h` also passes. So this confirms the file still parses and the job still loads, and nothing more; the number itself is a judgement call and wants a human eye.

Refs `gke-labs/kube-agents#635`, `gke-labs/kube-agents#925`, `gke-labs/kube-agents#939`, `gke-labs/kube-agents#951`, `gke-labs/kube-agents#956`.
