### PR TITLE
Expand release package testgrids to include E2, C4A, N4 machine series

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -658,8 +658,85 @@ periodics:
       - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
       - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-a,europe-west1-b,asia-northeast1-b"
       - "-all_image_families=gce-unstable-pkg-test-images"
-      # Please keep filter list synced between all release package images. Do not edit this list; copy/paste from line 661 for any updates.
-      - "-filter=^(cvm|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|disk|ssh|metadata|vmspec)$"
+      - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|lssd|metadata|network|packagevalidation|security|ssh|vmspec)$"
       - "-set_exit_status=false"
       - "-x86_shape=c3-standard-4"
+      - "-architecture_type=x86"
+- name: cit-periodics-release-package-c4a
+  cluster: gcp-guest
+  decorate: true 
+  decoration_config:
+    timeout: 12h
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cit-periodics-release-package-c4a
+  # Run every 12 hours at 08:30, 20:30 UTC / 01:30, 13:30 PDT
+  cron: "30 8,20 * * *"
+  spec:
+    containers:
+    - image: gcr.io/compute-image-tools/cloud-image-tests:latest
+      imagePullPolicy: Always
+      command:
+      - "/manager"
+      args:
+      - "-parallel_count=25"
+      - "-project=gcp-guest"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-a,europe-west1-b,asia-northeast1-b"
+      - "-all_image_families=gce-unstable-pkg-test-images"
+      - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|metadata|network|packagevalidation|security|ssh|vmspec)$"
+      - "-set_exit_status=false"
+      - "-arm64_shape=c4a-standard-4"
+      - "-architecture_type=arm64"
+- name: cit-periodics-release-package-e2
+  cluster: gcp-guest
+  decorate: true
+  decoration_config:
+    timeout: 12h
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cit-periodics-release-package-e2
+  # Run every 12 hours at 08:00, 20:00 UTC / 01:00, 13:00 PDT
+  cron: "0 8,20 * * *"
+  spec:
+    containers:
+    - image: gcr.io/compute-image-tools/cloud-image-tests:latest
+      imagePullPolicy: Always
+      command:
+      - "/manager"
+      args:
+      - "-parallel_count=25"
+      - "-project=gcp-guest"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-a,europe-west1-b,asia-northeast1-b"
+      - "-all_image_families=gce-unstable-pkg-test-images"
+      - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|metadata|network|packagevalidation|security|ssh|vmspec)$"
+      - "-set_exit_status=false"
+      - "-x86_shape=e2-standard-4"
+      - "-architecture_type=x86"
+- name: cit-periodics-release-package-n4
+  cluster: gcp-guest
+  decorate: true
+  decoration_config:
+    timeout: 12h
+  annotations:
+    testgrid-dashboards: googleoss-gcp-guest
+    testgrid-tab-name: cit-periodics-release-package-n4
+  # Run every 12 hours at 07:30, 19:30 UTC / 00:30, 12:30 PDT
+  cron: "30 7,19 * * *"
+  spec:
+    containers:
+    - image: gcr.io/compute-image-tools/cloud-image-tests:latest
+      imagePullPolicy: Always
+      command:
+      - "/manager"
+      args:
+      - "-parallel_count=25"
+      - "-project=gcp-guest"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-west1-a,europe-west1-b,asia-northeast1-b"
+      - "-all_image_families=gce-unstable-pkg-test-images"
+      - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|metadata|network|packagevalidation|security|ssh|vmspec)$"
+      - "-set_exit_status=false"
+      - "-x86_shape=n4-standard-4"
       - "-architecture_type=x86"


### PR DESCRIPTION
/cc @bkatyl @akerekes @TylerJDao 

This PR expands the release package TestGrids to add testing against E2, C4A, and N4 machine families. 