### PR TITLE
feat(kube-agents): raise smoke test max_concurrency to 10

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -2,12 +2,10 @@ presubmits:
   gke-labs/kube-agents:
   - name: pull-kube-agents-smoke-test
     # Boskos dynamically leases an evaluation project per run from the
-    # kube-agents-evals-project pool, which holds six fully provisioned
-    # projects (kube-agents-evals through -6 — the last three completed
-    # 2026-08-26). max_concurrency matches the pool size, so the pool runs
-    # saturated: a project stuck dirty degrades throughput to 5 rather than
-    # queueing work.
-    max_concurrency: 6
+    # kube-agents-evals-project pool, which holds ten fully provisioned
+    # projects (kube-agents-evals through -10 — completed 2026-08-28).
+    # max_concurrency matches the pool size, so the pool runs saturated.
+    max_concurrency: 10
     # Boskos server, pool config and reaper for build-kube-agents:
     # gke-internal/test-infra deployments/gke-agentic-tooling-team/boskos
     # That pool is the ceiling and this is the tap: raising this past the


### PR DESCRIPTION
Boskos pool in gke-internal/test-infra has been expanded to 10 projects (kube-agents-evals through kube-agents-evals-10) and deployed. Raising max_concurrency to 10 to match the pool size.