### PR TITLE
feat(kube-agents): make the eval smoke presubmit merge-blocking

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -17,10 +17,13 @@ presubmits:
     # .md is root-anchored: agents/**/*.md is prompt content shipped in the
     # image (deploy/docker/Dockerfile), so those PRs must still run the eval.
     skip_if_only_changed: '^(docs/|\.github/|examples/)|^[^/]+\.md$|^(LICENSE|OWNERS|OWNERS_ALIASES)$'
-    # Reported on every PR but not merge-blocking: the job provisions a GKE
-    # cluster and runs a full eval, so it is currently too slow to gate Tide on.
-    # Drop this once the runtime is down.
-    optional: true
+    # Merge-blocking since 2026-09: what blocks is not this flag alone but the
+    # BOOTSTRAP_ADMITTED roster in the repo's hack/ci-eval-pr.sh -- only cases
+    # named there can red a PR, and demoting a flaky case is a same-day edit
+    # on the kube-agents side, not a change here. Repetition collapse (a case
+    # fails only when all 3 repetitions fail) and the harness's infra
+    # classification absorb single-rep flake and endpoint saturation.
+    optional: false
     decorate: true
     decoration_config:
       # 85m was ~2x the ~43min this job averaged when it made two devops-bench


### PR DESCRIPTION
Flips `pull-kube-agents-smoke-test` to `optional: false`. **Both prerequisites are merged**: gke-labs/kube-agents#1096 (the BOOTSTRAP_ADMITTED roster — 13 of 17 cases with a clean record gate; 4 hold-outs with written exit conditions) and gke-labs/kube-agents#1095 (agent-endpoint 429 saturation classified as infra, the last known false-red class).

Why now: the suite covers eleven domains at three repetitions, and this Monday alone two PRs' smoke reds were their own breakage — a NetworkPolicy change that cut agent DNS fleet-wide (16/16 tasks red) and a Helm/Terraform change that failed environment setup in under a minute. With the job optional, both would merge on a green tide.

Why the risk is bounded, and bounded on the kube-agents side: only roster-admitted cases can red a PR on a graded failure; a case fails only when all three repetitions fail; infra-classified repetitions are excluded from the verdict. Demoting a flaky case is a one-line same-day change in kube-agents — nothing needs to change back here. Wall clock is ~150 min on a full green three-repetition run against the 360m ceiling #2676 set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)