### PR TITLE
Add hourly kube-agents eval dashboard refresh periodic

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
@@ -3,9 +3,12 @@ periodics:
   # Keeps the kube-agents eval dashboard fresh: reads eval logs from GCS,
   # renders HTML, and writes two objects to the dashboard bucket. No Boskos
   # lease, no cluster provisioning, no GPU -- this is a cheap read/render/write
-  # job, so hourly is affordable.
+  # job: incremental collection scans only the builds that finished since the
+  # last tick, so a 15m cadence costs seconds of GCS listing per run and keeps
+  # the dashboard close enough to real time for flake forensics during an
+  # incident. max_concurrency 1 makes a slow tick skip, not stack.
   cluster: build-kube-agents
-  interval: 1h
+  interval: 15m
   max_concurrency: 1
   decorate: true
   decoration_config:
@@ -15,7 +18,7 @@ periodics:
     # No gke-labs dashboard exists in testgrid/config.yaml yet; skip TestGrid
     # (same pattern as louhi-echo-test-periodic).
     testgrid-create-test-group: "false"
-    description: Hourly refresh of the kube-agents eval dashboard from GCS eval logs.
+    description: 15-minute refresh of the kube-agents eval dashboard from GCS eval logs.
   extra_refs:
   - org: gke-labs
     repo: kube-agents

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
@@ -1,0 +1,44 @@
+periodics:
+- name: ci-kube-agents-eval-dashboard-refresh
+  # Keeps the kube-agents eval dashboard fresh: reads eval logs from GCS,
+  # renders HTML, and writes two objects to the dashboard bucket. No Boskos
+  # lease, no cluster provisioning, no GPU -- this is a cheap read/render/write
+  # job, so hourly is affordable.
+  cluster: build-kube-agents
+  interval: 1h
+  max_concurrency: 1
+  decorate: true
+  decoration_config:
+    timeout: 30m
+    grace_period: 2m
+  annotations:
+    # No gke-labs dashboard exists in testgrid/config.yaml yet; skip TestGrid
+    # (same pattern as louhi-echo-test-periodic).
+    testgrid-create-test-group: "false"
+    description: Hourly refresh of the kube-agents eval dashboard from GCS eval logs.
+  extra_refs:
+  - org: gke-labs
+    repo: kube-agents
+    base_ref: main
+    workdir: true
+  spec:
+    # prowjob-default-sa holds roles/storage.objectAdmin on
+    # gs://kube-agents-dashboards. Migrating this job to a dedicated
+    # eval-dashboard-publisher GSA is a tracked hardening follow-up
+    # (see the publish-hook prerequisites in gke-labs/kube-agents#1043).
+    serviceAccountName: prowjob-default-sa
+    containers:
+    # Same image the pull-kube-agents-smoke-test presubmit uses; this job only
+    # needs its bash + gcloud/gsutil toolchain.
+    - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:latest-1.32
+      command:
+      - ./hack/ci-dashboard-refresh.sh
+      env:
+      # The script is inert without this: it names the GCS prefix the rendered
+      # dashboard objects are written to.
+      - name: EVAL_DASHBOARD_TARGET
+        value: gs://kube-agents-dashboards/evals/
+      resources:
+        requests:
+          memory: "512Mi"
+          cpu: "250m"


### PR DESCRIPTION
Adds `ci-kube-agents-eval-dashboard-refresh`, an every 15 minutes periodic that keeps the kube-agents eval dashboard fresh by running `hack/ci-dashboard-refresh.sh` from `gke-labs/kube-agents@main`.

## What it does

- Reads eval logs from GCS, renders the dashboard HTML, and writes **two objects** to the dashboard bucket. That is the entire job: **no Boskos lease, no cluster provisioning, no GPU**, which is why an every 15 minutes cadence is cheap (30m timeout, 250m CPU / 512Mi requests).
- Runs on `build-kube-agents` with the same `kubekins-e2e` image the `pull-kube-agents-smoke-test` presubmit already uses for its checkout+bash+gcloud needs.

## Env contract

The script is inert without `EVAL_DASHBOARD_TARGET`; this job sets it to `gs://kube-agents-dashboards/evals/`, which names the GCS prefix the rendered objects are written to.

## DRAFT until the companion lands

`hack/ci-dashboard-refresh.sh` is being added in a companion gke-labs/kube-agents PR (branch `jayantid:feat/dashboard-refresh-job`, no PR number yet). The script path is the agreed contract between the two changes; this PR stays draft until that one merges.

## Service account / IAM

The job runs as the default `prowjob-default-sa`, which already holds `roles/storage.objectAdmin` on `gs://kube-agents-dashboards`, so no new IAM is required. Migrating to a dedicated `eval-dashboard-publisher` GSA is a tracked hardening follow-up, documented in the publish-hook prerequisites from gke-labs/kube-agents#1043.

TestGrid is skipped via `testgrid-create-test-group: "false"` (no gke-labs dashboard exists in `testgrid/config.yaml` yet — same pattern as `louhi-echo-test-periodic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
