### PR TITLE
Add Kubeflow MCP 0.2 milestone

### DIFF
--- a/prow/oss/plugins.yaml
+++ b/prow/oss/plugins.yaml
@@ -132,7 +132,8 @@ milestone_applier:
     release-0.2: v0.2
     release-0.1: v0.1
   kubeflow/mcp-server:
-    main: v0.1
+    main: v0.2
+    release-0.1: v0.1
 
 plugins:
   GoogleCloudPlatform:


### PR DESCRIPTION
Updating milestone for Kubeflow MCP after release-0.1 branch is created.
ref: https://github.com/kubeflow/mcp-server/releases/tag/0.1.1

cc @andreyvelich @thesuperzapper @jaiakash  
/assign @airbornepony @chases2 @cjwagner @michelle192837