### PR TITLE
Disable tide batch testing for gke-labs/kube-agents

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 tide:
+  batch_size_limit:
+    # Disable batch testing (-1) for kube-agents: the merge-blocking smoke
+    # presubmit runs 1.5-3.5h, so one failed batch stalls every merge behind a
+    # multi-hour retry loop (2026-09-02 incident: the pool backed up while the
+    # fix for the failing case sat inside it). Merges ride each PR's own green
+    # smoke instead. Merge-skew risk (two individually-green PRs interacting
+    # badly) is accepted, with the nightly full-catalog run as backstop.
+    # Revert this line if main starts breaking from merge skew.
+    gke-labs/kube-agents: -1
   merge_method:
     GoogleCloudPlatform/compute-image-tools: squash
     GoogleCloudPlatform/compute-image-windows: squash


### PR DESCRIPTION
Disables tide batch testing for `gke-labs/kube-agents` only, so merges proceed on each PR's own green `pull-kube-agents-smoke-test` context instead of batch re-runs on the merge pool.

## Why

`pull-kube-agents-smoke-test` became merge-blocking in #2677 and runs **1.5–3.5h**. Tide batch-tests the merge pool with required presubmits, so a single flaky batch cycle puts every queued merge behind a multi-hour retry loop. In today's incident (2026-09-02) the pool backed up for hours while the incident-response fix (gke-labs/kube-agents#1173) sat "in merge pool" inside it and ultimately needed an admin force-merge.

## What the knob does

`tide.batch_size_limit` is an org/repo-keyed map; per the tide config schema in [kubernetes-sigs/prow `pkg/config/tide.go`](https://github.com/kubernetes-sigs/prow/blob/main/pkg/config/tide.go) (the deployed tide/checkconfig images are built from this repo, `v20260812-b5681a827`):

```
// BatchSizeLimitMap is a key/value pair of an org or org/repo as the key and
// integer batch size limit as the value. Use "*" as key to set a global default.
// Special values:
//  0 => unlimited batch size
// -1 => batch merging disabled :(
```

So `gke-labs/kube-agents: -1` disables batching for this repo only; all other repos keep the default (no entry => unlimited).

## Tradeoff

Accepted per the kube-agents TL: merge-skew risk (two individually-green PRs interacting badly on main), backstopped by the nightly full-catalog run under review (gke-labs/kube-agents#1175 / #2682). Serial merges through a 1.5–3.5h required context are slower, but the pool can no longer be wedged by one flaky batch.

**Revert path:** delete the one `gke-labs/kube-agents: -1` line if main starts breaking from merge skew.

Validated locally with strict YAML parse + duplicate-key detection; `pull-prow-config-validate` (checkconfig `--strict` with `unknown-fields-all`) is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Scope note — why repo-level disable is surgical here:** tide batches only re-run *Prow presubmits*, and `pull-kube-agents-smoke-test` is this repo's only one — every other required check is a GitHub Actions workflow, which never runs on batch refs and continues to gate per-PR unchanged. So this setting is equivalent to "exclude smoke from pool re-runs" (a per-job knob upstream Prow does not have): each PR still cannot merge without its own green smoke plus all Actions checks. This equivalence expires if the repo ever adds a second, cheap Prow presubmit worth batch-testing — revisit then.
