### PR TITLE
Add ci-kube-agents-pool-pressure periodic and the googleoss-kube-agents dashboard

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
@@ -23,6 +23,11 @@ periodics:
     testgrid-alert-email: hangdng@google.com
     testgrid-num-failures-to-alert: '3'
     testgrid-alert-stale-results-hours: '6'
+    # Prints the named property inside the result cells. One name for the whole
+    # test group, looked up per cell, so every row the check writes carries its
+    # own number under this name. Inert until the run writes a junit*.xml
+    # holding it -- a cell with no such property renders as it does today.
+    testgrid-in-cell-metric: value
     description: >-
       Measures how long kube-agents CI runs wait before their test can start and
       fails when the pool runbook's thresholds trip. Leases nothing from Boskos.

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml
@@ -1,0 +1,60 @@
+periodics:
+- name: ci-kube-agents-pool-pressure
+  # Hourly, off the hour so the sweep does not start alongside the presubmit herd.
+  cron: "23 * * * *"
+  # Same cluster as pull-kube-agents-smoke-test. Boskos is ClusterIP-only, so
+  # --boskos-via http only resolves from inside it.
+  cluster: build-kube-agents
+  max_concurrency: 1
+  decorate: true
+  decoration_config:
+    # A 7-day sweep read 476 builds in 288s from this cluster on 2026-09-02 and
+    # build volume is climbing, so the ceiling is generous and the script's own
+    # --deadline-seconds stops it well before the pod is killed. A killed pod
+    # reds the tab without saying anything about the queue.
+    timeout: 30m
+  extra_refs:
+  - org: gke-labs
+    repo: kube-agents
+    base_ref: main
+  annotations:
+    testgrid-dashboards: googleoss-kube-agents
+    testgrid-tab-name: pool-pressure
+    testgrid-alert-email: hangdng@google.com
+    testgrid-num-failures-to-alert: '3'
+    testgrid-alert-stale-results-hours: '6'
+    description: >-
+      Measures how long kube-agents CI runs wait before their test can start and
+      fails when the pool runbook's thresholds trip. Leases nothing from Boskos.
+  spec:
+    serviceAccountName: prowjob-default-sa
+    containers:
+    - image: gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+      command:
+      - /bin/sh
+      - -c
+      # The working directory after an extra_refs clone is the repo root.
+      # Exit 1 is a threshold breach and exit 2 is "could not measure"; both red
+      # the tab on purpose, because a check that goes green having read nothing
+      # is worse than no check. So the exit code is captured and re-raised at the
+      # end rather than being piped into another process, whose status would
+      # replace it.
+      #
+      # --json writes only JSON, with the human-readable report nested under
+      # "report". The artifact gets the JSON and the build log gets the report,
+      # because the build log is what a person opens from the TestGrid cell.
+      - |
+        set -eu
+        OUT="${ARTIFACTS:-/tmp}/pool-pressure.json"
+        rc=0
+        python3 scripts/pool_pressure.py \
+          --boskos-via http \
+          --deadline-seconds 1500 \
+          --json > "${OUT}" || rc=$?
+        python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["report"])' \
+          "${OUT}" || cat "${OUT}" || true
+        exit "${rc}"
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi

--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -149,6 +149,11 @@ presubmits:
           BOSKOS_OWNER="${JOB_NAME}-${BUILD_ID}"
           BOSKOSCTL=(boskosctl --server-url="${BOSKOS_SERVER}" --owner-name="${BOSKOS_OWNER}")
 
+          # ci-kube-agents-pool-pressure parses these banners out of build-log.txt
+          # to time the Boskos acquire: it matches "=== [<timestamp>] <text> ==="
+          # and picks the first whose text contains "boskos", then measures to the
+          # next timestamped banner. Reword freely, but keep the timestamp and the
+          # word "boskos" or that segment stops being measured.
           echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Leasing GCP Project from Boskos ==="
           RESOURCE="$("${BOSKOSCTL[@]}" acquire --type="${BOSKOS_RESOURCE_TYPE}" \
             --state=free --target-state=busy --timeout=10m)"

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -17,6 +17,7 @@ dashboards:
 - name: googleoss-kpt-config-sync-misc
 - name: googleoss-jwt-verify-lib
 - name: googleoss-rhos-periodic
+- name: googleoss-kube-agents
 
 dashboard_groups:
   - name: googleoss
@@ -31,6 +32,7 @@ dashboard_groups:
     - googleoss-grpc-transcoder
     - googleoss-http-pattern-matcher
     - googleoss-jwt-verify-lib
+    - googleoss-kube-agents
   - name: googleoss-kubeflow
     dashboard_names:
     - googleoss-kubeflow-pipelines


### PR DESCRIPTION
> **Unblocked.** This job clones kube-agents `main` and runs `scripts/pool_pressure.py`. That script landed in gke-labs/kube-agents#1192 on 2026-09-03, which was the only reason this PR was held. Ready for `/unhold`.

Runs the kube-agents pool-pressure check as an hourly periodic and creates the TestGrid dashboard it reports to. The check measures how long kube-agents CI runs wait before their test can start and fails when the pool runbook's thresholds trip. It leases nothing from Boskos and needs no new credential.

For gke-labs/kube-agents#1069.

**What's here**

- `prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml` — new, `ci-kube-agents-pool-pressure`, hourly at :23 on `build-kube-agents`.
- `testgrid/config.yaml` — declares `googleoss-kube-agents` and adds it to the `googleoss` group. kube-agents has no TestGrid presence today, and a job naming a dashboard that doesn't exist is a config error.
- `kube-agents-presubmits.yaml` — a comment above the `Leasing GCP Project from Boskos` banner. The check parses `=== [<timestamp>] <text> ===` and picks the first whose text contains `boskos`. Reword freely; dropping the timestamp or the word stops that segment being measured.

**A few choices worth flagging**

`cluster: build-kube-agents` — same cluster as `pull-kube-agents-smoke-test`. Boskos is ClusterIP-only, so `/metric` only resolves from inside it. Reading it leases nothing.

`google-cloud-cli:alpine` rather than `kubekins-e2e` — the check needs `gcloud` and `python3` and nothing else.

Exit 2 reds the tab on purpose: a check that goes green having read nothing is worse than no check. `testgrid-num-failures-to-alert: '3'` debounces a transient error; `testgrid-alert-stale-results-hours: '6'` catches the job silently ceasing to run.

Thresholds aren't in the job config — they default from constants in the script that cite the runbook, so the policy has one home.

**Verified**

The job's exact shell block was run on 2026-09-02 in a pod in `build-kube-agents`/`test-pods` as `prowjob-default-sa`, on the image named here, when the pool stood at 15 projects. The script was piped in, since #1192 had not merged yet; everything else is what the job will do.

```
476 builds read in 288.4s.
window         455      0.4     56.5    139.8
THRESHOLD BREACHED on 3 day(s): 2026-08-28, 2026-09-01, 2026-09-02
CAPACITY. Every project was leased while runs were waiting...
Pool state: 15 leased, 0 free, 15 projects total
```

288s against the 30m timeout, no truncation. The pod terminated non-zero, which is why the block captures and re-raises the exit code instead of piping into `tee` — under a pipe the status is the last command's and every breach would report green. `--json` prints only JSON with the report nested inside, so the block writes the JSON to `${ARTIFACTS}` and prints the report to the log, which is what a person opens from a red cell.

Also checked as that identity rather than assumed: `python3` is on the image (3.14.6); `gcloud storage cat` of a `gs://kube-agents-prow` object succeeds, so no IAM grant is needed; Boskos and Deck are both reachable. `prowjob-default-sa` has no project-level binding in `kube-agents-prow`, so that read is bucket-level and couldn't be confirmed from IAM — only by running as the identity. The relative script path follows `testgrid-canary-autobump`, which passes `--config=cluster/...` after an `extra_refs` clone.

Both probe pods were `--rm` and are gone; neither leased a project.

**Not verifiable before merge:** whether the cron fires, whether TestGrid ingests the tab, and whether `testgrid-alert-email` delivers.

**Risk:** one periodic on an existing cluster plus two config lines. It runs hourly for about five minutes, holds no lease, and writes nothing outside its artifacts, so it can't starve the presubmits it measures. Revert by deleting the file and the two `testgrid/config.yaml` lines.

The failure mode to expect is mail, not silence: a threshold breach and a broken run both red the tab and both mail after three consecutive failures.

**How likely that is has changed since this PR was written.** It was drafted against a 15-project pool at `max_concurrency: 15`, where the pool ran saturated and early reds looked likely. The pool is now **30 projects at `max_concurrency: 30`**. Re-measured on 2026-09-08 with `main`'s script over a two-day window, 125 builds read in 42.2s:

```
day           runs      p50      p95    worst   conc
2026-09-07      40      0.4      0.6      2.5     30
2026-09-08      75      0.4      0.5      0.5     30
Pool state: 16 leased, 14 free, 30 projects total
WITHIN THRESHOLD. No action.
```

So the tab starts green and exits 0. The alerting can be watched rather than braced for.

Note for whoever reviews alongside #2665: that PR also adds `prow/prowjobs/gke-labs/kube-agents/kube-agents-periodics.yaml`. If this lands first, #2665 becomes an edit to the file rather than a new one.

Generated with the help of Claude Opus 5.

