### PR TITLE
feat(kube-agents): increase pull-kube-agents-smoke-test max_concurrency to 30

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -2,10 +2,10 @@ presubmits:
   gke-labs/kube-agents:
   - name: pull-kube-agents-smoke-test
     # Boskos dynamically leases an evaluation project per run from the
-    # kube-agents-evals-project pool, which holds fifteen fully provisioned
-    # projects (kube-agents-evals through -15 — completed 2026-09-01).
+    # kube-agents-evals-project pool, which holds thirty fully provisioned
+    # projects (kube-agents-evals through -30 — completed 2026-09-03).
     # max_concurrency matches the pool size, so the pool runs saturated.
-    max_concurrency: 15
+    max_concurrency: 30
     # Boskos server, pool config and reaper for build-kube-agents:
     # gke-internal/test-infra deployments/gke-agentic-tooling-team/boskos
     # That pool is the ceiling and this is the tap: raising this past the


### PR DESCRIPTION
## Summary

Increases `max_concurrency` for `pull-kube-agents-smoke-test` from 15 to 30 in `prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml`.

## Why This Change

Matches the CI evaluation pool expansion onboarding `kube-agents-evals-16` through `kube-agents-evals-30` (tracked in gke-labs/kube-agents#1194) and the Boskos pool update in cl/2245750.

Allows up to 30 concurrent pull request smoke tests to execute in parallel on the `build-kube-agents` cluster, eliminating queue backlogs during burst periods.

## Testing

- Go Unit Tests: `go test ./prow/...` passed (`ok`).
- Live Project Validation:
  - Evaluation pool projects mapped in gke-labs/kube-agents#1194.
  - Boskos resource pool roster expanded to 30 resources in cl/2245750.
