### PR TITLE
feat(kube-agents): skip the smoke presubmit on tests, release scripts and installer entrypoints

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -14,9 +14,22 @@ presubmits:
     cluster: build-kube-agents
     always_run: false
     skip_report: false
-    # .md is root-anchored: agents/**/*.md is prompt content shipped in the
-    # image (deploy/docker/Dockerfile), so those PRs must still run the eval.
-    skip_if_only_changed: '^(docs/|\.github/|examples/)|^[^/]+\.md$|^(LICENSE|OWNERS|OWNERS_ALIASES)$'
+    # Only paths that cannot change what the agent does at eval time belong
+    # here: a diff confined to them leaves the eval nothing to measure, and
+    # running it anyway spends two hours and a leased eval project to grade
+    # behaviour the diff cannot reach. .md is root-anchored because
+    # agents/**/*.md is prompt content shipped in the image
+    # (deploy/docker/Dockerfile). tests/ is not shipped at all. scripts/release/
+    # runs at release time, and this job never invokes the root installer
+    # entrypoints, so neither is in the path of the agent under test.
+    #
+    # bench/ must never appear here -- it is the eval harness itself, so a
+    # change to it is exactly when the gate has to run -- and neither may
+    # agents/, deploy/, charts/ or k8s-operator/, which all reach the running
+    # agent. The filter skips only when every changed file matches, so one
+    # runtime file anywhere in a diff runs the full eval regardless: this
+    # decides what triggers the job, never what the job checks.
+    skip_if_only_changed: '^(docs/|\.github/|examples/|tests/|scripts/release/)|^[^/]+\.md$|^(LICENSE|OWNERS|OWNERS_ALIASES|\.gitignore|install\.sh|upgrade\.sh|uninstall\.sh)$'
     # Merge-blocking since 2026-09: what blocks is not this flag alone but the
     # BOOTSTRAP_ADMITTED roster in the repo's hack/ci-eval-pr.sh -- only cases
     # named there can red a PR, and demoting a flaky case is a same-day edit


### PR DESCRIPTION
`pull-kube-agents-smoke-test` already has a path filter. It was narrow enough that changes which cannot reach the agent under test still paid a full ~2h run, held a Boskos eval project for the duration, and could be red-flagged by agent behaviour their diff had no path to affect.

## Motivating case

gke-labs/kube-agents#1093 is a release bundle/SBOM change: `scripts/release/`, `install.sh`, `upgrade.sh`, `tests/`, `.gitignore`, docs. None of it matched the old alternatives, so it ran the eval repeatedly and went red on `compliance-rbac-overgrant`, `rca-remediation-pr` and `agent-kanban-smoke` — all three since shown to be environment-side (gke-labs/kube-agents#1171, #1189, #1184), and none of which its diff could affect.

Two facts make this safe rather than a bypass: the job never invokes the root installer entrypoints (no reference to `install.sh`, `upgrade.sh`, `lifecycle.sh` or Terraform anywhere in a build log), and `tests/` is not shipped in the image.

## Change

Adds `tests/`, `scripts/release/` and the root entrypoints `install.sh`, `upgrade.sh`, `uninstall.sh`, `.gitignore` to `skip_if_only_changed`.

Deliberately excluded, and called out in a comment so the list does not drift into a blanket bypass: `bench/` is the eval harness itself — a change there is precisely when the gate should run — and `agents/`, `deploy/`, `charts/` and `k8s-operator/` all reach the running agent. `.md` stays root-anchored because `agents/**/*.md` is prompt content shipped in the image.

## Validation

Applied the new pattern to the file lists of real pull requests:

| PR | changed paths | result |
|----|----|----|
| gke-labs/kube-agents#1093 | 21 files, release packaging | **skip** — the motivating case |
| gke-labs/kube-agents#1160 | `tests/e2e/` only | **skip** |
| gke-labs/kube-agents#1152 | installer, terraform, `agents/**/*.md` | **run** |
| gke-labs/kube-agents#1041 | `charts/` templates and values | **run** |

Negative controls, each correctly unmatched so the eval still runs: `agents/platform/skills/x/SKILL.md`, `bench/tasks/foo/task.yaml`, `deploy/docker/Dockerfile`, `charts/kube-agents/values.yaml`, `k8s-operator/main.go`, `hack/ci-eval-pr.sh`.

YAML parses and the pattern compiles. No other job or field is touched.

## Scope note

`skip_if_only_changed` skips only when *every* changed file matches, so one runtime file anywhere in a diff and the full eval runs regardless. This narrows what triggers the job, not what the job checks once it starts.

Generated with the help of Claude (Opus 5).