### PR TITLE
feat(kube-agents): cap tide batches at 2 and pin prioritize_existing_batches

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -13,6 +13,26 @@
 # limitations under the License.
 
 tide:
+  batch_size_limit:
+    # Cap kube-agents tide batches at PAIRS. The repo's merge-blocking smoke
+    # presubmit runs 1.5-3.5h, and a batch is discarded whenever any member
+    # drops out of the pool mid-flight -- observed 2026-09-03: a PASSING
+    # two-PR batch was thrown away because one member's individual retest
+    # flaked while the batch ran (GoogleCloudPlatform/oss-test-infra#2687).
+    # Batch survival is the product of member stability over a multi-hour
+    # window, so wide batches almost never land; pairs keep the 2x
+    # amortization while bounding one member's flake to one wasted partner.
+    # Upstream semantics (kubernetes-sigs/prow pkg/config/tide.go):
+    # 0 => unlimited (the default), -1 => disabled. Raise to 3 if the
+    # per-run green rate stays >95%; revisit if tide grows green-batch
+    # salvage (#2687).
+    gke-labs/kube-agents: 2
+  prioritize_existing_batches:
+    # Already the upstream default (true); pinned here so the repo's
+    # batching posture is explicit next to the size cap: finish an
+    # in-flight batch and reuse its results rather than restarting when
+    # new PRs become eligible -- restarts cost a full 1.5-3.5h run.
+    gke-labs/kube-agents: true
   merge_method:
     GoogleCloudPlatform/compute-image-tools: squash
     GoogleCloudPlatform/compute-image-windows: squash


### PR DESCRIPTION
Supersedes #2683 (which proposed disabling batching under a since-withdrawn theory — full correction history on #2687).

## What

Two tide settings for `gke-labs/kube-agents` only:
- `batch_size_limit: 2` — the default is **unlimited** ([kubernetes-sigs/prow pkg/config/tide.go](https://github.com/kubernetes-sigs/prow/blob/main/pkg/config/tide.go#L243): `0 => unlimited, -1 => disabled`). With a 1.5–3.5h merge-blocking presubmit, batch survival is the product of every member's stability over the flight window; on 2026-09-03 a **passing** two-PR batch was discarded because one member's individual retest flaked mid-flight, and the innocent PR sat mergeable ~8h (timeline in #2687). Pairs keep the 2× amortization while bounding one flake to one wasted partner. We'll propose raising to 3 if the repo's per-run green rate holds >95%.
- `prioritize_existing_batches: true` — upstream's default, pinned for legibility beside the cap: finish in-flight batches and reuse results rather than restarting when new PRs become eligible (a restart costs a full run).

## Why draft

Opened as draft pending the owners' read on #2687's questions (esp. whether green-batch salvage exists or is planned, which would change the calculus). If the answer is "tune batch size," this is the tuning; happy to adjust values to your guidance. #2683 will be closed in favor of this.

## Context

- #2687 — the throughput diagnosis (serial fresh-base retests + batch fragility at multi-hour job lengths).
- gke-labs/kube-agents#1202 — the repo-side plan this pairs with (flake elimination, wall-clock reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)