### PR TITLE
feat(kube-agents): skip the smoke presubmit on the unit tests under scripts/

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml
@@ -19,9 +19,13 @@ presubmits:
     # running it anyway spends two hours and a leased eval project to grade
     # behaviour the diff cannot reach. .md is root-anchored because
     # agents/**/*.md is prompt content shipped in the image
-    # (deploy/docker/Dockerfile). tests/ is not shipped at all. scripts/release/
-    # runs at release time, and this job never invokes the root installer
-    # entrypoints, so neither is in the path of the agent under test.
+    # (deploy/docker/Dockerfile). tests/ is not shipped at all, and neither are
+    # the unit tests beside the repository tooling, scripts/test_*.py: the
+    # Dockerfile copies agents/*/scripts/, not scripts/. scripts/ as a whole
+    # stays off the list because hack/ci-eval-pr.sh reads scripts/eval_dashboard/
+    # from the tree it runs in. scripts/release/ runs at release time, and this
+    # job never invokes the root installer entrypoints, so neither is in the
+    # path of the agent under test.
     #
     # bench/ must never appear here -- it is the eval harness itself, so a
     # change to it is exactly when the gate has to run -- and neither may
@@ -29,7 +33,7 @@ presubmits:
     # agent. The filter skips only when every changed file matches, so one
     # runtime file anywhere in a diff runs the full eval regardless: this
     # decides what triggers the job, never what the job checks.
-    skip_if_only_changed: '^(docs/|\.github/|examples/|tests/|scripts/release/)|^[^/]+\.md$|^(LICENSE|OWNERS|OWNERS_ALIASES|\.gitignore|install\.sh|upgrade\.sh|uninstall\.sh)$'
+    skip_if_only_changed: '^(docs/|\.github/|examples/|tests/|scripts/release/)|^scripts/test_[^/]+\.py$|^[^/]+\.md$|^(LICENSE|OWNERS|OWNERS_ALIASES|\.gitignore|install\.sh|upgrade\.sh|uninstall\.sh)$'
     # Merge-blocking since 2026-09: what blocks is not this flag alone but the
     # BOOTSTRAP_ADMITTED roster in the repo's hack/ci-eval-pr.sh -- only cases
     # named there can red a PR, and demoting a flaky case is a same-day edit


### PR DESCRIPTION
The filter exempts tests/ because nothing in it is shipped, but the unit tests beside
the repository tooling live at scripts/test_*.py and matched no alternative, so a
test-only change under scripts/ ran the full eval.

gke-labs/kube-agents#1233 is the motivating case: a workflow edit under .github/ plus
two test files under scripts/ ran the two-hour eval and leased a project to grade
behaviour the diff had no path to. The Dockerfile copies agents/*/scripts/, not
scripts/, so those tests never reach the agent under test.

Only the top-level test files are added. scripts/ as a whole stays off the list
because hack/ci-eval-pr.sh reads scripts/eval_dashboard/ from the tree it runs in,
and tests nested under scripts/*/ stay with their directories.

As before, the filter skips only when every changed file matches, so this narrows
what triggers the job, not what the job checks once it starts.

Validation: `go test .` in prow/tests passes; the new pattern was checked against the
three files in gke-labs/kube-agents#1233 (all now skip) and against
scripts/github_api.py, scripts/eval_dashboard/test_publish.py,
agents/platform/scripts/test_credential_proxy.py and bench/tests/test_x.py (all still
run).
