### PR TITLE
feat(kube-agents): tide ejects GitHub-BLOCKED PRs instead of silently retrying

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -13,6 +13,17 @@
 # limitations under the License.
 
 tide:
+  github_merge_blocks_policy:
+    # Eject GitHub-BLOCKED pull requests from the kube-agents merge pool
+    # instead of silently retrying ("permit", the default). Observed twice:
+    # 2026-09-01, one PR accumulated 231 silent merge attempts over 5h46m
+    # behind an unresolved-comments ruleset; 2026-09-05, tide batched the
+    # only two GitHub-BLOCKED PRs in the pool (heads missing now-required
+    # checks) and the batch-capture rule held ~13 mergeable PRs hostage
+    # behind the unmergeable pair. With "block", such PRs leave the pool
+    # with an explicit status message until their GitHub-side blocker is
+    # fixed. Evidence: GoogleCloudPlatform/oss-test-infra#2687.
+    gke-labs/kube-agents: block
   merge_method:
     GoogleCloudPlatform/compute-image-tools: squash
     GoogleCloudPlatform/compute-image-windows: squash


### PR DESCRIPTION
One map entry: `github_merge_blocks_policy: gke-labs/kube-agents: block`.

**Why now**: reproducing live tonight — tide batched the only two GitHub-BLOCKED PRs in the pool (old heads missing now-required checks; GitHub refuses the merge), the batch cannot complete, and the batch-capture rule is holding ~13 individually-mergeable PRs hostage behind it. Second occurrence of the silent-retry class: on 2026-09-01 a PR accumulated **231 silent merge attempts over 5h46m** behind an unresolved-comments ruleset. With `block`, such PRs leave the pool with an explicit status message naming the problem, and the rest of the queue flows.

Semantics verified against kubernetes-sigs/prow `pkg/config/tide.go` (`GitHubMergeBlocksPolicyMap`; "ignore"/"permit"/"block", default permit-with-warnings). Caveat stated honestly: field presence in the deployed tide vintage inferred from source-of-the-image-date; checkconfig on this PR is the authoritative validation. Full mechanics + timeline: #2687; repo-side context: gke-labs/kube-agents#1202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)