### PR TITLE
Update release-package TestGrid configurations for parallelism, testing zones, and testing projects.

### DIFF
--- a/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/gcp-guest/gcp-guest-config.yaml
@@ -653,10 +653,11 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=25"
+      - "-parallel_count=20"
+      - "-parallel_stagger=30s"
       - "-project=gcp-guest"
-      - "-test_projects=gce-unstable-pkg-test-images"
-      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-c,us-west1-a,europe-west1-b,europe-west4-a,asia-northeast1-b,asia-southeast1-b"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-c,us-west1-a,us-west1-b,us-west1-c,europe-west1-b,europe-west1-c,europe-west4-a,europe-west4-b,europe-west4-c,asia-southeast1-a,asia-southeast1-b,asia-southeast1-c,asia-northeast1-a,asia-northeast1-b"
       - "-all_image_families=gce-unstable-pkg-test-images"
       - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|lssd|metadata|network|packagevalidation|security|ssh|vmspec)$"
       - "-set_exit_status=false"
@@ -679,10 +680,11 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=25"
+      - "-parallel_count=20"
+      - "-parallel_stagger=30s"
       - "-project=gcp-guest"
-      - "-test_projects=gce-unstable-pkg-test-images"
-      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-c,us-west1-a,europe-west1-b,europe-west4-a,asia-northeast1-b,asia-southeast1-b"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-c,us-west1-a,us-west1-b,us-west1-c,europe-west1-b,europe-west1-c,europe-west4-a,europe-west4-b,asia-east1-a,asia-east1-b,asia-east1-c,asia-southeast1-a,asia-southeast1-b"
       - "-all_image_families=gce-unstable-pkg-test-images"
       - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|metadata|network|packagevalidation|security|ssh|vmspec)$"
       - "-set_exit_status=false"
@@ -705,10 +707,11 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=25"
+      - "-parallel_count=20"
+      - "-parallel_stagger=30s"
       - "-project=gcp-guest"
       - "-test_projects=gce-unstable-pkg-test-images"
-      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-c,us-west1-a,europe-west1-b,europe-west4-a,asia-northeast1-b,asia-southeast1-b"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-c,us-west1-a,us-west1-b,us-west1-c,europe-west1-b,europe-west1-c,europe-west1-d,europe-west4-a,europe-west4-b,europe-west4-c,asia-east1-a,asia-east1-b,asia-east1-c,asia-northeast1-a,asia-northeast1-b,asia-southeast1-a"
       - "-all_image_families=gce-unstable-pkg-test-images"
       - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|metadata|network|packagevalidation|security|ssh|vmspec)$"
       - "-set_exit_status=false"
@@ -731,10 +734,11 @@ periodics:
       command:
       - "/manager"
       args:
-      - "-parallel_count=25"
+      - "-parallel_count=20"
+      - "-parallel_stagger=30s"
       - "-project=gcp-guest"
-      - "-test_projects=gce-unstable-pkg-test-images"
-      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-c,us-west1-a,europe-west1-b,europe-west4-a,asia-northeast1-b,asia-southeast1-b"
+      - "-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005"
+      - "-zones=us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east4-b,us-west1-a,us-west1-b,us-west1-c,europe-west1-b,europe-west1-c,europe-west3-a,europe-west4-a,europe-west4-b,europe-west4-c,asia-east1-a,asia-east1-c,asia-northeast1-a,asia-northeast1-b,asia-southeast1-b"
       - "-all_image_families=gce-unstable-pkg-test-images"
       - "-filter=^(cvm|disk|guestagent|hostnamevalidation|hotattach|imageboot|licensevalidation|loadbalancer|metadata|network|packagevalidation|security|ssh|vmspec)$"
       - "-set_exit_status=false"


### PR DESCRIPTION
/cc @bkatyl @akerekes 

This PR updates parallelism configs (parallel_count=25—>20, parallel_stagger=60s—>30s) and increases testing zones to ~14-18 zones to further reduce resource/quota strain.