### PR TITLE
fix(kube-agents): red post-kube-agents-eval-rc when no summary is written

### DIFF
--- a/prow/prowjobs/gke-labs/kube-agents/kube-agents-postsubmits.yaml
+++ b/prow/prowjobs/gke-labs/kube-agents/kube-agents-postsubmits.yaml
@@ -333,12 +333,37 @@ postsubmits:
           # on purpose -- hack/ci-eval-rc.sh preserves the real exit status
           # rather than swallowing it, precisely so that the decision to ignore
           # it is visible here instead of buried in the script. The cost is that
-          # this job's status says nothing, and as a postsubmit that status is
-          # also a commit status on the promoted commit: a RED candidate, a
-          # failed deploy and a broken driver all report success there. The
-          # verdict a reader wants is in the rc-eval-summary.md artifact, which
-          # the driver writes on every path including the failure ones.
+          # the verdict no longer reaches this job's status, and as a postsubmit
+          # that status is also a commit status on the promoted commit: a RED
+          # candidate and a failed deploy both report success there. The verdict
+          # a reader wants is in the rc-eval-summary.md artifact.
           run_step ./hack/ci-eval-rc.sh || true
+          # Advisory on the VERDICT, not on the plumbing.
+          #
+          # The driver writes rc-eval-summary.md once it has a candidate
+          # deployed, or a deploy failure to report about one -- and NOT before.
+          # It exits ahead of the summary on all four of its early guards: a
+          # resolve failure (the tag will not peel, or the candidate's images
+          # are not in GHCR), a dirty tree, a failed checkout, and the marker
+          # refusal on a candidate too old to measure. Every one of those is the
+          # job's own machinery failing rather than a judgement on the release.
+          #
+          # Left to `|| true` alone they are indistinguishable from a good run:
+          # green status, no verdict, and an empty rc-target.env as the only
+          # artifact. A resolver broken for a month would look like a month of
+          # green. So the presence of the summary is what this job gates on --
+          # the one thing that separates "measured it, here is the answer" from
+          # "never got far enough to measure anything".
+          #
+          # A deploy failure still writes a NOT RUN summary and still reports
+          # success, which is the design. This only fires when the artifact is
+          # absent. `set -e` at the top of this script turns the exit below into
+          # a red job, and the EXIT trap still runs cleanup, so the Boskos lease
+          # goes back either way.
+          if [ ! -f "${ARTIFACTS}/rc-eval-summary.md" ]; then
+            echo "ERROR: hack/ci-eval-rc.sh produced no rc-eval-summary.md, so it exited before it had a candidate to report on -- a resolve failure, a dirty tree, a failed checkout, or the marker refusal. The build log above says which. Failing the job: a green status with no verdict is indistinguishable from a run that worked." >&2
+            exit 1
+          fi
         resources:
           requests:
             memory: "1Gi"


### PR DESCRIPTION
Follow-up to #2691, fixing a [review finding ](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2691#discussion_r3960411880)that arrived as that PR merged.

`post-kube-agents-eval-rc` runs its driver as `run_step ./hack/ci-eval-rc.sh || true`. The `|| true` is deliberate — the lane is advisory and must not block a release — and the comment beside it justified the meaningless exit status by pointing at the artifact:

> The verdict a reader wants is in the rc-eval-summary.md artifact, which the driver writes on every path including the failure ones.

That claim is wrong, and I wrote it. `hack/ci-eval-rc.sh` writes the summary only once it has a candidate deployed, or a deploy failure to report about one. It exits ahead of the summary on all four of its early guards:

| Guard | `ci-eval-rc.sh` |
| --- | --- |
| resolve failure (tag will not peel, or images absent from GHCR) | line 195, under `set -e` |
| dirty tree | line 211 |
| failed checkout | line 222 |
| marker refusal — candidate too old to measure | line 233 |

Each of those produces a green job with no verdict, and an empty `rc-target.env` as the only artifact. Indistinguishable in Prow from a run that worked, so a resolver broken for a month would look like a month of green.

## The fix

Gate on the artifact rather than on the exit status:

```bash
run_step ./hack/ci-eval-rc.sh || true
if [ ! -f "${ARTIFACTS}/rc-eval-summary.md" ]; then
  echo "ERROR: hack/ci-eval-rc.sh produced no rc-eval-summary.md, ..." >&2
  exit 1
fi
```

Absent summary means the driver never reached a candidate — the job's own machinery failing, not a judgement on the release. A deploy failure still writes a `NOT RUN` summary and still reports success, which is the design. The comment that made the false claim is corrected in the same commit.

## Testing

Both branches were exercised against artifact directories produced by real `hack/ci-eval-rc.sh` runs, in a throwaway clone checked out at `staging_2609071712_ab52251`, with `gcloud`/`helm`/`kubectl`/`terraform` shadowed so nothing could reach a cluster:

- **Summary present** (driver ran to a deploy failure on a missing `GEMINI_API_KEY`, wrote `Verdict: NOT RUN`) → guard passes, job stays green.
- **Summary absent** (driver given a non-existent tag, exited 1 at the resolve guard, left a zero-byte `rc-target.env`) → guard fires, job reds.

Also verified:

- `ARTIFACTS` is always set for a decorated job — `decorate()` assigns it unconditionally as its first statement (`pod-utils/decorate/podspec.go`), so the `set -u` in this script cannot trip on it.
- `set -euo pipefail` is line 1, so the `exit 1` reds the job rather than being swallowed.
- `trap cleanup EXIT INT TERM` is installed before the step list, so the Boskos lease is returned on the new failure path.
- YAML parses; `bash -n` clean on the embedded script.

**Not live-tested.** The job has not run yet — it fires on the next `staging_*` promotion, and this lands ahead of that.

## Credit

The finding, the diagnosis, and the shape of the fix are the reviewer's on #2691; the four exit points and the empty-`rc-target.env` symptom were called correctly. One detail from that comment does not carry over: it cites the periodic revision's line numbers and the 02:00 UTC `rc_*` image race, which no longer applies now that the trigger is a `staging_*` tag cut after `verify_candidate_images.sh` and the E2E matrix. The defect survives by the other three routes regardless — the marker refusal on a promoted older commit being the most plausible.

---

Generated with the help of Claude (Opus 5).
